### PR TITLE
[#58] Phase 1A: non-interactive mode for `sf new`

### DIFF
--- a/src/__tests__/integration/commands/new.non-interactive.spec.ts
+++ b/src/__tests__/integration/commands/new.non-interactive.spec.ts
@@ -1,0 +1,246 @@
+import { mkdir, rm, readFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import inquirer from 'inquirer'
+
+jest.mock('inquirer')
+
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual('../../../utils'),
+  checkNodeVersion: jest.fn(),
+  computeFileHashes: jest.fn().mockResolvedValue({})
+}))
+
+jest.mock('../../../builders/api.builder', () => ({ createApiApp: jest.fn() }))
+jest.mock('../../../builders/web.builder', () => ({ createWebApp: jest.fn() }))
+jest.mock('../../../builders/monorepo.builder', () => ({ createMonorepoRoot: jest.fn() }))
+jest.mock('../../../builders/dev-services.builder', () => ({ createDevServicesCompose: jest.fn() }))
+jest.mock('../../../installers/skills.installer', () => ({ installSkills: jest.fn() }))
+
+jest.mock('../../../runners/database.runner', () => ({ initAndStartDb: jest.fn() }))
+jest.mock('../../../runners/s3.runner', () => ({ initAndStartS3: jest.fn() }))
+jest.mock('../../../runners/server.runner', () => ({
+  startBackend: jest.fn(),
+  startFrontend: jest.fn(),
+  startMonorepoApps: jest.fn(),
+  waitForServer: jest.fn()
+}))
+jest.mock('../../../runners/terminal.runner', () => ({
+  openTerminal: jest.fn(),
+  getHuskySetupCommand: jest.fn().mockReturnValue('')
+}))
+
+jest.mock('ora', () => () => ({
+  start: () => ({ text: '', succeed: jest.fn(), fail: jest.fn() })
+}))
+
+jest.mock('terminal-link', () => ({
+  __esModule: true,
+  default: (text: string) => text
+}))
+
+import { newCommand } from '../../../commands/new'
+import { createApiApp } from '../../../builders/api.builder'
+import { createWebApp } from '../../../builders/web.builder'
+import { createMonorepoRoot } from '../../../builders/monorepo.builder'
+import { createDevServicesCompose } from '../../../builders/dev-services.builder'
+import { installSkills } from '../../../installers/skills.installer'
+import { initAndStartDb } from '../../../runners/database.runner'
+import { initAndStartS3 } from '../../../runners/s3.runner'
+import { openTerminal } from '../../../runners/terminal.runner'
+
+const mockedPrompt = inquirer.prompt as unknown as jest.Mock
+const mockedCreateApiApp = createApiApp as jest.MockedFunction<typeof createApiApp>
+const mockedCreateWebApp = createWebApp as jest.MockedFunction<typeof createWebApp>
+const mockedCreateMonorepoRoot = createMonorepoRoot as jest.MockedFunction<typeof createMonorepoRoot>
+const mockedCreateDevServices = createDevServicesCompose as jest.MockedFunction<typeof createDevServicesCompose>
+const mockedInstallSkills = installSkills as jest.MockedFunction<typeof installSkills>
+const mockedInitAndStartDb = initAndStartDb as jest.MockedFunction<typeof initAndStartDb>
+const mockedInitAndStartS3 = initAndStartS3 as jest.MockedFunction<typeof initAndStartS3>
+const mockedOpenTerminal = openTerminal as jest.MockedFunction<typeof openTerminal>
+
+describe('newCommand (non-interactive integration)', () => {
+  let tempDir: string
+  let originalCwd: string
+  let logSpy: jest.SpyInstance
+  let errorSpy: jest.SpyInstance
+  let exitSpy: jest.SpyInstance
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `sf-int-new-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    originalCwd = process.cwd()
+    await mkdir(tempDir, { recursive: true })
+    process.chdir(tempDir)
+
+    jest.clearAllMocks()
+
+    // Simulate Inquirer's native prefill behavior: when all applicable
+    // questions are prefilled, inquirer.prompt returns the prefilled answers as-is.
+    mockedPrompt.mockImplementation(((_questions: unknown, answers: Record<string, unknown>) => Promise.resolve(answers ?? {})) as never)
+
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never)
+  })
+
+  afterEach(async () => {
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
+    process.chdir(originalCwd)
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  const baseOpts = {
+    nonInteractive: true,
+    projectName: 'acme',
+    projectDescription: 'My acme project',
+    structure: 'multirepo' as const,
+    mainBranch: 'main' as const,
+    setupRepo: 'local' as const,
+    dbSetup: 'manual' as const,
+    s3Setup: 'manual' as const,
+    emailService: 'none' as const,
+    analytics: false,
+    workflow: 'none'
+  }
+
+  it('runs end-to-end from flags alone without asking the user any question', async () => {
+    await newCommand(baseOpts)
+
+    expect(mockedCreateApiApp).toHaveBeenCalledTimes(1)
+    expect(mockedCreateWebApp).toHaveBeenCalledTimes(1)
+    expect(mockedInstallSkills).toHaveBeenCalledTimes(1)
+
+    // Every prompt call must have received the full prefill (never prompted for real input).
+    for (const call of mockedPrompt.mock.calls) {
+      expect(call[1]).toBeDefined()
+    }
+  })
+
+  it('propagates flags through to the API builder', async () => {
+    await newCommand({
+      nonInteractive: true,
+      projectName: 'acme',
+      projectDescription: 'd',
+      structure: 'multirepo',
+      mainBranch: 'main',
+      setupRepo: 'local',
+      dbSetup: 'credentials',
+      dbType: 'postgresql',
+      dbHost: 'db.example.com',
+      dbPort: '5432',
+      dbUser: 'admin',
+      dbPassword: 'secret',
+      dbName: 'acme_prod',
+      s3Setup: 'manual',
+      emailService: 'mailersend',
+      mailersendApiKey: 'ms-key',
+      mailersendSenderEmail: 'hello@acme.com',
+      mailersendSenderName: 'Acme',
+      analytics: false,
+      workflow: 'none'
+    })
+
+    expect(mockedCreateApiApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectName: 'acme',
+        isMonorepo: false,
+        mainBranch: 'main',
+        emailService: 'mailersend',
+        mailersendApiKey: 'ms-key',
+        mailersendSenderEmail: 'hello@acme.com',
+        mailersendSenderName: 'Acme',
+        dbCredentials: expect.objectContaining({
+          dbType: 'postgresql',
+          host: 'db.example.com',
+          port: '5432',
+          user: 'admin',
+          password: 'secret',
+          database: 'acme_prod'
+        })
+      })
+    )
+  })
+
+  it('writes a manifest reflecting the flags', async () => {
+    await newCommand({
+      ...baseOpts,
+      structure: 'monorepo',
+      analytics: true
+    })
+
+    // newCommand chdir's into the project directory before writing the manifest
+    const manifest = JSON.parse(await readFile('.saasfoundry.json', 'utf8'))
+    expect(manifest).toMatchObject({
+      projectName: 'acme',
+      structure: 'monorepo',
+      modules: {
+        emailService: 'none',
+        s3Setup: 'manual',
+        dbSetup: 'manual',
+        includeAnalytics: true,
+        advancedSkills: []
+      }
+    })
+  })
+
+  it('creates a monorepo root when --structure monorepo', async () => {
+    await newCommand({ ...baseOpts, structure: 'monorepo' })
+
+    expect(mockedCreateMonorepoRoot).toHaveBeenCalledTimes(1)
+  })
+
+  const dockerOpts = {
+    ...baseOpts,
+    dbSetup: 'docker' as const,
+    dbUser: 'postgres',
+    dbPassword: 'postgres',
+    dbName: 'acme_db',
+    s3Setup: 'docker' as const,
+    s3Bucket: 'acme-uploads'
+  }
+
+  it('does not start services by default in non-interactive mode', async () => {
+    await newCommand(dockerOpts)
+
+    expect(mockedInitAndStartDb).not.toHaveBeenCalled()
+    expect(mockedInitAndStartS3).not.toHaveBeenCalled()
+    expect(mockedOpenTerminal).not.toHaveBeenCalled()
+  })
+
+  it('starts services when --start-services is passed', async () => {
+    await newCommand({ ...dockerOpts, startServices: true, startApps: 'none' })
+
+    expect(mockedInitAndStartDb).toHaveBeenCalledTimes(1)
+    expect(mockedInitAndStartS3).toHaveBeenCalledTimes(1)
+    expect(mockedOpenTerminal).not.toHaveBeenCalled()
+  })
+
+  it('skips dev services builder when dbSetup=manual and s3Setup=manual', async () => {
+    await newCommand(baseOpts)
+
+    expect(mockedCreateDevServices).not.toHaveBeenCalled()
+  })
+
+  it('calls the dev services builder when docker services are requested', async () => {
+    await newCommand(dockerOpts)
+
+    expect(mockedCreateDevServices).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces missing required flags as a thrown error (not a hang)', async () => {
+    await expect(
+      newCommand({
+        nonInteractive: true,
+        // projectName intentionally missing
+        structure: 'multirepo'
+      })
+    ).rejects.toThrow(/Missing required values in --non-interactive mode/)
+
+    expect(mockedPrompt).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/unit/commands/new.options.spec.ts
+++ b/src/__tests__/unit/commands/new.options.spec.ts
@@ -1,0 +1,156 @@
+import { buildPrefillFromOptions, shouldSkipWorkflow, NewCommandOptions } from '../../../commands/new.options'
+
+describe('buildPrefillFromOptions', () => {
+  it('returns an empty prefill when no options are provided', () => {
+    expect(buildPrefillFromOptions({})).toEqual({})
+  })
+
+  it('maps simple project fields', () => {
+    const prefill = buildPrefillFromOptions({
+      projectName: 'acme',
+      projectDescription: 'Great app',
+      mainBranch: 'main'
+    })
+
+    expect(prefill).toMatchObject({
+      projectName: 'acme',
+      projectDescription: 'Great app',
+      mainBranch: 'main'
+    })
+  })
+
+  it('converts --structure monorepo to isMonorepo=true', () => {
+    expect(buildPrefillFromOptions({ structure: 'monorepo' }).isMonorepo).toBe(true)
+    expect(buildPrefillFromOptions({ structure: 'multirepo' }).isMonorepo).toBe(false)
+  })
+
+  it('collects db fields into a nested dbCredentials object', () => {
+    const prefill = buildPrefillFromOptions({
+      dbType: 'postgresql',
+      dbHost: 'localhost',
+      dbPort: '5432',
+      dbUser: 'postgres',
+      dbPassword: 'secret',
+      dbName: 'acme_db'
+    })
+
+    expect(prefill.dbCredentials).toEqual({
+      dbType: 'postgresql',
+      host: 'localhost',
+      port: '5432',
+      user: 'postgres',
+      password: 'secret',
+      database: 'acme_db'
+    })
+  })
+
+  it('only includes db fields that were explicitly provided', () => {
+    const prefill = buildPrefillFromOptions({ dbHost: 'localhost' })
+
+    expect(prefill.dbCredentials).toEqual({ host: 'localhost' })
+  })
+
+  it('omits dbCredentials entirely when no db fields are provided', () => {
+    const prefill = buildPrefillFromOptions({ projectName: 'acme' })
+
+    expect(prefill.dbCredentials).toBeUndefined()
+  })
+
+  it('collects s3 fields into a nested s3Credentials object', () => {
+    const prefill = buildPrefillFromOptions({
+      s3Endpoint: 'http://localhost:9000',
+      s3AccessKey: 'AKIA...',
+      s3SecretKey: 'secret',
+      s3Bucket: 'my-bucket',
+      s3Region: 'eu-west-1'
+    })
+
+    expect(prefill.s3Credentials).toEqual({
+      endpoint: 'http://localhost:9000',
+      accessKey: 'AKIA...',
+      secretKey: 'secret',
+      bucket: 'my-bucket',
+      region: 'eu-west-1'
+    })
+  })
+
+  it('maps --analytics / --no-analytics to includeAnalytics', () => {
+    expect(buildPrefillFromOptions({ analytics: true }).includeAnalytics).toBe(true)
+    expect(buildPrefillFromOptions({ analytics: false }).includeAnalytics).toBe(false)
+    expect(buildPrefillFromOptions({}).includeAnalytics).toBeUndefined()
+  })
+
+  it('parses advancedSkills CSV and trims whitespace', () => {
+    const prefill = buildPrefillFromOptions({ advancedSkills: 'context7, atlassian ,  notion' })
+
+    expect(prefill.advancedSkills).toEqual(['context7', 'atlassian', 'notion'])
+  })
+
+  it('filters out empty entries from the advancedSkills CSV', () => {
+    const prefill = buildPrefillFromOptions({ advancedSkills: 'context7,,atlassian,' })
+
+    expect(prefill.advancedSkills).toEqual(['context7', 'atlassian'])
+  })
+
+  it('maps skill credentials flags to their prefill keys', () => {
+    const opts: NewCommandOptions = {
+      atlassianEmail: 'a@b.c',
+      atlassianApiToken: 'token',
+      atlassianSite: 'acme',
+      atlassianCloudId: 'cloud-1',
+      notionApiToken: 'notion-tok',
+      notionApiVersion: '2022-06-28',
+      figmaApiToken: 'figma-tok',
+      context7ApiKey: 'c7'
+    }
+
+    const prefill = buildPrefillFromOptions(opts)
+
+    expect(prefill).toMatchObject({
+      atlassianEmail: 'a@b.c',
+      atlassianApiToken: 'token',
+      atlassianSite: 'acme',
+      atlassianCloudId: 'cloud-1',
+      notionApiToken: 'notion-tok',
+      notionApiVersion: '2022-06-28',
+      figmaApiToken: 'figma-tok',
+      context7ApiKey: 'c7'
+    })
+  })
+
+  it('maps repo setup fields', () => {
+    const prefill = buildPrefillFromOptions({
+      setupRepo: 'existing',
+      monorepoUrl: 'git@github.com:acme/repo.git',
+      backendRepoUrl: 'git@github.com:acme/api.git',
+      frontendRepoUrl: 'git@github.com:acme/web.git'
+    })
+
+    expect(prefill).toMatchObject({
+      setupRepo: 'existing',
+      monorepoUrl: 'git@github.com:acme/repo.git',
+      backendRepoUrl: 'git@github.com:acme/api.git',
+      frontendRepoUrl: 'git@github.com:acme/web.git'
+    })
+  })
+})
+
+describe('shouldSkipWorkflow', () => {
+  it('returns true when --no-workflow is used (workflow=false)', () => {
+    expect(shouldSkipWorkflow({ workflow: false })).toBe(true)
+  })
+
+  it('returns true when --workflow none is used', () => {
+    expect(shouldSkipWorkflow({ workflow: 'none' })).toBe(true)
+    expect(shouldSkipWorkflow({ workflow: 'NONE' })).toBe(true)
+  })
+
+  it('returns false when --workflow is omitted', () => {
+    expect(shouldSkipWorkflow({})).toBe(false)
+  })
+
+  it('returns false for other workflow strings', () => {
+    expect(shouldSkipWorkflow({ workflow: 'github-projects' })).toBe(false)
+    expect(shouldSkipWorkflow({ workflow: 'jira' })).toBe(false)
+  })
+})

--- a/src/__tests__/unit/prompts/helpers.spec.ts
+++ b/src/__tests__/unit/prompts/helpers.spec.ts
@@ -1,0 +1,137 @@
+import inquirer, { DistinctQuestion } from 'inquirer'
+
+import { promptWithPrefill } from '../../../prompts/helpers'
+
+jest.mock('inquirer')
+
+const mockedPrompt = inquirer.prompt as unknown as jest.Mock
+
+describe('promptWithPrefill', () => {
+  beforeEach(() => {
+    mockedPrompt.mockReset()
+  })
+
+  describe('interactive mode', () => {
+    it('forwards prefill to inquirer as the second argument', async () => {
+      mockedPrompt.mockResolvedValue({ name: 'acme', mode: 'fast' })
+
+      const questions: DistinctQuestion[] = [
+        { type: 'input', name: 'name', message: 'Name?' },
+        { type: 'input', name: 'mode', message: 'Mode?' }
+      ]
+
+      const result = await promptWithPrefill(questions, { prefill: { name: 'acme' } })
+
+      expect(mockedPrompt).toHaveBeenCalledTimes(1)
+      expect(mockedPrompt).toHaveBeenCalledWith(questions, { name: 'acme' })
+      expect(result).toEqual({ name: 'acme', mode: 'fast' })
+    })
+
+    it('passes an empty object when no prefill is provided', async () => {
+      mockedPrompt.mockResolvedValue({ answer: 42 })
+
+      await promptWithPrefill([{ type: 'input', name: 'answer', message: 'Answer?' }])
+
+      expect(mockedPrompt).toHaveBeenCalledWith(expect.any(Array), {})
+    })
+
+    it('does not throw when non-prefilled questions remain', async () => {
+      mockedPrompt.mockResolvedValue({ a: 1, b: 2 })
+
+      await expect(
+        promptWithPrefill(
+          [
+            { type: 'input', name: 'a', message: '?' },
+            { type: 'input', name: 'b', message: '?' }
+          ],
+          { prefill: { a: 1 } }
+        )
+      ).resolves.toEqual({ a: 1, b: 2 })
+    })
+  })
+
+  describe('non-interactive mode', () => {
+    it('throws listing all missing required values', async () => {
+      await expect(
+        promptWithPrefill(
+          [
+            { type: 'input', name: 'projectName', message: 'Project name?' },
+            { type: 'list', name: 'structure', message: 'Structure?' },
+            { type: 'input', name: 'mainBranch', message: 'Branch?' }
+          ],
+          { nonInteractive: true, prefill: { projectName: 'acme' } }
+        )
+      ).rejects.toThrow(/Missing required values in --non-interactive mode: structure, mainBranch/)
+    })
+
+    it('does not call inquirer when values are missing', async () => {
+      await expect(promptWithPrefill([{ type: 'input', name: 'missing', message: '?' }], { nonInteractive: true })).rejects.toThrow()
+
+      expect(mockedPrompt).not.toHaveBeenCalled()
+    })
+
+    it('passes through when every applicable question has a prefilled value', async () => {
+      mockedPrompt.mockResolvedValue({ name: 'acme', branch: 'main' })
+
+      const result = await promptWithPrefill(
+        [
+          { type: 'input', name: 'name', message: '?' },
+          { type: 'input', name: 'branch', message: '?' }
+        ],
+        { nonInteractive: true, prefill: { name: 'acme', branch: 'main' } }
+      )
+
+      expect(result).toEqual({ name: 'acme', branch: 'main' })
+      expect(mockedPrompt).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores questions whose `when` evaluates to false', async () => {
+      mockedPrompt.mockResolvedValue({ emailService: 'none' })
+
+      const questions: DistinctQuestion[] = [
+        { type: 'list', name: 'emailService', message: '?' },
+        {
+          type: 'input',
+          name: 'mailersendApiKey',
+          message: '?',
+          when: (answers) => answers.emailService === 'mailersend'
+        }
+      ]
+
+      await expect(promptWithPrefill(questions, { nonInteractive: true, prefill: { emailService: 'none' } })).resolves.toEqual({ emailService: 'none' })
+    })
+
+    it('reports conditional questions as missing when the `when` evaluates to true', async () => {
+      const questions: DistinctQuestion[] = [
+        { type: 'list', name: 'emailService', message: '?' },
+        {
+          type: 'input',
+          name: 'mailersendApiKey',
+          message: '?',
+          when: (answers) => answers.emailService === 'mailersend'
+        }
+      ]
+
+      await expect(promptWithPrefill(questions, { nonInteractive: true, prefill: { emailService: 'mailersend' } })).rejects.toThrow(/mailersendApiKey/)
+    })
+
+    it('resolves nested dot-notation paths in prefill (e.g. dbCredentials.host)', async () => {
+      mockedPrompt.mockResolvedValue({ 'dbCredentials.host': 'localhost' })
+
+      await expect(promptWithPrefill([{ type: 'input', name: 'dbCredentials.host', message: '?' }], { nonInteractive: true, prefill: { dbCredentials: { host: 'localhost' } } })).resolves.toBeDefined()
+    })
+
+    it('treats async `when` callbacks as applicable (safer to ask)', async () => {
+      const questions: DistinctQuestion[] = [
+        {
+          type: 'input',
+          name: 'asyncField',
+          message: '?',
+          when: async () => true
+        }
+      ]
+
+      await expect(promptWithPrefill(questions, { nonInteractive: true })).rejects.toThrow(/asyncField/)
+    })
+  })
+})

--- a/src/__tests__/unit/prompts/helpers.spec.ts
+++ b/src/__tests__/unit/prompts/helpers.spec.ts
@@ -121,6 +121,30 @@ describe('promptWithPrefill', () => {
       await expect(promptWithPrefill([{ type: 'input', name: 'dbCredentials.host', message: '?' }], { nonInteractive: true, prefill: { dbCredentials: { host: 'localhost' } } })).resolves.toBeDefined()
     })
 
+    it('treats `when` callbacks returning undefined as falsy (matches Inquirer)', async () => {
+      mockedPrompt.mockResolvedValue({})
+
+      const questions: DistinctQuestion[] = [
+        {
+          type: 'input',
+          name: 'nested',
+          message: '?',
+          when: (answers) => answers.parent
+        }
+      ]
+
+      await expect(promptWithPrefill(questions, { nonInteractive: true })).resolves.toBeDefined()
+    })
+
+    it('deduplicates missing names when multiple questions share the same name', async () => {
+      const questions: DistinctQuestion[] = [
+        { type: 'list', name: 'setupRepo', message: 'Monorepo repo?', when: (a) => a.isMonorepo === true },
+        { type: 'list', name: 'setupRepo', message: 'Multirepo repo?', when: (a) => a.isMonorepo === false }
+      ]
+
+      await expect(promptWithPrefill(questions, { nonInteractive: true, prefill: { isMonorepo: true } })).rejects.toThrow(/setupRepo(?!.*setupRepo)/s)
+    })
+
     it('treats async `when` callbacks as applicable (safer to ask)', async () => {
       const questions: DistinctQuestion[] = [
         {

--- a/src/commands/new.options.ts
+++ b/src/commands/new.options.ts
@@ -1,0 +1,142 @@
+import { Answers, DbCredentials, S3Credentials } from '../types'
+
+export interface NewCommandOptions {
+  nonInteractive?: boolean
+
+  // Project basics
+  projectName?: string
+  projectDescription?: string
+  structure?: 'monorepo' | 'multirepo'
+  mainBranch?: 'main' | 'master'
+
+  // Repository
+  setupRepo?: 'local' | 'existing'
+  monorepoUrl?: string
+  backendRepoUrl?: string
+  frontendRepoUrl?: string
+
+  // Database
+  dbSetup?: 'docker' | 'credentials' | 'manual'
+  dbType?: 'postgresql' | 'sql'
+  dbHost?: string
+  dbPort?: string
+  dbUser?: string
+  dbPassword?: string
+  dbName?: string
+
+  // Email
+  emailService?: 'none' | 'mailersend'
+  mailersendApiKey?: string
+  mailersendSenderEmail?: string
+  mailersendSenderName?: string
+
+  // Storage
+  s3Setup?: 'docker' | 'credentials' | 'manual'
+  s3Endpoint?: string
+  s3AccessKey?: string
+  s3SecretKey?: string
+  s3Bucket?: string
+  s3Region?: string
+
+  // Analytics
+  analytics?: boolean
+
+  // Advanced skills
+  advancedSkills?: string
+  context7ApiKey?: string
+  atlassianEmail?: string
+  atlassianApiToken?: string
+  atlassianSite?: string
+  atlassianCloudId?: string
+  notionApiToken?: string
+  notionApiVersion?: string
+  figmaApiToken?: string
+
+  // Workflow (flag allows skipping; full config still goes through `sf workflow` or interactive)
+  workflow?: string | boolean
+
+  // Post-setup behavior
+  startServices?: boolean
+  startApps?: 'all' | 'backend' | 'frontend' | 'none'
+}
+
+/**
+ * Convert Commander-parsed options into a `Partial<Answers>` prefill
+ * consumable by `getUserStartProjectInputs`.
+ *
+ * Only fields that were explicitly passed end up in the prefill, so the
+ * interactive prompt still asks for anything the user didn't specify.
+ */
+export function buildPrefillFromOptions(opts: NewCommandOptions): Partial<Answers> {
+  const prefill: Partial<Answers> = {}
+
+  if (opts.projectName !== undefined) prefill.projectName = opts.projectName
+  if (opts.projectDescription !== undefined) prefill.projectDescription = opts.projectDescription
+  if (opts.structure !== undefined) prefill.isMonorepo = opts.structure === 'monorepo'
+  if (opts.mainBranch !== undefined) prefill.mainBranch = opts.mainBranch
+
+  if (opts.setupRepo !== undefined) prefill.setupRepo = opts.setupRepo
+  if (opts.monorepoUrl !== undefined) prefill.monorepoUrl = opts.monorepoUrl
+  if (opts.backendRepoUrl !== undefined) prefill.backendRepoUrl = opts.backendRepoUrl
+  if (opts.frontendRepoUrl !== undefined) prefill.frontendRepoUrl = opts.frontendRepoUrl
+
+  if (opts.dbSetup !== undefined) prefill.dbSetup = opts.dbSetup
+
+  const dbCreds: Partial<DbCredentials> = {}
+  if (opts.dbType !== undefined) dbCreds.dbType = opts.dbType
+  if (opts.dbHost !== undefined) dbCreds.host = opts.dbHost
+  if (opts.dbPort !== undefined) dbCreds.port = opts.dbPort
+  if (opts.dbUser !== undefined) dbCreds.user = opts.dbUser
+  if (opts.dbPassword !== undefined) dbCreds.password = opts.dbPassword
+  if (opts.dbName !== undefined) dbCreds.database = opts.dbName
+  if (Object.keys(dbCreds).length > 0) prefill.dbCredentials = dbCreds as DbCredentials
+
+  if (opts.emailService !== undefined) prefill.emailService = opts.emailService
+  if (opts.mailersendApiKey !== undefined) prefill.mailersendApiKey = opts.mailersendApiKey
+  if (opts.mailersendSenderEmail !== undefined) prefill.mailersendSenderEmail = opts.mailersendSenderEmail
+  if (opts.mailersendSenderName !== undefined) prefill.mailersendSenderName = opts.mailersendSenderName
+
+  if (opts.s3Setup !== undefined) prefill.s3Setup = opts.s3Setup
+
+  const s3Creds: Partial<S3Credentials> = {}
+  if (opts.s3Endpoint !== undefined) s3Creds.endpoint = opts.s3Endpoint
+  if (opts.s3AccessKey !== undefined) s3Creds.accessKey = opts.s3AccessKey
+  if (opts.s3SecretKey !== undefined) s3Creds.secretKey = opts.s3SecretKey
+  if (opts.s3Bucket !== undefined) s3Creds.bucket = opts.s3Bucket
+  if (opts.s3Region !== undefined) s3Creds.region = opts.s3Region
+  if (Object.keys(s3Creds).length > 0) prefill.s3Credentials = s3Creds as S3Credentials
+
+  if (opts.analytics !== undefined) prefill.includeAnalytics = opts.analytics
+
+  if (opts.advancedSkills !== undefined) {
+    prefill.advancedSkills = opts.advancedSkills
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+
+  if (opts.context7ApiKey !== undefined) prefill.context7ApiKey = opts.context7ApiKey
+  if (opts.atlassianEmail !== undefined) prefill.atlassianEmail = opts.atlassianEmail
+  if (opts.atlassianApiToken !== undefined) prefill.atlassianApiToken = opts.atlassianApiToken
+  if (opts.atlassianSite !== undefined) prefill.atlassianSite = opts.atlassianSite
+  if (opts.atlassianCloudId !== undefined) prefill.atlassianCloudId = opts.atlassianCloudId
+  if (opts.notionApiToken !== undefined) prefill.notionApiToken = opts.notionApiToken
+  if (opts.notionApiVersion !== undefined) prefill.notionApiVersion = opts.notionApiVersion
+  if (opts.figmaApiToken !== undefined) prefill.figmaApiToken = opts.figmaApiToken
+
+  return prefill
+}
+
+/**
+ * Whether the workflow step should be skipped entirely, based on the
+ * `--workflow` / `--no-workflow` flags.
+ *
+ * - `--no-workflow` → Commander sets `opts.workflow = false`
+ * - `--workflow none` → explicit skip
+ * - anything else → interactive config (or prefilled `workflow` object, handled upstream)
+ */
+export function shouldSkipWorkflow(opts: NewCommandOptions): boolean {
+  if (opts.workflow === false) return true
+  if (typeof opts.workflow === 'string' && opts.workflow.toLowerCase() === 'none') return true
+  return false
+}

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -18,16 +18,20 @@ import { getHuskySetupCommand, openTerminal } from '../runners/terminal.runner'
 import { SaaSFoundryManifest } from '../types'
 import { checkNodeVersion, computeFileHashes, setDefaultDbCredentials } from '../utils'
 import { version as cliVersion } from '../../package.json'
+import { NewCommandOptions, buildPrefillFromOptions } from './new.options'
 
 /**
  * Main function
  */
-export async function newCommand() {
+export async function newCommand(opts: NewCommandOptions = {}) {
   // Verify Node.js version before proceeding
   checkNodeVersion()
 
+  const prefill = buildPrefillFromOptions(opts)
+  const nonInteractive = opts.nonInteractive === true
+
   // Chat with user
-  const startProjectAnswers = await getUserStartProjectInputs()
+  const startProjectAnswers = await getUserStartProjectInputs({ prefill, nonInteractive })
 
   // Set default values for database credentials
   if (startProjectAnswers.dbCredentials) startProjectAnswers.dbCredentials = setDefaultDbCredentials(startProjectAnswers.dbCredentials)
@@ -232,14 +236,21 @@ export async function newCommand() {
       initMessage = 'Do you want to initialize the database now?'
     }
 
-    const { startServices } = await inquirer.prompt<{ startServices: boolean }>([
-      {
-        type: 'confirm',
-        name: 'startServices',
-        message: initMessage,
-        default: true
-      }
-    ])
+    let startServices: boolean
+    if (opts.startServices !== undefined) {
+      startServices = opts.startServices
+    } else if (nonInteractive) {
+      startServices = false
+    } else {
+      ;({ startServices } = await inquirer.prompt<{ startServices: boolean }>([
+        {
+          type: 'confirm',
+          name: 'startServices',
+          message: initMessage,
+          default: true
+        }
+      ]))
+    }
 
     if (startServices) {
       let servicesOk = true
@@ -273,22 +284,29 @@ export async function newCommand() {
 
       // Propose to start apps
       if (servicesOk) {
-        const { startApps } = await inquirer.prompt<{
-          startApps: 'backend' | 'frontend' | 'all' | 'none'
-        }>([
-          {
-            type: 'list',
-            name: 'startApps',
-            message: 'Do you want to start apps?',
-            choices: [
-              { name: 'Yes, start all', value: 'all' },
-              { name: 'Yes, only backend', value: 'backend' },
-              { name: 'Yes, only frontend', value: 'frontend' },
-              { name: "No, I'll do it myself", value: 'none' }
-            ],
-            default: 'backend'
-          }
-        ])
+        let startApps: 'backend' | 'frontend' | 'all' | 'none'
+        if (opts.startApps !== undefined) {
+          startApps = opts.startApps
+        } else if (nonInteractive) {
+          startApps = 'none'
+        } else {
+          ;({ startApps } = await inquirer.prompt<{
+            startApps: 'backend' | 'frontend' | 'all' | 'none'
+          }>([
+            {
+              type: 'list',
+              name: 'startApps',
+              message: 'Do you want to start apps?',
+              choices: [
+                { name: 'Yes, start all', value: 'all' },
+                { name: 'Yes, only backend', value: 'backend' },
+                { name: 'Yes, only frontend', value: 'frontend' },
+                { name: "No, I'll do it myself", value: 'none' }
+              ],
+              default: 'backend'
+            }
+          ]))
+        }
 
         if (startProjectAnswers.isMonorepo) {
           if (startApps !== 'none') await startMonorepoApps(startApps)
@@ -297,7 +315,7 @@ export async function newCommand() {
           if (startApps === 'frontend' || startApps === 'all') await startFrontend(startProjectAnswers.projectName, startProjectAnswers.isMonorepo, true)
 
           // If user didn't choose to start the backend, open a contextualized terminal for it
-          if (startApps !== 'backend' && startApps !== 'all') {
+          if (!nonInteractive && startApps !== 'backend' && startApps !== 'all') {
             const apiPath = `apps/${startProjectAnswers.projectName}-api`
             await openTerminal(apiPath, {
               command: getHuskySetupCommand(),
@@ -306,7 +324,7 @@ export async function newCommand() {
           }
 
           // If user didn't choose to start the frontend, open a contextualized terminal for it
-          if (startApps !== 'frontend' && startApps !== 'all') {
+          if (!nonInteractive && startApps !== 'frontend' && startApps !== 'all') {
             const webPath = `apps/${startProjectAnswers.projectName}-web`
             await openTerminal(webPath, {
               command: getHuskySetupCommand(),
@@ -319,7 +337,7 @@ export async function newCommand() {
         // This ensures the frontend is the active tab at the end
 
         // 1. Open GitHub Project board first if configured
-        if (startProjectAnswers.workflow?.projectUrl) {
+        if (!nonInteractive && startProjectAnswers.workflow?.projectUrl) {
           try {
             const boardUrl = `${startProjectAnswers.workflow.projectUrl}?layout=board`
             console.log(chalk.blue('Opening GitHub Project board in browser...'))
@@ -331,7 +349,7 @@ export async function newCommand() {
         }
 
         // 2. Open API docs if backend is started
-        if (startApps === 'backend' || startApps === 'all') {
+        if (!nonInteractive && (startApps === 'backend' || startApps === 'all')) {
           try {
             console.log(chalk.blue('Waiting for backend to be ready...'))
             await waitForServer('http://localhost:3500/api/health')
@@ -345,7 +363,7 @@ export async function newCommand() {
         }
 
         // 3. Open frontend last (will be the active tab)
-        if (startApps === 'frontend' || startApps === 'all') {
+        if (!nonInteractive && (startApps === 'frontend' || startApps === 'all')) {
           try {
             console.log(chalk.blue('Waiting for frontend to be ready...'))
             await waitForServer('http://localhost:5173')
@@ -358,7 +376,7 @@ export async function newCommand() {
           }
         }
       }
-    } else {
+    } else if (!nonInteractive) {
       // User doesn't want to start services, open terminals
       console.log(chalk.blue('Opening terminals for your project...'))
 
@@ -378,7 +396,7 @@ export async function newCommand() {
         })
       }
     }
-  } else {
+  } else if (!nonInteractive) {
     // Nothing to start (DB=manual, S3=manual/credentials), open terminals
     console.log(chalk.blue('Opening terminals for your project...'))
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,61 @@ import { workflowCommand } from './commands/workflow'
 const program = new Command()
 
 program.name('sf').description('SaaSFoundry CLI - Create and manage your SaaS projects').version(version)
-program.command('new').description('Create a new SaaSFoundry project').action(newCommand)
+program
+  .command('new')
+  .description('Create a new SaaSFoundry project')
+  .option('--non-interactive', 'Fail if any required value is missing instead of prompting')
+  // Project basics
+  .option('--project-name <name>', 'Project name (kebab-case)')
+  .option('--project-description <description>', 'Project description')
+  .option('--structure <structure>', 'Project structure: monorepo or multirepo')
+  .option('--main-branch <branch>', 'Main branch name: main or master')
+  // Repository
+  .option('--setup-repo <setup>', 'Repository setup: local or existing')
+  .option('--monorepo-url <url>', 'Monorepo remote URL (when --structure monorepo and --setup-repo existing)')
+  .option('--backend-repo-url <url>', 'Backend repository URL (when --structure multirepo and --setup-repo existing)')
+  .option('--frontend-repo-url <url>', 'Frontend repository URL (when --structure multirepo and --setup-repo existing)')
+  // Database
+  .option('--db-setup <setup>', 'Database setup: docker, credentials, or manual')
+  .option('--db-type <type>', 'Database type: postgresql or sql')
+  .option('--db-host <host>', 'Database host')
+  .option('--db-port <port>', 'Database port')
+  .option('--db-user <user>', 'Database user')
+  .option('--db-password <password>', 'Database password')
+  .option('--db-name <name>', 'Database name')
+  // Email
+  .option('--email-service <service>', 'Email service: none or mailersend')
+  .option('--mailersend-api-key <key>', 'MailerSend API key')
+  .option('--mailersend-sender-email <email>', 'MailerSend sender email')
+  .option('--mailersend-sender-name <name>', 'MailerSend sender name')
+  // Storage
+  .option('--s3-setup <setup>', 'S3 storage setup: docker, credentials, or manual')
+  .option('--s3-endpoint <endpoint>', 'S3 endpoint URL')
+  .option('--s3-access-key <key>', 'S3 access key')
+  .option('--s3-secret-key <key>', 'S3 secret key')
+  .option('--s3-bucket <bucket>', 'S3 bucket name')
+  .option('--s3-region <region>', 'S3 region')
+  // Analytics
+  .option('--analytics', 'Include analytics module')
+  .option('--no-analytics', 'Skip analytics module')
+  // Advanced skills
+  .option('--advanced-skills <skills>', 'Comma-separated list of advanced skills (context7,atlassian,notion,figma)')
+  .option('--context7-api-key <key>', 'Context7 API key (unused — free public API)')
+  .option('--atlassian-email <email>', 'Atlassian account email')
+  .option('--atlassian-api-token <token>', 'Atlassian API token')
+  .option('--atlassian-site <site>', 'Atlassian site name (e.g. "mycompany")')
+  .option('--atlassian-cloud-id <id>', 'Atlassian Cloud ID')
+  .option('--notion-api-token <token>', 'Notion API token')
+  .option('--notion-api-version <version>', 'Notion API version (default: 2022-06-28)')
+  .option('--figma-api-token <token>', 'Figma API token')
+  // Workflow
+  .option('--workflow <config>', 'Workflow preset or "none" to skip')
+  .option('--no-workflow', 'Skip workflow configuration entirely')
+  // Post-setup behavior
+  .option('--start-services', 'Start dev services automatically (DB + MinIO)')
+  .option('--no-start-services', 'Do not start dev services after setup')
+  .option('--start-apps <mode>', 'Apps to start after setup: all, backend, frontend, none')
+  .action((opts) => newCommand(opts))
 program.command('update').description('Add modules to an existing SaaSFoundry project').action(updateCommand)
 program
   .command('tools')

--- a/src/prompts/helpers.ts
+++ b/src/prompts/helpers.ts
@@ -25,10 +25,9 @@ function getByPath(obj: Record<string, unknown>, path: string): unknown {
  * Evaluate a question's `when` condition against the accumulated answers.
  * Returns true if the question would be asked.
  *
- * Note: async `when` functions are treated as applicable — the Inquirer runtime
- * will re-evaluate them properly at prompt time. This helper only uses the result
- * to report missing answers in non-interactive mode, so erring on the side of
- * "would be asked" is safer than silently skipping.
+ * Matches Inquirer's truthy/falsy semantics for sync callbacks. Async callbacks
+ * (which return a Promise) are treated as applicable — we can't await here, and
+ * erring on "would be asked" keeps the non-interactive error list complete.
  */
 function isQuestionApplicable<T extends InquirerAnswers>(q: DistinctQuestion<T>, accumulated: T): boolean {
   if (q.when === undefined) return true
@@ -36,8 +35,10 @@ function isQuestionApplicable<T extends InquirerAnswers>(q: DistinctQuestion<T>,
   if (typeof q.when === 'function') {
     try {
       const result = q.when(accumulated)
-      if (typeof result === 'boolean') return result
-      return true
+      if (result !== null && typeof result === 'object' && typeof (result as { then?: unknown }).then === 'function') {
+        return true
+      }
+      return Boolean(result)
     } catch {
       return true
     }
@@ -57,19 +58,19 @@ export async function promptWithPrefill<T extends InquirerAnswers>(questions: Re
   const { prefill = {}, nonInteractive = false } = options
 
   if (nonInteractive) {
-    const missing: string[] = []
+    const missing = new Set<string>()
     const accumulated = { ...prefill } as unknown as T
 
     for (const q of questions) {
       if (!isQuestionApplicable(q, accumulated)) continue
       const name = q.name as string
       if (getByPath(accumulated as Record<string, unknown>, name) === undefined) {
-        missing.push(name)
+        missing.add(name)
       }
     }
 
-    if (missing.length > 0) {
-      throw new Error(`Missing required values in --non-interactive mode: ${missing.join(', ')}\n` + `Run \`sf new --help\` for the full flag list.`)
+    if (missing.size > 0) {
+      throw new Error(`Missing required values in --non-interactive mode: ${Array.from(missing).join(', ')}\n` + `Run \`sf new --help\` for the full flag list.`)
     }
   }
 

--- a/src/prompts/helpers.ts
+++ b/src/prompts/helpers.ts
@@ -1,0 +1,78 @@
+import inquirer, { Answers as InquirerAnswers, DistinctQuestion } from 'inquirer'
+
+export interface PromptOptions {
+  prefill?: Record<string, unknown>
+  nonInteractive?: boolean
+}
+
+/**
+ * Resolve a dot-notation path against an object, matching Inquirer's _.get semantics.
+ */
+function getByPath(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.')
+  let current: unknown = obj
+  for (const part of parts) {
+    if (current !== null && typeof current === 'object') {
+      current = (current as Record<string, unknown>)[part]
+    } else {
+      return undefined
+    }
+  }
+  return current
+}
+
+/**
+ * Evaluate a question's `when` condition against the accumulated answers.
+ * Returns true if the question would be asked.
+ *
+ * Note: async `when` functions are treated as applicable — the Inquirer runtime
+ * will re-evaluate them properly at prompt time. This helper only uses the result
+ * to report missing answers in non-interactive mode, so erring on the side of
+ * "would be asked" is safer than silently skipping.
+ */
+function isQuestionApplicable<T extends InquirerAnswers>(q: DistinctQuestion<T>, accumulated: T): boolean {
+  if (q.when === undefined) return true
+  if (typeof q.when === 'boolean') return q.when
+  if (typeof q.when === 'function') {
+    try {
+      const result = q.when(accumulated)
+      if (typeof result === 'boolean') return result
+      return true
+    } catch {
+      return true
+    }
+  }
+  return true
+}
+
+/**
+ * Wrap `inquirer.prompt` with prefill + non-interactive support.
+ *
+ * - Questions whose name already has a value in `prefill` are skipped (Inquirer's
+ *   native behavior via the second argument).
+ * - In `nonInteractive` mode, throws if any applicable question is missing a
+ *   prefilled value, with a list of missing names.
+ */
+export async function promptWithPrefill<T extends InquirerAnswers>(questions: ReadonlyArray<DistinctQuestion<T>>, options: PromptOptions = {}): Promise<T> {
+  const { prefill = {}, nonInteractive = false } = options
+
+  if (nonInteractive) {
+    const missing: string[] = []
+    const accumulated = { ...prefill } as unknown as T
+
+    for (const q of questions) {
+      if (!isQuestionApplicable(q, accumulated)) continue
+      const name = q.name as string
+      if (getByPath(accumulated as Record<string, unknown>, name) === undefined) {
+        missing.push(name)
+      }
+    }
+
+    if (missing.length > 0) {
+      throw new Error(`Missing required values in --non-interactive mode: ${missing.join(', ')}\n` + `Run \`sf new --help\` for the full flag list.`)
+    }
+  }
+
+  const answers = await inquirer.prompt<T>(questions as unknown as DistinctQuestion<T>[], prefill as Partial<T>)
+  return answers
+}

--- a/src/prompts/project.prompts.ts
+++ b/src/prompts/project.prompts.ts
@@ -3,345 +3,419 @@ import inquirer from 'inquirer'
 import { exec } from 'shelljs'
 
 import { Answers } from '../types'
+import { promptWithPrefill } from './helpers'
 import { promptAdvancedSkills, collectAdvancedSkillsCredentials } from './skills.prompts'
 import { promptWorkflowConfiguration } from './workflow.prompts'
+
+export interface StartProjectInputsOptions {
+  prefill?: Partial<Answers>
+  nonInteractive?: boolean
+}
 
 /**
  * Get user inputs
  */
-export async function getUserStartProjectInputs() {
-  const answers = await inquirer.prompt<Answers>([
-    {
-      type: 'input',
-      name: 'projectName',
-      message: 'What is the name of your project?',
-      validate: (input: string) => {
-        if (!input) return 'Project name is required'
-        if (!/^[a-z0-9-]+$/.test(input)) {
-          return 'Project name can only contain lowercase letters, numbers, and hyphens'
+export async function getUserStartProjectInputs(options: StartProjectInputsOptions = {}) {
+  const { prefill = {}, nonInteractive = false } = options
+
+  const answers = await promptWithPrefill<Answers>(
+    [
+      {
+        type: 'input',
+        name: 'projectName',
+        message: 'What is the name of your project?',
+        validate: (input: string) => {
+          if (!input) return 'Project name is required'
+          if (!/^[a-z0-9-]+$/.test(input)) {
+            return 'Project name can only contain lowercase letters, numbers, and hyphens'
+          }
+          return true
         }
-        return true
-      }
-    },
-    {
-      type: 'input',
-      name: 'projectDescription',
-      message: 'What is the description of your project?',
-      default: (answers: Answers) => `${answers.projectName} is just an amazing SaaSFoundry project`
-    },
-    {
-      type: 'list',
-      name: 'mainBranch',
-      message: 'Which main branch name do you prefer?',
-      choices: [
-        { name: 'main', value: 'main' },
-        { name: 'master', value: 'master' }
-      ],
-      default: 'main'
-    },
-    {
-      type: 'list',
-      name: 'isMonorepo',
-      message: 'How would you like to structure your project?',
-      choices: [
-        { name: 'Monorepo: Single Git repository with Turborepo (centralized management, shared tooling)', value: true },
-        { name: 'Multirepo: Separate Git repositories for Backend and Frontend (independent management)', value: false }
-      ],
-      default: true
-    },
-    {
-      type: 'list',
-      name: 'setupRepo',
-      message: 'Do you have already a remote repository?',
-      choices: [
-        { name: 'Not yet, just setup on local', value: 'local' },
-        { name: "Yes, I'll give you the link", value: 'existing' }
-      ],
-      when: (answers: Answers) => answers.isMonorepo
-    },
-    {
-      type: 'list',
-      name: 'setupRepo',
-      message: 'Do you have already remote repositories?',
-      choices: [
-        { name: 'Not yet, just setup on local for both', value: 'local' },
-        { name: "Yes, I'll give you the links", value: 'existing' }
-      ],
-      when: (answers: Answers) => !answers.isMonorepo
-    },
-    {
-      type: 'input',
-      name: 'monorepoUrl',
-      message: 'Enter your existing monorepo Git URL',
-      when: (answers: Answers) => answers.isMonorepo && answers.setupRepo === 'existing',
-      validate: (input: string) => {
-        if (!input) return 'Git URL is required'
-        return true
-      }
-    },
-    {
-      type: 'input',
-      name: 'backendRepoUrl',
-      message: 'Enter your existing backend Git URL',
-      when: (answers: Answers) => !answers.isMonorepo && answers.setupRepo === 'existing',
-      validate: (input: string) => {
-        if (!input) return 'Backend Git URL is required'
-        return true
       },
-      default: 'https://github.com/agachet/saasfoundry'
-    },
-    {
-      type: 'input',
-      name: 'frontendRepoUrl',
-      message: 'Enter your existing frontend Git URL',
-      when: (answers: Answers) => !answers.isMonorepo && answers.setupRepo === 'existing',
-      validate: (input: string) => {
-        if (!input) return 'Frontend Git URL is required'
-        return true
+      {
+        type: 'input',
+        name: 'projectDescription',
+        message: 'What is the description of your project?',
+        default: (current: Answers) => `${current.projectName} is just an amazing SaaSFoundry project`
       },
-      default: 'https://github.com/agachet/saasfoundry'
-    },
-    {
-      type: 'list',
-      name: 'dbSetup',
-      message: 'Do you want to set up a development database with Docker? (you must have docker installed)',
-      choices: [
-        {
-          name: 'Yes, with Docker (adds PostgreSQL to docker-compose.dev-services.yml)',
-          value: 'docker'
+      {
+        type: 'list',
+        name: 'mainBranch',
+        message: 'Which main branch name do you prefer?',
+        choices: [
+          { name: 'main', value: 'main' },
+          { name: 'master', value: 'master' }
+        ],
+        default: 'main'
+      },
+      {
+        type: 'list',
+        name: 'isMonorepo',
+        message: 'How would you like to structure your project?',
+        choices: [
+          { name: 'Monorepo: Single Git repository with Turborepo (centralized management, shared tooling)', value: true },
+          { name: 'Multirepo: Separate Git repositories for Backend and Frontend (independent management)', value: false }
+        ],
+        default: true
+      },
+      {
+        type: 'list',
+        name: 'setupRepo',
+        message: 'Do you have already a remote repository?',
+        choices: [
+          { name: 'Not yet, just setup on local', value: 'local' },
+          { name: "Yes, I'll give you the link", value: 'existing' }
+        ],
+        when: (current: Answers) => current.isMonorepo
+      },
+      {
+        type: 'list',
+        name: 'setupRepo',
+        message: 'Do you have already remote repositories?',
+        choices: [
+          { name: 'Not yet, just setup on local for both', value: 'local' },
+          { name: "Yes, I'll give you the links", value: 'existing' }
+        ],
+        when: (current: Answers) => !current.isMonorepo
+      },
+      {
+        type: 'input',
+        name: 'monorepoUrl',
+        message: 'Enter your existing monorepo Git URL',
+        when: (current: Answers) => current.isMonorepo && current.setupRepo === 'existing',
+        validate: (input: string) => {
+          if (!input) return 'Git URL is required'
+          return true
+        }
+      },
+      {
+        type: 'input',
+        name: 'backendRepoUrl',
+        message: 'Enter your existing backend Git URL',
+        when: (current: Answers) => !current.isMonorepo && current.setupRepo === 'existing',
+        validate: (input: string) => {
+          if (!input) return 'Backend Git URL is required'
+          return true
         },
-        {
-          name: 'No, connect the API to my existing database',
-          value: 'credentials'
+        default: 'https://github.com/agachet/saasfoundry'
+      },
+      {
+        type: 'input',
+        name: 'frontendRepoUrl',
+        message: 'Enter your existing frontend Git URL',
+        when: (current: Answers) => !current.isMonorepo && current.setupRepo === 'existing',
+        validate: (input: string) => {
+          if (!input) return 'Frontend Git URL is required'
+          return true
         },
-        { name: "No, I'll do it later", value: 'manual' }
-      ]
-    },
-    {
-      type: 'list',
-      name: 'dbCredentials.dbType',
-      message: 'Which database technology are you using?',
-      choices: [
-        { name: 'PostgreSQL', value: 'postgresql' },
-        { name: 'SQL Server', value: 'sql' }
-      ],
-      when: (answers: Answers) => answers.dbSetup === 'credentials',
-      default: 'postgresql'
-    },
-    {
-      type: 'input',
-      name: 'dbCredentials.host',
-      message: 'Database host',
-      when: (answers: Answers) => answers.dbSetup === 'credentials'
-    },
-    {
-      type: 'input',
-      name: 'dbCredentials.port',
-      message: 'Database port',
-      when: (answers: Answers) => answers.dbSetup === 'credentials'
-    },
-    {
-      type: 'input',
-      name: 'dbCredentials.user',
-      message: 'Database user',
-      when: (answers: Answers) => answers.dbSetup === 'docker' || answers.dbSetup === 'credentials',
-      default: 'db_dev_user'
-    },
-    {
-      type: 'input',
-      name: 'dbCredentials.password',
-      message: 'Database password',
-      when: (answers: Answers) => answers.dbSetup === 'docker' || answers.dbSetup === 'credentials',
-      default: 'db_dev_password'
-    },
-    {
-      type: 'input',
-      name: 'dbCredentials.database',
-      message: 'Database name',
-      when: (answers: Answers) => answers.dbSetup === 'docker' || answers.dbSetup === 'credentials',
-      default: 'db_dev'
-    },
-    {
-      type: 'list',
-      name: 'emailService',
-      message: 'For your transactional emails (account creation, password reset, etc.), which service would you like to set up?',
-      choices: [
-        { name: 'None, just set up the logic', value: 'none' },
-        { name: 'MailerSend [free, 3000 emails/month]', value: 'mailersend' }
-      ],
-      default: 'mailersend'
-    }
-  ])
+        default: 'https://github.com/agachet/saasfoundry'
+      },
+      {
+        type: 'list',
+        name: 'dbSetup',
+        message: 'Do you want to set up a development database with Docker? (you must have docker installed)',
+        choices: [
+          {
+            name: 'Yes, with Docker (adds PostgreSQL to docker-compose.dev-services.yml)',
+            value: 'docker'
+          },
+          {
+            name: 'No, connect the API to my existing database',
+            value: 'credentials'
+          },
+          { name: "No, I'll do it later", value: 'manual' }
+        ]
+      },
+      {
+        type: 'list',
+        name: 'dbCredentials.dbType',
+        message: 'Which database technology are you using?',
+        choices: [
+          { name: 'PostgreSQL', value: 'postgresql' },
+          { name: 'SQL Server', value: 'sql' }
+        ],
+        when: (current: Answers) => current.dbSetup === 'credentials',
+        default: 'postgresql'
+      },
+      {
+        type: 'input',
+        name: 'dbCredentials.host',
+        message: 'Database host',
+        when: (current: Answers) => current.dbSetup === 'credentials'
+      },
+      {
+        type: 'input',
+        name: 'dbCredentials.port',
+        message: 'Database port',
+        when: (current: Answers) => current.dbSetup === 'credentials'
+      },
+      {
+        type: 'input',
+        name: 'dbCredentials.user',
+        message: 'Database user',
+        when: (current: Answers) => current.dbSetup === 'docker' || current.dbSetup === 'credentials',
+        default: 'db_dev_user'
+      },
+      {
+        type: 'input',
+        name: 'dbCredentials.password',
+        message: 'Database password',
+        when: (current: Answers) => current.dbSetup === 'docker' || current.dbSetup === 'credentials',
+        default: 'db_dev_password'
+      },
+      {
+        type: 'input',
+        name: 'dbCredentials.database',
+        message: 'Database name',
+        when: (current: Answers) => current.dbSetup === 'docker' || current.dbSetup === 'credentials',
+        default: 'db_dev'
+      },
+      {
+        type: 'list',
+        name: 'emailService',
+        message: 'For your transactional emails (account creation, password reset, etc.), which service would you like to set up?',
+        choices: [
+          { name: 'None, just set up the logic', value: 'none' },
+          { name: 'MailerSend [free, 3000 emails/month]', value: 'mailersend' }
+        ],
+        default: 'mailersend'
+      }
+    ],
+    { prefill, nonInteractive }
+  )
 
   // Handle MailerSend configuration immediately after email service choice
   if (answers.emailService === 'mailersend') {
-    console.log(chalk.yellow('\nYou need to create an account on MailerSend to get your API key.'))
-    console.log(chalk.yellow('Note: The following link is an affiliate link. We appreciate your support of the SaaSFoundry project by signing up through this link.'))
-    console.log(chalk.yellow('Opening https://www.mailersend.com?ref=52o9lkySkTka in your browser in few seconds...'))
+    const allCredsProvided = prefill.mailersendApiKey !== undefined && prefill.mailersendSenderEmail !== undefined && prefill.mailersendSenderName !== undefined
 
-    // Wait a few seconds before opening the URL
-    await new Promise((resolve) => setTimeout(resolve, 4000))
+    if (!allCredsProvided && !nonInteractive) {
+      console.log(chalk.yellow('\nYou need to create an account on MailerSend to get your API key.'))
+      console.log(chalk.yellow('Note: The following link is an affiliate link. We appreciate your support of the SaaSFoundry project by signing up through this link.'))
+      console.log(chalk.yellow('Opening https://www.mailersend.com?ref=52o9lkySkTka in your browser in few seconds...'))
 
-    // Open the URL in the default browser
-    const openCommand = process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open'
-    await exec(`${openCommand} https://www.mailersend.com/signup?ref=52o9lkySkTka`)
+      // Wait a few seconds before opening the URL
+      await new Promise((resolve) => setTimeout(resolve, 4000))
 
-    const { ready } = await inquirer.prompt<{ ready: boolean }>([
-      {
-        type: 'confirm',
-        name: 'ready',
-        message: 'Are you ready to configure your MailerSend credentials?',
-        default: true
-      }
-    ])
+      // Open the URL in the default browser
+      const openCommand = process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open'
+      await exec(`${openCommand} https://www.mailersend.com/signup?ref=52o9lkySkTka`)
 
-    if (ready) {
-      const mailerSendAnswers = await inquirer.prompt<Answers>([
+      const { ready } = await inquirer.prompt<{ ready: boolean }>([
         {
-          type: 'input',
-          name: 'mailersendApiKey',
-          message: 'Enter your MailerSend API key',
-          validate: (input: string) => {
-            if (!input) return 'API key is required'
-            return true
-          }
-        },
-        {
-          type: 'input',
-          name: 'mailersendSenderEmail',
-          message: 'Enter your MailerSend sender email',
-          default: `noreply@${answers.projectName.toLowerCase().replace(/\s+/g, '')}.com`,
-          validate: (input: string) => {
-            if (!input) return 'Sender email is required'
-            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input)) return 'Please enter a valid email address'
-            return true
-          }
-        },
-        {
-          type: 'input',
-          name: 'mailersendSenderName',
-          message: 'Enter your MailerSend sender name',
-          default: answers.projectName.charAt(0).toUpperCase() + answers.projectName.slice(1),
-          validate: (input: string) => {
-            if (!input) return 'Sender name is required'
-            return true
-          }
+          type: 'confirm',
+          name: 'ready',
+          message: 'Are you ready to configure your MailerSend credentials?',
+          default: true
         }
       ])
 
-      Object.assign(answers, mailerSendAnswers)
+      if (!ready) {
+        console.log(chalk.yellow('\nThe email service logic will be set up but disabled until you implement your own service.'))
+      } else {
+        const mailerSendAnswers = await promptWithPrefill<Answers>(
+          [
+            {
+              type: 'input',
+              name: 'mailersendApiKey',
+              message: 'Enter your MailerSend API key',
+              validate: (input: string) => {
+                if (!input) return 'API key is required'
+                return true
+              }
+            },
+            {
+              type: 'input',
+              name: 'mailersendSenderEmail',
+              message: 'Enter your MailerSend sender email',
+              default: `noreply@${answers.projectName.toLowerCase().replace(/\s+/g, '')}.com`,
+              validate: (input: string) => {
+                if (!input) return 'Sender email is required'
+                if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input)) return 'Please enter a valid email address'
+                return true
+              }
+            },
+            {
+              type: 'input',
+              name: 'mailersendSenderName',
+              message: 'Enter your MailerSend sender name',
+              default: answers.projectName.charAt(0).toUpperCase() + answers.projectName.slice(1),
+              validate: (input: string) => {
+                if (!input) return 'Sender name is required'
+                return true
+              }
+            }
+          ],
+          { prefill: { ...prefill, ...answers }, nonInteractive }
+        )
+
+        Object.assign(answers, mailerSendAnswers)
+      }
     } else {
-      console.log(chalk.yellow('\nThe email service logic will be set up but disabled until you implement your own service.'))
+      // All credentials are prefilled (or nonInteractive with prefill) — gather directly
+      const mailerSendAnswers = await promptWithPrefill<Answers>(
+        [
+          {
+            type: 'input',
+            name: 'mailersendApiKey',
+            message: 'Enter your MailerSend API key',
+            validate: (input: string) => {
+              if (!input) return 'API key is required'
+              return true
+            }
+          },
+          {
+            type: 'input',
+            name: 'mailersendSenderEmail',
+            message: 'Enter your MailerSend sender email',
+            default: `noreply@${answers.projectName.toLowerCase().replace(/\s+/g, '')}.com`,
+            validate: (input: string) => {
+              if (!input) return 'Sender email is required'
+              if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input)) return 'Please enter a valid email address'
+              return true
+            }
+          },
+          {
+            type: 'input',
+            name: 'mailersendSenderName',
+            message: 'Enter your MailerSend sender name',
+            default: answers.projectName.charAt(0).toUpperCase() + answers.projectName.slice(1),
+            validate: (input: string) => {
+              if (!input) return 'Sender name is required'
+              return true
+            }
+          }
+        ],
+        { prefill: { ...prefill, ...answers }, nonInteractive }
+      )
+
+      Object.assign(answers, mailerSendAnswers)
     }
   }
 
   // S3 storage setup (asked after email configuration)
-  const s3Answers = await inquirer.prompt<Answers>([
-    {
-      type: 'list',
-      name: 's3Setup',
-      message: 'Do you want to set up object storage (S3) for file uploads (logos, documents, etc.)?',
-      choices: [
-        {
-          name: 'Yes, add MinIO with Docker (free, S3-compatible, added to dev services)',
-          value: 'docker'
-        },
-        {
-          name: 'Yes, connect to my existing S3-compatible server',
-          value: 'credentials'
-        },
-        { name: "No, I'll do it later", value: 'manual' }
-      ]
-    },
-    {
-      type: 'input',
-      name: 's3Credentials.endpoint',
-      message: 'S3 endpoint URL (e.g. https://s3.amazonaws.com or http://minio.example.com:9000)',
-      when: (s3: Answers) => s3.s3Setup === 'credentials',
-      validate: (input: string) => {
-        if (!input) return 'Endpoint URL is required'
-        return true
+  const s3Answers = await promptWithPrefill<Answers>(
+    [
+      {
+        type: 'list',
+        name: 's3Setup',
+        message: 'Do you want to set up object storage (S3) for file uploads (logos, documents, etc.)?',
+        choices: [
+          {
+            name: 'Yes, add MinIO with Docker (free, S3-compatible, added to dev services)',
+            value: 'docker'
+          },
+          {
+            name: 'Yes, connect to my existing S3-compatible server',
+            value: 'credentials'
+          },
+          { name: "No, I'll do it later", value: 'manual' }
+        ]
+      },
+      {
+        type: 'input',
+        name: 's3Credentials.endpoint',
+        message: 'S3 endpoint URL (e.g. https://s3.amazonaws.com or http://minio.example.com:9000)',
+        when: (s3: Answers) => s3.s3Setup === 'credentials',
+        validate: (input: string) => {
+          if (!input) return 'Endpoint URL is required'
+          return true
+        }
+      },
+      {
+        type: 'input',
+        name: 's3Credentials.accessKey',
+        message: 'S3 access key',
+        when: (s3: Answers) => s3.s3Setup === 'credentials',
+        validate: (input: string) => {
+          if (!input) return 'Access key is required'
+          return true
+        }
+      },
+      {
+        type: 'input',
+        name: 's3Credentials.secretKey',
+        message: 'S3 secret key',
+        when: (s3: Answers) => s3.s3Setup === 'credentials',
+        validate: (input: string) => {
+          if (!input) return 'Secret key is required'
+          return true
+        }
+      },
+      {
+        type: 'input',
+        name: 's3Credentials.bucket',
+        message: 'S3 bucket name',
+        when: (s3: Answers) => s3.s3Setup === 'credentials' || s3.s3Setup === 'docker',
+        default: () => `${answers.projectName}-uploads`
+      },
+      {
+        type: 'input',
+        name: 's3Credentials.region',
+        message: 'S3 region',
+        when: (s3: Answers) => s3.s3Setup === 'credentials',
+        default: 'us-east-1'
       }
-    },
-    {
-      type: 'input',
-      name: 's3Credentials.accessKey',
-      message: 'S3 access key',
-      when: (s3: Answers) => s3.s3Setup === 'credentials',
-      validate: (input: string) => {
-        if (!input) return 'Access key is required'
-        return true
-      }
-    },
-    {
-      type: 'input',
-      name: 's3Credentials.secretKey',
-      message: 'S3 secret key',
-      when: (s3: Answers) => s3.s3Setup === 'credentials',
-      validate: (input: string) => {
-        if (!input) return 'Secret key is required'
-        return true
-      }
-    },
-    {
-      type: 'input',
-      name: 's3Credentials.bucket',
-      message: 'S3 bucket name',
-      when: (s3: Answers) => s3.s3Setup === 'credentials' || s3.s3Setup === 'docker',
-      default: () => `${answers.projectName}-uploads`
-    },
-    {
-      type: 'input',
-      name: 's3Credentials.region',
-      message: 'S3 region',
-      when: (s3: Answers) => s3.s3Setup === 'credentials',
-      default: 'us-east-1'
-    }
-  ])
+    ],
+    { prefill: { ...prefill, ...answers }, nonInteractive }
+  )
 
   // Analytics setup (asked after S3 configuration)
-  const analyticsAnswers = await inquirer.prompt<Answers>([
-    {
-      type: 'confirm',
-      name: 'includeAnalytics',
-      message: 'Would you like to include anonymous user analytics (Umami)? (privacy-friendly, self-hosted)',
-      default: true
-    }
-  ])
+  const analyticsAnswers = await promptWithPrefill<Answers>(
+    [
+      {
+        type: 'confirm',
+        name: 'includeAnalytics',
+        message: 'Would you like to include anonymous user analytics (Umami)? (privacy-friendly, self-hosted)',
+        default: true
+      }
+    ],
+    { prefill, nonInteractive }
+  )
 
   // Workflow setup (asked after analytics, BEFORE skills)
-  console.log()
-  console.log(chalk.cyan('🔧 AI Workflow Configuration (Optional)'))
-  console.log(chalk.gray('Configure project management tools for AI collaboration (GitHub Projects, Jira, Notion, Linear)'))
-  console.log()
-
-  const workflowPrompt = await inquirer.prompt<{ configureWorkflow: boolean }>([
-    {
-      type: 'confirm',
-      name: 'configureWorkflow',
-      message: 'Do you want to configure an AI workflow tool now?',
-      default: true
-    }
-  ])
-
+  // In non-interactive mode, respect prefilled `workflow`; if absent, default to no workflow config.
   let workflowAnswers: Partial<Answers> = {}
   let selectedWorkflowTool: string | undefined
 
-  if (workflowPrompt.configureWorkflow) {
-    // Pass repository URL if available (for GitHub Project creation)
-    const repositoryUrl = answers.monorepoUrl || answers.backendRepoUrl || answers.frontendRepoUrl
-
-    const { workflow, aiRules } = await promptWorkflowConfiguration(answers.projectName, repositoryUrl)
-    workflowAnswers = { workflow, aiRules }
-    selectedWorkflowTool = workflow.tool
+  if (nonInteractive) {
+    // Non-interactive: use prefilled workflow if provided, otherwise skip (tool = 'none')
+    if (prefill.workflow) {
+      workflowAnswers = { workflow: prefill.workflow, aiRules: prefill.aiRules }
+      selectedWorkflowTool = prefill.workflow.tool
+    } else {
+      selectedWorkflowTool = 'none'
+    }
   } else {
-    console.log(chalk.gray('You can configure workflow later with: sf workflow create\n'))
-    selectedWorkflowTool = 'none'
+    console.log()
+    console.log(chalk.cyan('🔧 AI Workflow Configuration (Optional)'))
+    console.log(chalk.gray('Configure project management tools for AI collaboration (GitHub Projects, Jira, Notion, Linear)'))
+    console.log()
+
+    const workflowPrompt = await inquirer.prompt<{ configureWorkflow: boolean }>([
+      {
+        type: 'confirm',
+        name: 'configureWorkflow',
+        message: 'Do you want to configure an AI workflow tool now?',
+        default: true
+      }
+    ])
+
+    if (workflowPrompt.configureWorkflow) {
+      // Pass repository URL if available (for GitHub Project creation)
+      const repositoryUrl = answers.monorepoUrl || answers.backendRepoUrl || answers.frontendRepoUrl
+
+      const { workflow, aiRules } = await promptWorkflowConfiguration(answers.projectName, repositoryUrl)
+      workflowAnswers = { workflow, aiRules }
+      selectedWorkflowTool = workflow.tool
+    } else {
+      console.log(chalk.gray('You can configure workflow later with: sf workflow create\n'))
+      selectedWorkflowTool = 'none'
+    }
   }
 
   // Skills setup (asked AFTER workflow, with pre-selection based on workflow tool)
-  const advancedSkills = await promptAdvancedSkills(selectedWorkflowTool)
-  const skillsCredentials = await collectAdvancedSkillsCredentials(advancedSkills)
+  const advancedSkills = await promptAdvancedSkills(selectedWorkflowTool, { prefill, nonInteractive })
+  const skillsCredentials = await collectAdvancedSkillsCredentials(advancedSkills, { prefill, nonInteractive })
 
   const skillsAnswers: Partial<Answers> = {
     advancedSkills,

--- a/src/prompts/skills.prompts.ts
+++ b/src/prompts/skills.prompts.ts
@@ -3,6 +3,8 @@ import chalk from 'chalk'
 import { exec } from 'child_process'
 import { promisify } from 'util'
 
+import { PromptOptions, promptWithPrefill } from './helpers'
+
 const execAsync = promisify(exec)
 
 export interface AdvancedSkillCredentials {
@@ -27,8 +29,24 @@ export interface AdvancedSkillCredentials {
  * Prompt user to select which advanced skills to install
  * Skills are pre-selected based on the workflow tool chosen
  * @param workflowTool - The workflow tool selected (github-projects, jira, notion, linear, none)
+ * @param options - Prefill + non-interactive mode
  */
-export async function promptAdvancedSkills(workflowTool?: string): Promise<string[]> {
+export async function promptAdvancedSkills(workflowTool?: string, options: PromptOptions = {}): Promise<string[]> {
+  const { prefill = {}, nonInteractive = false } = options
+
+  // If advancedSkills is already provided via prefill, use it directly
+  if (Array.isArray(prefill.advancedSkills)) {
+    return prefill.advancedSkills as string[]
+  }
+
+  // Non-interactive without prefill: default to empty list (or workflow-driven pre-selection)
+  if (nonInteractive) {
+    const preSelected: string[] = []
+    if (workflowTool === 'jira') preSelected.push('atlassian')
+    if (workflowTool === 'notion') preSelected.push('notion')
+    return preSelected
+  }
+
   console.log(chalk.blue('\n📚 Advanced Skills (Optional)'))
   console.log(chalk.gray('These skills integrate with external services and require API tokens.\nYou can skip this now and configure them later when Claude prompts you.'))
 
@@ -86,40 +104,49 @@ async function openBrowser(url: string): Promise<void> {
  * Context7 uses a free public API - no credentials needed
  * This function is kept for compatibility but doesn't collect any credentials
  */
-export async function promptContext7Credentials(): Promise<Partial<AdvancedSkillCredentials>> {
-  console.log(chalk.blue('\n📚 Context7 - Free Public API'))
-  console.log(chalk.gray('Context7 provides up-to-date library documentation without requiring API keys.'))
-  console.log(chalk.gray('No configuration needed!\n'))
+export async function promptContext7Credentials(options: PromptOptions = {}): Promise<Partial<AdvancedSkillCredentials>> {
+  const { nonInteractive = false } = options
+  if (!nonInteractive) {
+    console.log(chalk.blue('\n📚 Context7 - Free Public API'))
+    console.log(chalk.gray('Context7 provides up-to-date library documentation without requiring API keys.'))
+    console.log(chalk.gray('No configuration needed!\n'))
+  }
   return {}
 }
 
 /**
  * Prompt for Atlassian credentials (Jira/Confluence)
  */
-export async function promptAtlassianCredentials(): Promise<Partial<AdvancedSkillCredentials>> {
-  console.log(chalk.yellow('\n🔑 Atlassian Configuration'))
-  console.log(chalk.yellow('You need an Atlassian API token to integrate with Jira and Confluence.'))
-  console.log(chalk.yellow('Opening https://id.atlassian.com/manage-profile/security/api-tokens in your browser in few seconds...'))
+export async function promptAtlassianCredentials(options: PromptOptions = {}): Promise<Partial<AdvancedSkillCredentials>> {
+  const { prefill = {}, nonInteractive = false } = options
+  const allCredsProvided = prefill.atlassianEmail !== undefined && prefill.atlassianApiToken !== undefined && prefill.atlassianSite !== undefined && prefill.atlassianCloudId !== undefined
 
-  await new Promise((resolve) => setTimeout(resolve, 3000))
-  await openBrowser('https://id.atlassian.com/manage-profile/security/api-tokens')
+  if (!allCredsProvided && !nonInteractive) {
+    console.log(chalk.yellow('\n🔑 Atlassian Configuration'))
+    console.log(chalk.yellow('You need an Atlassian API token to integrate with Jira and Confluence.'))
+    console.log(chalk.yellow('Opening https://id.atlassian.com/manage-profile/security/api-tokens in your browser in few seconds...'))
 
-  const { ready } = await inquirer.prompt<{ ready: boolean }>([
-    {
-      type: 'confirm',
-      name: 'ready',
-      message: 'Are you ready to configure your Atlassian credentials?',
-      default: true
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+    await openBrowser('https://id.atlassian.com/manage-profile/security/api-tokens')
+
+    const { ready } = await inquirer.prompt<{ ready: boolean }>([
+      {
+        type: 'confirm',
+        name: 'ready',
+        message: 'Are you ready to configure your Atlassian credentials?',
+        default: true
+      }
+    ])
+
+    if (!ready) {
+      console.log(chalk.yellow('Atlassian skill will be set up but disabled until you configure it.'))
+      console.log(chalk.gray('Claude will prompt you to configure it when you try to use it.\n'))
+      return {}
     }
-  ])
+  }
 
-  if (ready) {
-    const answers = await inquirer.prompt<{
-      atlassianEmail: string
-      atlassianApiToken: string
-      atlassianSite: string
-      atlassianCloudId: string
-    }>([
+  return await promptWithPrefill<Partial<AdvancedSkillCredentials>>(
+    [
       {
         type: 'input',
         name: 'atlassianEmail',
@@ -157,41 +184,44 @@ export async function promptAtlassianCredentials(): Promise<Partial<AdvancedSkil
           return true
         }
       }
-    ])
-
-    return answers
-  } else {
-    console.log(chalk.yellow('Atlassian skill will be set up but disabled until you configure it.'))
-    console.log(chalk.gray('Claude will prompt you to configure it when you try to use it.\n'))
-    return {}
-  }
+    ],
+    { prefill, nonInteractive }
+  )
 }
 
 /**
  * Prompt for Notion API token
  */
-export async function promptNotionCredentials(): Promise<Partial<AdvancedSkillCredentials>> {
-  console.log(chalk.yellow('\n🔑 Notion Configuration'))
-  console.log(chalk.yellow('You need a Notion API token to integrate with your Notion workspace.'))
-  console.log(chalk.yellow('Opening https://www.notion.so/my-integrations in your browser in few seconds...'))
+export async function promptNotionCredentials(options: PromptOptions = {}): Promise<Partial<AdvancedSkillCredentials>> {
+  const { prefill = {}, nonInteractive = false } = options
+  const allCredsProvided = prefill.notionApiToken !== undefined && prefill.notionApiVersion !== undefined
 
-  await new Promise((resolve) => setTimeout(resolve, 3000))
-  await openBrowser('https://www.notion.so/my-integrations')
+  if (!allCredsProvided && !nonInteractive) {
+    console.log(chalk.yellow('\n🔑 Notion Configuration'))
+    console.log(chalk.yellow('You need a Notion API token to integrate with your Notion workspace.'))
+    console.log(chalk.yellow('Opening https://www.notion.so/my-integrations in your browser in few seconds...'))
 
-  const { ready } = await inquirer.prompt<{ ready: boolean }>([
-    {
-      type: 'confirm',
-      name: 'ready',
-      message: 'Are you ready to configure your Notion credentials?',
-      default: true
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+    await openBrowser('https://www.notion.so/my-integrations')
+
+    const { ready } = await inquirer.prompt<{ ready: boolean }>([
+      {
+        type: 'confirm',
+        name: 'ready',
+        message: 'Are you ready to configure your Notion credentials?',
+        default: true
+      }
+    ])
+
+    if (!ready) {
+      console.log(chalk.yellow('Notion skill will be set up but disabled until you configure it.'))
+      console.log(chalk.gray('Claude will prompt you to configure it when you try to use it.\n'))
+      return {}
     }
-  ])
+  }
 
-  if (ready) {
-    const answers = await inquirer.prompt<{
-      notionApiToken: string
-      notionApiVersion: string
-    }>([
+  return await promptWithPrefill<Partial<AdvancedSkillCredentials>>(
+    [
       {
         type: 'input',
         name: 'notionApiToken',
@@ -211,38 +241,44 @@ export async function promptNotionCredentials(): Promise<Partial<AdvancedSkillCr
           return true
         }
       }
-    ])
-
-    return answers
-  } else {
-    console.log(chalk.yellow('Notion skill will be set up but disabled until you configure it.'))
-    console.log(chalk.gray('Claude will prompt you to configure it when you try to use it.\n'))
-    return {}
-  }
+    ],
+    { prefill, nonInteractive }
+  )
 }
 
 /**
  * Prompt for Figma API token
  */
-export async function promptFigmaCredentials(): Promise<Partial<AdvancedSkillCredentials>> {
-  console.log(chalk.yellow('\n🔑 Figma Configuration'))
-  console.log(chalk.yellow('You need a Figma API token to integrate with Figma designs.'))
-  console.log(chalk.yellow('Opening https://www.figma.com/developers/api#access-tokens in your browser in few seconds...'))
+export async function promptFigmaCredentials(options: PromptOptions = {}): Promise<Partial<AdvancedSkillCredentials>> {
+  const { prefill = {}, nonInteractive = false } = options
+  const allCredsProvided = prefill.figmaApiToken !== undefined
 
-  await new Promise((resolve) => setTimeout(resolve, 3000))
-  await openBrowser('https://www.figma.com/developers/api#access-tokens')
+  if (!allCredsProvided && !nonInteractive) {
+    console.log(chalk.yellow('\n🔑 Figma Configuration'))
+    console.log(chalk.yellow('You need a Figma API token to integrate with Figma designs.'))
+    console.log(chalk.yellow('Opening https://www.figma.com/developers/api#access-tokens in your browser in few seconds...'))
 
-  const { ready } = await inquirer.prompt<{ ready: boolean }>([
-    {
-      type: 'confirm',
-      name: 'ready',
-      message: 'Are you ready to configure your Figma credentials?',
-      default: true
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+    await openBrowser('https://www.figma.com/developers/api#access-tokens')
+
+    const { ready } = await inquirer.prompt<{ ready: boolean }>([
+      {
+        type: 'confirm',
+        name: 'ready',
+        message: 'Are you ready to configure your Figma credentials?',
+        default: true
+      }
+    ])
+
+    if (!ready) {
+      console.log(chalk.yellow('Figma skill will be set up but disabled until you configure it.'))
+      console.log(chalk.gray('Claude will prompt you to configure it when you try to use it.\n'))
+      return {}
     }
-  ])
+  }
 
-  if (ready) {
-    const { figmaApiToken } = await inquirer.prompt<{ figmaApiToken: string }>([
+  return await promptWithPrefill<Partial<AdvancedSkillCredentials>>(
+    [
       {
         type: 'input',
         name: 'figmaApiToken',
@@ -252,35 +288,30 @@ export async function promptFigmaCredentials(): Promise<Partial<AdvancedSkillCre
           return true
         }
       }
-    ])
-
-    return { figmaApiToken }
-  } else {
-    console.log(chalk.yellow('Figma skill will be set up but disabled until you configure it.'))
-    console.log(chalk.gray('Claude will prompt you to configure it when you try to use it.\n'))
-    return {}
-  }
+    ],
+    { prefill, nonInteractive }
+  )
 }
 
 /**
  * Orchestrate credential collection for selected advanced skills
  */
-export async function collectAdvancedSkillsCredentials(selectedSkills: string[]): Promise<AdvancedSkillCredentials> {
+export async function collectAdvancedSkillsCredentials(selectedSkills: string[], options: PromptOptions = {}): Promise<AdvancedSkillCredentials> {
   const credentials: AdvancedSkillCredentials = {}
 
   for (const skill of selectedSkills) {
     switch (skill) {
       case 'context7':
-        Object.assign(credentials, await promptContext7Credentials())
+        Object.assign(credentials, await promptContext7Credentials(options))
         break
       case 'atlassian':
-        Object.assign(credentials, await promptAtlassianCredentials())
+        Object.assign(credentials, await promptAtlassianCredentials(options))
         break
       case 'notion':
-        Object.assign(credentials, await promptNotionCredentials())
+        Object.assign(credentials, await promptNotionCredentials(options))
         break
       case 'figma':
-        Object.assign(credentials, await promptFigmaCredentials())
+        Object.assign(credentials, await promptFigmaCredentials(options))
         break
     }
   }


### PR DESCRIPTION
Resolves #58 — Phase 1A of the `tool-saasfoundry` skill epic (#18).

## Summary

Enable `sf new` to run fully unattended via CLI flags, so the `tool-saasfoundry` Claude Code skill (and any CI) can orchestrate project scaffolding without stdin.

### What changed

- **`src/index.ts`** — registered a full `.option(...)` chain on `sf new` covering every prompt in `project.prompts.ts` + `skills.prompts.ts`: `--non-interactive`, project/structure/branch/repo flags, `--db-*`, `--s3-*`, `--email-service` + `--mailersend-*`, `--analytics`/`--no-analytics`, `--advanced-skills` (CSV) + per-skill credential flags, `--workflow`/`--no-workflow`, `--start-services`/`--no-start-services`, `--start-apps`.
- **`src/prompts/helpers.ts` (new)** — `promptWithPrefill<T>` wraps `inquirer.prompt` with prefill + non-interactive validation. In non-interactive mode, throws with the list of missing applicable questions instead of hanging. Matches Inquirer's truthy/falsy `when` semantics; async `when` callbacks are treated as applicable (safer to surface).
- **`src/commands/new.options.ts` (new)** — `NewCommandOptions` interface + `buildPrefillFromOptions(opts)` translates flat Commander flags into the nested `Answers` prefill shape Inquirer expects (`dbCredentials.*`, `s3Credentials.*`, `advancedSkills` CSV, …). Plus `shouldSkipWorkflow(opts)` for `--no-workflow` / `--workflow none`.
- **`src/commands/new.ts`** — reads options, builds the prefill, passes `{prefill, nonInteractive}` through to `getUserStartProjectInputs`, and suppresses all terminal/browser opens in non-interactive mode so CI gets clean control back. `startServices` defaults to `false` in non-interactive mode (opt-in with `--start-services`).
- **`src/prompts/project.prompts.ts` + `src/prompts/skills.prompts.ts`** — routed through `promptWithPrefill` end-to-end so a mixed-mode invocation (some flags + some prompts) still works in an interactive shell.

### Bug fix caught during AI Testing

During Scenario 2 I ran `sf new --non-interactive --project-name foo` and the error listed `setupRepo` twice and a spurious `monorepoUrl`. Root cause: sync `when` callbacks returning `undefined` (because the dependency wasn't prefilled) were being treated as applicable, and duplicate-name questions (the two `setupRepo` prompts) weren't deduped. Fixed in `bc4662f`: coerce sync `when` results with `Boolean(result)` (matching Inquirer), treat Promise returns as applicable, and collect missing names into a `Set`.

Clean output after the fix:
```
Missing required values in --non-interactive mode: projectDescription, mainBranch, isMonorepo, setupRepo, dbSetup, emailService
```

## Test plan

Full test plan posted to #58: https://github.com/DiamondForgeFr/SaaSFoundry/issues/58#issuecomment-4264103530

AI Testing report (9 scenarios + automated checks, all green): https://github.com/DiamondForgeFr/SaaSFoundry/issues/58#issuecomment-4264151357

### Manual scenarios executed end-to-end
- `sf new --help` documents every flag
- Missing required flag in `--non-interactive` fails fast with a clean list (no duplicates)
- Full multirepo non-interactive generation: `apps/acme-multi-api` + `apps/acme-multi-web` created, `.saasfoundry.json` matches flags, no terminals/browsers opened
- Monorepo + `--db-setup docker --s3-setup docker`: monorepo root + `apps/api/docker-compose.dev-services.yml` generated
- `--email-service mailersend` without credential flags reports exactly `mailersendApiKey, mailersendSenderEmail, mailersendSenderName`

### Non-regression tests added
- `src/__tests__/unit/prompts/helpers.spec.ts` — 12 tests for `promptWithPrefill`: prefill forwarding, non-interactive validation, dot-notation paths, `when` semantics (sync/falsy/async), dedup
- `src/__tests__/unit/commands/new.options.spec.ts` — 17 tests for `buildPrefillFromOptions`: field mapping, nested db/s3 credentials, analytics toggle, advanced-skills CSV, skill credentials, repo fields; plus `shouldSkipWorkflow`
- `src/__tests__/integration/commands/new.non-interactive.spec.ts` — 9 tests for `newCommand` end-to-end: flag propagation to API builder, manifest content, monorepo root creation, dev-services builder invocation, missing-flag error handling

### Automated checks
- `npm run build` — clean
- `npm run lint` — 0 errors
- Full Jest matrix (unit + integration + e2e + smoke) — **326/326 passing** across 26 suites
- Pre-push Docker scenarios (`multirepo-minimal`, `monorepo-minimal`) — **2/2 passing**

## Commits on branch

- `e67926f feat(#58): add promptWithPrefill helper for non-interactive mode`
- `1f3df74 refactor(#58): route project and skills prompts through promptWithPrefill`
- `a0d062d feat(#58): add --non-interactive flag and full option set to sf new`
- `bc4662f fix(#58): dedupe and coerce when callbacks in non-interactive validator`

## Parent epic

Unblocks the rest of #18 — Phase 1B (`sf update` non-interactive, #59), Phase 2 (`sf modules list/info/match --json`, #60), Phase 3 (`sf skill install/update/uninstall`, #61), Phase 4 (`sf feedback`, #62).
