### PR TITLE
feat(#60): sf modules catalogue JSON API + enriched metadata

### DIFF
--- a/.claude/docs/modules-catalogue-schema.md
+++ b/.claude/docs/modules-catalogue-schema.md
@@ -1,0 +1,102 @@
+# Modules Catalogue — JSON Schema
+
+**Audience**: authors of Claude Code skills (e.g. `tool-saasfoundry`) that read the SaaSFoundry module catalogue programmatically.
+
+The catalogue is the **single source of truth** for what modules SaaSFoundry can install. It is consumed by `sf new`, `sf update`, and the public `sf modules` command group.
+
+Skill consumers should call `sf modules` with `--json` rather than parsing human output. The JSON envelope is versioned by `cliVersion` so consumers can detect and adapt to future additions.
+
+## Stability guarantees
+
+- **Additive between minor CLI versions** — new fields may appear; existing fields are not renamed or removed without a major bump.
+- `cliVersion` is always present at the top of every `--json` response.
+- Field semantics (meaning of `category`, of `installOnly`, etc.) are stable across minor versions.
+- Array order in `CATALOGUE` is stable within a given CLI version but not guaranteed across versions — consumers should key by `name`, not index.
+
+## Entry point: module names
+
+Every entry is identified by a stable machine `name`. The canonical list is emitted by `sf modules list --json`.
+
+Current entries (as of `1.0.0-beta`):
+
+- **Modules** (addable via `sf update`): `email`, `storage`, `analytics`
+- **Skills** (advanced Claude Code skills): `sf-skill-context7`, `sf-skill-atlassian`, `sf-skill-notion`, `sf-skill-figma`
+- **Structural** (shipped with `sf new`, not addable later): `auth`, `i18n`, `workflow-system`
+
+## `sf modules list --json`
+
+```json
+{
+  "cliVersion": "1.0.0-beta",
+  "modules": [
+    { "name": "email", "displayName": "...", "category": "module", "installed": false, ... },
+    ...
+  ]
+}
+```
+
+Each array entry is a full `ModuleDefinition` augmented with `installed: boolean` computed from `.saasfoundry.json` in the current working directory (defaults to `false` when no manifest is present).
+
+## `sf modules info <name> --json`
+
+```json
+{
+  "cliVersion": "1.0.0-beta",
+  "module": { "name": "email", ..., "installed": false }
+}
+```
+
+Exits with code `1` and a human-readable error on stderr when the module name is unknown.
+
+## `sf modules match "<intent>" --json`
+
+```json
+{
+  "cliVersion": "1.0.0-beta",
+  "intent": "send transactional emails",
+  "results": [
+    {
+      "name": "email",
+      "displayName": "MailerSend Email Service",
+      "category": "module",
+      "score": 5,
+      "reasons": ["keywords: transactional", "description: transactional, emails"]
+    }
+  ]
+}
+```
+
+Scoring algorithm:
+
+- Tokenize the intent (lowercase, split on non-alphanumeric, ≥ 2 chars, drop stopwords).
+- Per module, match tokens against `keywords` (exact set match, weight 3), `alternatives` (substring match, weight 2), `description` (substring match, weight 1).
+- Return modules with `score > 0`, sorted descending.
+
+The score is **relative**, not calibrated — consumers should use it for ranking, not for absolute thresholds. Claude is expected to do the final semantic matching client-side using `keywords`, `provides`, `alternatives`, and `description` from the top candidates.
+
+## `ModuleDefinition` — field reference
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `name` | string | Stable machine id. Used by `--add-modules`, `sf modules info`, installed-state lookups. Never renamed. |
+| `displayName` | string | Human-readable label for tables and prompts. May change for clarity. |
+| `description` | string | One-sentence summary. Used in `sf modules list`, `sf update` prompts, and match scoring. |
+| `category` | `'module' \| 'skill' \| 'structural'` | `module` = addable via `sf update`. `skill` = advanced Claude Code skill. `structural` = baked into `sf new`, not addable later. |
+| `keywords` | string[] | Curated lowercase single-word tags for intent matching. Highest match weight. |
+| `provides` | string[] | What the module adds to the generated project (services, UI, tables, env vars). |
+| `alternatives` | string[] | What users might otherwise custom-build. Feeds the anti-reinvention guardrail — Claude should cite these when proposing a SaaSFoundry module over a hand-rolled solution. |
+| `introducedInVersion` | string | First CLI version that shipped this module (semver). |
+| `minCliVersion` | string | Minimum CLI version required to install (semver). |
+| `filesAffected` | string[] | Paths touched when installing. Used by `sf update --dry-run` previews. |
+| `dependencies` | string[] | npm package names added to the generated project. |
+| `installOnly` | `'scaffold' \| undefined` | Present and equal to `'scaffold'` iff the module can only be chosen at `sf new` time. Absent on post-install modules. |
+
+## Consumer contract (for `tool-saasfoundry` and similar)
+
+Recommended skill flow when a user asks *"how do I add X?"*:
+
+1. `sf modules match "<user intent>" --json` → shortlist candidates.
+2. `sf modules info <candidate> --json` → read `provides`, `alternatives`, `filesAffected`.
+3. If `category === 'structural'`, inform the user it ships with `sf new` and is not addable via `sf update`.
+4. Otherwise, propose `sf update --add-modules <name>` with the appropriate credential flags (derived from `--help`).
+5. Check `minCliVersion` against the user's installed CLI version before recommending.

--- a/.claude/docs/modules-catalogue-schema.md
+++ b/.claude/docs/modules-catalogue-schema.md
@@ -72,28 +72,29 @@ Scoring algorithm:
 - Per module, match tokens against `keywords` (exact set match, weight 3), `alternatives` (substring match, weight 2), `description` (substring match, weight 1).
 - Return modules with `score > 0`, sorted descending.
 
-The score is **relative**, not calibrated — consumers should use it for ranking, not for absolute thresholds. Claude is expected to do the final semantic matching client-side using `keywords`, `provides`, `alternatives`, and `description` from the top candidates.
+The score is **relative**, not calibrated — consumers should use it for ranking, not for absolute thresholds. Claude is expected to do the final semantic matching client-side using `keywords`,
+`provides`, `alternatives`, and `description` from the top candidates.
 
 ## `ModuleDefinition` — field reference
 
-| Field | Type | Meaning |
-| --- | --- | --- |
-| `name` | string | Stable machine id. Used by `--add-modules`, `sf modules info`, installed-state lookups. Never renamed. |
-| `displayName` | string | Human-readable label for tables and prompts. May change for clarity. |
-| `description` | string | One-sentence summary. Used in `sf modules list`, `sf update` prompts, and match scoring. |
-| `category` | `'module' \| 'skill' \| 'structural'` | `module` = addable via `sf update`. `skill` = advanced Claude Code skill. `structural` = baked into `sf new`, not addable later. |
-| `keywords` | string[] | Curated lowercase single-word tags for intent matching. Highest match weight. |
-| `provides` | string[] | What the module adds to the generated project (services, UI, tables, env vars). |
-| `alternatives` | string[] | What users might otherwise custom-build. Feeds the anti-reinvention guardrail — Claude should cite these when proposing a SaaSFoundry module over a hand-rolled solution. |
-| `introducedInVersion` | string | First CLI version that shipped this module (semver). |
-| `minCliVersion` | string | Minimum CLI version required to install (semver). |
-| `filesAffected` | string[] | Paths touched when installing. Used by `sf update --dry-run` previews. |
-| `dependencies` | string[] | npm package names added to the generated project. |
-| `installOnly` | `'scaffold' \| undefined` | Present and equal to `'scaffold'` iff the module can only be chosen at `sf new` time. Absent on post-install modules. |
+| Field                 | Type                                  | Meaning                                                                                                                                                                   |
+| --------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                | string                                | Stable machine id. Used by `--add-modules`, `sf modules info`, installed-state lookups. Never renamed.                                                                    |
+| `displayName`         | string                                | Human-readable label for tables and prompts. May change for clarity.                                                                                                      |
+| `description`         | string                                | One-sentence summary. Used in `sf modules list`, `sf update` prompts, and match scoring.                                                                                  |
+| `category`            | `'module' \| 'skill' \| 'structural'` | `module` = addable via `sf update`. `skill` = advanced Claude Code skill. `structural` = baked into `sf new`, not addable later.                                          |
+| `keywords`            | string[]                              | Curated lowercase single-word tags for intent matching. Highest match weight.                                                                                             |
+| `provides`            | string[]                              | What the module adds to the generated project (services, UI, tables, env vars).                                                                                           |
+| `alternatives`        | string[]                              | What users might otherwise custom-build. Feeds the anti-reinvention guardrail — Claude should cite these when proposing a SaaSFoundry module over a hand-rolled solution. |
+| `introducedInVersion` | string                                | First CLI version that shipped this module (semver).                                                                                                                      |
+| `minCliVersion`       | string                                | Minimum CLI version required to install (semver).                                                                                                                         |
+| `filesAffected`       | string[]                              | Paths touched when installing. Used by `sf update --dry-run` previews.                                                                                                    |
+| `dependencies`        | string[]                              | npm package names added to the generated project.                                                                                                                         |
+| `installOnly`         | `'scaffold' \| undefined`             | Present and equal to `'scaffold'` iff the module can only be chosen at `sf new` time. Absent on post-install modules.                                                     |
 
 ## Consumer contract (for `tool-saasfoundry` and similar)
 
-Recommended skill flow when a user asks *"how do I add X?"*:
+Recommended skill flow when a user asks _"how do I add X?"_:
 
 1. `sf modules match "<user intent>" --json` → shortlist candidates.
 2. `sf modules info <candidate> --json` → read `provides`, `alternatives`, `filesAffected`.

--- a/src/__tests__/integration/commands/modules.spec.ts
+++ b/src/__tests__/integration/commands/modules.spec.ts
@@ -1,0 +1,207 @@
+import { mkdir, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { modulesCommand } from '../../../commands/modules'
+import { SaaSFoundryManifest } from '../../../types'
+import { version as cliVersion } from '../../../../package.json'
+
+describe('modulesCommand (integration)', () => {
+  let tempDir: string
+  let originalCwd: string
+  let logSpy: jest.SpyInstance
+  let errorSpy: jest.SpyInstance
+  let exitSpy: jest.SpyInstance
+
+  const buildManifest = (overrides: Partial<SaaSFoundryManifest['modules']> = {}): SaaSFoundryManifest => ({
+    version: cliVersion,
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    structure: 'monorepo',
+    projectName: 'modules-integration',
+    modules: {
+      emailService: 'none',
+      s3Setup: 'manual',
+      dbSetup: 'docker',
+      includeAnalytics: false,
+      advancedSkills: [],
+      ...overrides
+    }
+  })
+
+  const writeManifest = async (manifest: SaaSFoundryManifest) => {
+    await writeFile('.saasfoundry.json', JSON.stringify(manifest, null, 2))
+  }
+
+  const getAllLogOutput = () => logSpy.mock.calls.map((call) => call.join(' ')).join('\n')
+  const getJsonOutput = () => JSON.parse(logSpy.mock.calls.map((call) => call.join(' ')).join('\n'))
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `sf-int-modules-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    originalCwd = process.cwd()
+    await mkdir(tempDir, { recursive: true })
+    process.chdir(tempDir)
+
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined)
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never)
+  })
+
+  afterEach(async () => {
+    process.chdir(originalCwd)
+    await rm(tempDir, { recursive: true, force: true })
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
+  })
+
+  describe('list', () => {
+    it('should print the catalogue in human mode', async () => {
+      await modulesCommand('list')
+      const output = getAllLogOutput()
+      expect(output).toContain('SaaSFoundry Module Catalogue')
+      expect(output).toContain('email')
+      expect(output).toContain('storage')
+      expect(output).toContain('analytics')
+      expect(output).toContain('Advanced Skills')
+      expect(output).toContain('Structural')
+    })
+
+    it('should include cliVersion and all modules in --json mode', async () => {
+      await modulesCommand('list', '--json')
+      const payload = getJsonOutput()
+      expect(payload.cliVersion).toBe(cliVersion)
+      expect(Array.isArray(payload.modules)).toBe(true)
+      expect(payload.modules.length).toBeGreaterThanOrEqual(7)
+      for (const entry of payload.modules) {
+        expect(entry).toHaveProperty('name')
+        expect(entry).toHaveProperty('installed')
+        expect(typeof entry.installed).toBe('boolean')
+      }
+    })
+
+    it('should mark email as installed when manifest has mailersend', async () => {
+      await writeManifest(buildManifest({ emailService: 'mailersend' }))
+      await modulesCommand('list', '--json')
+      const payload = getJsonOutput()
+      const email = payload.modules.find((m: { name: string }) => m.name === 'email')
+      expect(email.installed).toBe(true)
+    })
+
+    it('should mark storage as installed when s3Setup is docker', async () => {
+      await writeManifest(buildManifest({ s3Setup: 'docker' }))
+      await modulesCommand('list', '--json')
+      const payload = getJsonOutput()
+      const storage = payload.modules.find((m: { name: string }) => m.name === 'storage')
+      expect(storage.installed).toBe(true)
+    })
+
+    it('should mark advanced skill as installed when listed in advancedSkills', async () => {
+      await writeManifest(buildManifest({ advancedSkills: ['notion'] }))
+      await modulesCommand('list', '--json')
+      const payload = getJsonOutput()
+      const skill = payload.modules.find((m: { name: string }) => m.name === 'sf-skill-notion')
+      expect(skill.installed).toBe(true)
+    })
+
+    it('should default installed to false with no manifest', async () => {
+      await modulesCommand('list', '--json')
+      const payload = getJsonOutput()
+      const email = payload.modules.find((m: { name: string }) => m.name === 'email')
+      expect(email.installed).toBe(false)
+    })
+
+    it('should mark structural modules as installed when manifest present', async () => {
+      await writeManifest(buildManifest())
+      await modulesCommand('list', '--json')
+      const payload = getJsonOutput()
+      const auth = payload.modules.find((m: { name: string }) => m.name === 'auth')
+      expect(auth.installed).toBe(true)
+    })
+  })
+
+  describe('info', () => {
+    it('should print module detail in human mode', async () => {
+      await modulesCommand('info', 'email')
+      const output = getAllLogOutput()
+      expect(output).toContain('MailerSend Email Service')
+      expect(output).toContain('Keywords:')
+      expect(output).toContain('Provides:')
+      expect(output).toContain('Alternatives:')
+    })
+
+    it('should return a single module in --json mode', async () => {
+      await modulesCommand('info', 'storage', '--json')
+      const payload = getJsonOutput()
+      expect(payload.cliVersion).toBe(cliVersion)
+      expect(payload.module.name).toBe('storage')
+      expect(payload.module).toHaveProperty('installed')
+    })
+
+    it('should exit with error when module is unknown', async () => {
+      await expect(modulesCommand('info', 'nope')).rejects.toThrow('process.exit(1)')
+      const errorOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+      expect(errorOutput).toContain('Module "nope" not found')
+    })
+
+    it('should exit when name is missing', async () => {
+      await expect(modulesCommand('info')).rejects.toThrow('process.exit(1)')
+    })
+  })
+
+  describe('match', () => {
+    it('should rank email first for a transactional email intent (--json)', async () => {
+      await modulesCommand('match', 'transactional emails', '--json')
+      const payload = getJsonOutput()
+      expect(payload.intent).toBe('transactional emails')
+      expect(payload.results[0].name).toBe('email')
+      expect(payload.results[0].score).toBeGreaterThan(0)
+      expect(Array.isArray(payload.results[0].reasons)).toBe(true)
+    })
+
+    it('should rank storage first for an upload/S3 intent', async () => {
+      await modulesCommand('match', 'file uploads to s3', '--json')
+      const payload = getJsonOutput()
+      expect(payload.results[0].name).toBe('storage')
+    })
+
+    it('should rank atlassian first for a jira intent', async () => {
+      await modulesCommand('match', 'jira tickets', '--json')
+      const payload = getJsonOutput()
+      expect(payload.results[0].name).toBe('sf-skill-atlassian')
+    })
+
+    it('should return empty results for unrelated intent', async () => {
+      await modulesCommand('match', 'xyzzy foobarbaz', '--json')
+      const payload = getJsonOutput()
+      expect(payload.results).toEqual([])
+    })
+
+    it('should exit when intent is missing', async () => {
+      await expect(modulesCommand('match')).rejects.toThrow('process.exit(1)')
+    })
+
+    it('should print top 3 in human mode', async () => {
+      await modulesCommand('match', 'analytics tracking')
+      const output = getAllLogOutput()
+      expect(output).toContain('Modules matching:')
+      expect(output).toContain('Umami Analytics')
+    })
+  })
+
+  describe('dispatch', () => {
+    it('should show help when no subcommand is given', async () => {
+      await modulesCommand()
+      const output = getAllLogOutput()
+      expect(output).toContain('SaaSFoundry Modules')
+      expect(output).toContain('Usage:')
+    })
+
+    it('should exit on unknown subcommand', async () => {
+      await expect(modulesCommand('bogus')).rejects.toThrow('process.exit(1)')
+      const errorOutput = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+      expect(errorOutput).toContain('Unknown subcommand: bogus')
+    })
+  })
+})

--- a/src/__tests__/unit/catalogue/modules.spec.ts
+++ b/src/__tests__/unit/catalogue/modules.spec.ts
@@ -1,0 +1,82 @@
+import { CATALOGUE, getAllModuleNames, getModuleByName, ModuleDefinition } from '../../../catalogue/modules'
+
+describe('module catalogue', () => {
+  describe('integrity', () => {
+    it('should have no duplicate module names', () => {
+      const names = CATALOGUE.map((m) => m.name)
+      const unique = new Set(names)
+      expect(unique.size).toBe(names.length)
+    })
+
+    it('should populate every required field on every entry', () => {
+      for (const module of CATALOGUE) {
+        expect(module.name).toMatch(/^[a-z0-9-]+$/)
+        expect(module.displayName).toBeTruthy()
+        expect(module.description).toBeTruthy()
+        expect(['module', 'skill', 'structural']).toContain(module.category)
+        expect(Array.isArray(module.keywords)).toBe(true)
+        expect(module.keywords.length).toBeGreaterThan(0)
+        expect(Array.isArray(module.provides)).toBe(true)
+        expect(module.provides.length).toBeGreaterThan(0)
+        expect(Array.isArray(module.alternatives)).toBe(true)
+        expect(module.alternatives.length).toBeGreaterThan(0)
+        expect(module.introducedInVersion).toMatch(/^\d+\.\d+\.\d+/)
+        expect(module.minCliVersion).toMatch(/^\d+\.\d+\.\d+/)
+        expect(Array.isArray(module.filesAffected)).toBe(true)
+        expect(module.filesAffected.length).toBeGreaterThan(0)
+        expect(Array.isArray(module.dependencies)).toBe(true)
+      }
+    })
+
+    it('should only use "scaffold" as installOnly value when present', () => {
+      for (const module of CATALOGUE) {
+        if (module.installOnly !== undefined) {
+          expect(module.installOnly).toBe('scaffold')
+        }
+      }
+    })
+
+    it('should flag all structural entries as scaffold-only', () => {
+      const structural = CATALOGUE.filter((m) => m.category === 'structural')
+      for (const module of structural) {
+        expect(module.installOnly).toBe('scaffold')
+      }
+    })
+
+    it('should use lowercase single-word keywords', () => {
+      for (const module of CATALOGUE) {
+        for (const keyword of module.keywords) {
+          expect(keyword).toBe(keyword.toLowerCase())
+          expect(keyword).not.toMatch(/\s/)
+        }
+      }
+    })
+
+    it('should include the known phase-1 modules', () => {
+      const names = CATALOGUE.map((m) => m.name)
+      for (const expected of ['email', 'storage', 'analytics', 'sf-skill-context7', 'sf-skill-atlassian', 'sf-skill-notion', 'sf-skill-figma']) {
+        expect(names).toContain(expected)
+      }
+    })
+  })
+
+  describe('getModuleByName', () => {
+    it('should return the matching module', () => {
+      const module = getModuleByName('email')
+      expect(module).toBeDefined()
+      expect(module?.displayName).toBe('MailerSend Email Service')
+    })
+
+    it('should return undefined for an unknown name', () => {
+      expect(getModuleByName('does-not-exist')).toBeUndefined()
+    })
+  })
+
+  describe('getAllModuleNames', () => {
+    it('should return every catalogue name', () => {
+      const names = getAllModuleNames()
+      expect(names).toHaveLength(CATALOGUE.length)
+      expect(names).toEqual(CATALOGUE.map((m: ModuleDefinition) => m.name))
+    })
+  })
+})

--- a/src/catalogue/modules.ts
+++ b/src/catalogue/modules.ts
@@ -1,0 +1,205 @@
+/**
+ * Single source of truth for the SaaSFoundry module catalogue.
+ *
+ * Consumed by:
+ * - `sf modules list|info|match` (direct)
+ * - `sf update` via `getAvailableModules()` in `prompts/update.prompts.ts`
+ * - The `tool-saasfoundry` Claude Code skill (via `--json` output)
+ */
+
+export type ModuleCategory = 'module' | 'skill' | 'structural'
+
+export interface ModuleDefinition {
+  /** Stable machine identifier used by `--add-modules` and `sf modules info`. */
+  name: string
+  /** Human-friendly display name (for tables, prompts). */
+  displayName: string
+  /** One-sentence description shown in prompts and `sf modules list`. */
+  description: string
+  /** `module` (addable via sf update), `skill` (advanced Claude skill), `structural` (baked into sf new). */
+  category: ModuleCategory
+  /** Keywords for intent matching (lower-case, single words preferred). */
+  keywords: string[]
+  /** What this module gives the generated project (services, UI, tables, …). */
+  provides: string[]
+  /** What users might otherwise custom-build — feeds the anti-reinvention guardrail. */
+  alternatives: string[]
+  /** First CLI version that shipped this module. */
+  introducedInVersion: string
+  /** Minimum CLI version required to install it. */
+  minCliVersion: string
+  /** Paths touched when installed — for dry-run previews. */
+  filesAffected: string[]
+  /** npm dependencies added to the generated project. */
+  dependencies: string[]
+  /** Set to `'scaffold'` when the module can only be chosen at `sf new` time. */
+  installOnly?: 'scaffold'
+}
+
+export const CATALOGUE: ModuleDefinition[] = [
+  {
+    name: 'email',
+    displayName: 'MailerSend Email Service',
+    description: 'Transactional emails (account creation, password reset, invitations) via MailerSend [free, 3000 emails/month]',
+    category: 'module',
+    keywords: ['email', 'mail', 'smtp', 'transactional', 'mailersend', 'notifications', 'invitations', 'password-reset'],
+    provides: ['MailerSendService (NestJS)', 'Auth/invitation email flows', 'Test credentials in .env.test'],
+    alternatives: ['Nodemailer', 'SendGrid', 'AWS SES', 'Postmark', 'Resend', 'custom SMTP integration'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: [
+      'apps/api/src/modules/email/services/mailersend.service.ts',
+      'apps/api/src/modules/email/email.module.ts',
+      'apps/api/src/modules/auth/services/auth.service.ts',
+      'apps/api/src/modules/invitation/services/invitation.service.ts',
+      'apps/api/src/configs/env/services/env.service.ts',
+      'apps/api/.env',
+      'apps/api/.env.test',
+      'apps/api/deployment.yml'
+    ],
+    dependencies: ['mailersend']
+  },
+  {
+    name: 'storage',
+    displayName: 'S3 Object Storage',
+    description: 'File uploads (logos, documents) with S3-compatible storage (MinIO via Docker or existing server)',
+    category: 'module',
+    keywords: ['storage', 's3', 'files', 'upload', 'uploads', 'minio', 'object-storage', 'cdn', 'blob'],
+    provides: ['StorageModule (NestJS)', 'Multer file-upload middleware', 'Org logo upload endpoint', 'MinIO docker-compose service (optional)'],
+    alternatives: ['custom S3 wrapper', 'Cloudinary', 'local filesystem storage', 'Firebase Storage', 'Supabase Storage'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: [
+      'apps/api/src/modules/storage/',
+      'apps/api/src/modules/org/',
+      'apps/api/src/configs/env/services/env.service.ts',
+      'apps/api/src/app.module.ts',
+      'apps/api/.env',
+      'apps/api/.env.test',
+      'apps/web/.env',
+      'docker-compose.dev-services.yml'
+    ],
+    dependencies: ['@aws-sdk/client-s3', '@types/multer']
+  },
+  {
+    name: 'analytics',
+    displayName: 'Umami Analytics',
+    description: 'Privacy-friendly anonymous user analytics (self-hosted, production only)',
+    category: 'module',
+    keywords: ['analytics', 'umami', 'tracking', 'metrics', 'privacy', 'stats', 'observability'],
+    provides: ['Umami tracking script loader', 'Production-only initialization', 'VITE_ANALYTICS_* env vars'],
+    alternatives: ['Google Analytics', 'Plausible', 'PostHog', 'Fathom', 'Matomo', 'custom tracking'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: ['apps/web/src/lib/analytics/', 'apps/web/src/main.tsx', 'apps/web/.env'],
+    dependencies: []
+  },
+  {
+    name: 'sf-skill-context7',
+    displayName: 'Advanced Skill: Context7',
+    description: 'Up-to-date library documentation (React, Vite, Prisma, etc.) [free, no credentials]',
+    category: 'skill',
+    keywords: ['context7', 'documentation', 'docs', 'libraries', 'reference', 'api-docs'],
+    provides: ['Claude Code skill: tool-context7', 'Library documentation lookup via MCP'],
+    alternatives: ['manual docs browsing', 'stale training data', 'devdocs.io'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: ['.claude/skills/tool-context7/', '.mcp.json'],
+    dependencies: []
+  },
+  {
+    name: 'sf-skill-atlassian',
+    displayName: 'Advanced Skill: Atlassian',
+    description: 'Jira/Confluence integration (tickets, wiki, sprints)',
+    category: 'skill',
+    keywords: ['atlassian', 'jira', 'confluence', 'tickets', 'issues', 'wiki', 'sprints', 'agile'],
+    provides: ['Claude Code skill: tool-atlassian', 'Jira ticket queries & edits', 'Confluence page reads & writes'],
+    alternatives: ['Jira REST API directly', 'manual ticket updates', 'jira-cli'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: ['.claude/skills/tool-atlassian/', '.mcp.json', '~/.claude/credentials/atlassian/'],
+    dependencies: []
+  },
+  {
+    name: 'sf-skill-notion',
+    displayName: 'Advanced Skill: Notion',
+    description: 'Notion workspace integration (pages, databases, views)',
+    category: 'skill',
+    keywords: ['notion', 'pages', 'databases', 'views', 'workspace', 'docs', 'wiki'],
+    provides: ['Claude Code skill: tool-notion', 'Notion page/database CRUD', 'View management'],
+    alternatives: ['Notion REST API directly', 'manual Notion UI'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: ['.claude/skills/tool-notion/', '.mcp.json', '~/.claude/credentials/notion/'],
+    dependencies: []
+  },
+  {
+    name: 'sf-skill-figma',
+    displayName: 'Advanced Skill: Figma',
+    description: 'Figma design system integration (designs, components)',
+    category: 'skill',
+    keywords: ['figma', 'design', 'design-system', 'components', 'ui', 'ux', 'mockups'],
+    provides: ['Claude Code skill: tool-figma', 'Design context extraction', 'Code Connect mappings'],
+    alternatives: ['Figma REST API directly', 'manual design-to-code translation'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: ['.claude/skills/tool-figma/', '.mcp.json', '~/.claude/credentials/figma/'],
+    dependencies: []
+  },
+  {
+    name: 'auth',
+    displayName: 'Authentication & Authorization',
+    description: 'JWT auth with email/password, roles, permissions, sessions, and invitation flow (shipped with sf new)',
+    category: 'structural',
+    keywords: ['auth', 'authentication', 'authorization', 'jwt', 'login', 'signup', 'roles', 'permissions', 'session'],
+    provides: ['AuthModule (NestJS)', 'JWT + Passport strategies', 'Role/permission guards', 'Invitation flow', 'Login/signup UI pages'],
+    alternatives: ['Auth0', 'Clerk', 'Supabase Auth', 'Firebase Auth', 'NextAuth.js', 'custom JWT'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: ['apps/api/src/modules/auth/', 'apps/web/src/pages/public/login*', 'apps/web/src/pages/public/sign-up*'],
+    dependencies: ['@nestjs/passport', '@nestjs/jwt', 'passport', 'passport-jwt', 'bcrypt'],
+    installOnly: 'scaffold'
+  },
+  {
+    name: 'i18n',
+    displayName: 'Internationalization',
+    description: 'Multi-language support via i18next (YAML translations, language switcher) (shipped with sf new)',
+    category: 'structural',
+    keywords: ['i18n', 'internationalization', 'translations', 'locales', 'languages', 'i18next', 'l10n'],
+    provides: ['i18next setup', 'YAML translation files', 'Language switcher component', 'Locale-aware routing'],
+    alternatives: ['react-intl', 'lingui', 'custom translation map'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: ['apps/web/src/locales/', 'apps/web/src/i18n.ts', 'apps/web/src/components/language-switcher/'],
+    dependencies: ['i18next', 'react-i18next', 'i18next-browser-languagedetector'],
+    installOnly: 'scaffold'
+  },
+  {
+    name: 'workflow-system',
+    displayName: 'Workflow System (AI-driven)',
+    description: 'Dogfooded Backlog → Ready → In Progress → AI Testing → Human Testing → In Review → Done workflow with GitHub Projects integration (shipped with sf new)',
+    category: 'structural',
+    keywords: ['workflow', 'ai', 'claude', 'github-projects', 'status', 'skill', 'tickets', 'agile'],
+    provides: ['.claude/skills/sf-workflow/', '.claude/skills/sf-tool-github-projects/', 'Status transition helpers', 'Subtask creation CLI'],
+    alternatives: ['raw GitHub Issues', 'Linear', 'Jira (with sf-skill-atlassian)', 'custom workflow tooling'],
+    introducedInVersion: '1.0.0-beta',
+    minCliVersion: '1.0.0-beta',
+    filesAffected: ['.claude/skills/sf-workflow/', '.claude/skills/sf-tool-github-projects/', '.saasfoundry.json'],
+    dependencies: [],
+    installOnly: 'scaffold'
+  }
+]
+
+/**
+ * Look up a single module by its machine name.
+ */
+export function getModuleByName(name: string): ModuleDefinition | undefined {
+  return CATALOGUE.find((m) => m.name === name)
+}
+
+/**
+ * All module names — useful for validating `--add-modules` input.
+ */
+export function getAllModuleNames(): string[] {
+  return CATALOGUE.map((m) => m.name)
+}

--- a/src/commands/modules.ts
+++ b/src/commands/modules.ts
@@ -1,0 +1,275 @@
+import chalk from 'chalk'
+import { readFile } from 'fs/promises'
+
+import { CATALOGUE, getModuleByName, ModuleCategory, ModuleDefinition } from '../catalogue/modules'
+import { SaaSFoundryManifest } from '../types'
+import { fileExists } from '../utils'
+import { version as cliVersion } from '../../package.json'
+
+type ModulesSubcommand = 'list' | 'info' | 'match'
+
+interface ParsedArgs {
+  json: boolean
+  positional: string[]
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const positional: string[] = []
+  let json = false
+  for (const arg of args) {
+    if (arg === '--json') json = true
+    else if (arg !== undefined && arg !== null && arg !== '') positional.push(arg)
+  }
+  return { json, positional }
+}
+
+export async function modulesCommand(subcommand?: string, ...args: string[]) {
+  if (!subcommand) {
+    showHelp()
+    return
+  }
+
+  const { json, positional } = parseArgs(args)
+
+  switch (subcommand as ModulesSubcommand) {
+    case 'list':
+      await runList(json)
+      break
+    case 'info':
+      await runInfo(positional[0], json)
+      break
+    case 'match':
+      await runMatch(positional.join(' '), json)
+      break
+    default:
+      console.error(chalk.red(`Unknown subcommand: ${subcommand}`))
+      showHelp()
+      process.exit(1)
+  }
+}
+
+function showHelp() {
+  console.log(chalk.blue('\n  SaaSFoundry Modules - Catalogue & intent matching'))
+  console.log(chalk.blue('  ' + '─'.repeat(60)))
+  console.log(chalk.white('\n  Usage: sf modules <subcommand> [options]\n'))
+  console.log(chalk.white('  Subcommands:'))
+  console.log(chalk.gray('    list [--json]             List all modules + installed state'))
+  console.log(chalk.gray('    info <name> [--json]      Show one module in detail'))
+  console.log(chalk.gray('    match "<intent>" [--json] Rank modules matching an intent'))
+  console.log(chalk.white('\n  Examples:'))
+  console.log(chalk.gray('    sf modules list'))
+  console.log(chalk.gray('    sf modules info email --json'))
+  console.log(chalk.gray('    sf modules match "send transactional emails"'))
+  console.log()
+}
+
+/**
+ * Try to load the manifest from the current working directory. Returns null
+ * when the user is not inside a SaaSFoundry project — all commands are still
+ * usable (installed state just defaults to `false`).
+ */
+async function tryReadManifest(): Promise<SaaSFoundryManifest | null> {
+  const path = '.saasfoundry.json'
+  if (!(await fileExists(path))) return null
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as SaaSFoundryManifest
+  } catch {
+    return null
+  }
+}
+
+function isInstalled(module: ModuleDefinition, manifest: SaaSFoundryManifest | null): boolean {
+  if (!manifest || !manifest.modules) return false
+  if (module.category === 'structural') return true
+
+  switch (module.name) {
+    case 'email':
+      return manifest.modules.emailService === 'mailersend'
+    case 'storage':
+      return manifest.modules.s3Setup === 'docker' || manifest.modules.s3Setup === 'credentials'
+    case 'analytics':
+      return manifest.modules.includeAnalytics === true
+    case 'sf-skill-context7':
+    case 'sf-skill-atlassian':
+    case 'sf-skill-notion':
+    case 'sf-skill-figma': {
+      const skill = module.name.replace(/^sf-skill-/, '')
+      return (manifest.modules.advancedSkills || []).includes(skill)
+    }
+    default:
+      return false
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// list
+// ────────────────────────────────────────────────────────────────────────────
+
+async function runList(json: boolean) {
+  const manifest = await tryReadManifest()
+  const entries = CATALOGUE.map((m) => ({ ...m, installed: isInstalled(m, manifest) }))
+
+  if (json) {
+    console.log(JSON.stringify({ cliVersion, modules: entries }, null, 2))
+    return
+  }
+
+  console.log(chalk.blue('\n  SaaSFoundry Module Catalogue'))
+  console.log(chalk.blue('  ' + '─'.repeat(60)))
+  if (!manifest) {
+    console.log(chalk.gray('  (no .saasfoundry.json in cwd — installed state unknown)'))
+  }
+  console.log()
+
+  const groups: Record<string, typeof entries> = { module: [], skill: [], structural: [] }
+  for (const entry of entries) groups[entry.category].push(entry)
+
+  const printGroup = (title: string, rows: typeof entries) => {
+    if (rows.length === 0) return
+    console.log(chalk.white(`  ${title}`))
+    for (const row of rows) {
+      const mark = row.installed ? chalk.green('✓') : chalk.gray(' ')
+      const scaffoldTag = row.installOnly === 'scaffold' ? chalk.yellow(' [scaffold-only]') : ''
+      console.log(`    ${mark} ${chalk.bold(row.name.padEnd(22))} ${chalk.gray(row.description)}${scaffoldTag}`)
+    }
+    console.log()
+  }
+
+  printGroup('Modules (addable via `sf update`)', groups.module)
+  printGroup('Advanced Skills', groups.skill)
+  printGroup('Structural (shipped with `sf new`)', groups.structural)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// info
+// ────────────────────────────────────────────────────────────────────────────
+
+async function runInfo(name: string | undefined, json: boolean) {
+  if (!name) {
+    console.error(chalk.red('Usage: sf modules info <name> [--json]'))
+    process.exit(1)
+  }
+
+  const module = getModuleByName(name)
+  if (!module) {
+    console.error(chalk.red(`Module "${name}" not found.`))
+    console.error(chalk.gray(`Known modules: ${CATALOGUE.map((m) => m.name).join(', ')}`))
+    process.exit(1)
+  }
+
+  const manifest = await tryReadManifest()
+  const installed = isInstalled(module, manifest)
+
+  if (json) {
+    console.log(JSON.stringify({ cliVersion, module: { ...module, installed } }, null, 2))
+    return
+  }
+
+  console.log(chalk.blue(`\n  ${module.displayName}`))
+  console.log(chalk.blue('  ' + '─'.repeat(60)))
+  console.log(`  ${chalk.bold('Name:'.padEnd(22))} ${module.name}`)
+  console.log(`  ${chalk.bold('Category:'.padEnd(22))} ${module.category}${module.installOnly === 'scaffold' ? chalk.yellow(' (scaffold-only)') : ''}`)
+  console.log(`  ${chalk.bold('Installed here:'.padEnd(22))} ${installed ? chalk.green('yes') : chalk.gray('no')}`)
+  console.log(`  ${chalk.bold('Introduced in:'.padEnd(22))} ${module.introducedInVersion}`)
+  console.log(`  ${chalk.bold('Min CLI version:'.padEnd(22))} ${module.minCliVersion}`)
+  console.log(`  ${chalk.bold('Description:'.padEnd(22))} ${module.description}`)
+  console.log(`  ${chalk.bold('Keywords:'.padEnd(22))} ${module.keywords.join(', ')}`)
+  console.log(`  ${chalk.bold('Provides:')}`)
+  for (const item of module.provides) console.log(chalk.gray(`    • ${item}`))
+  console.log(`  ${chalk.bold('Alternatives:')}`)
+  for (const item of module.alternatives) console.log(chalk.gray(`    • ${item}`))
+  if (module.dependencies.length > 0) {
+    console.log(`  ${chalk.bold('npm dependencies:')}`)
+    for (const item of module.dependencies) console.log(chalk.gray(`    • ${item}`))
+  }
+  console.log(`  ${chalk.bold('Files affected:')}`)
+  for (const item of module.filesAffected) console.log(chalk.gray(`    • ${item}`))
+  console.log()
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// match — weighted keyword scoring
+// ────────────────────────────────────────────────────────────────────────────
+
+interface MatchResult {
+  name: string
+  displayName: string
+  category: ModuleCategory
+  score: number
+  reasons: string[]
+}
+
+const STOPWORDS = new Set(['the', 'and', 'for', 'with', 'from', 'that', 'this', 'into', 'via', 'using', 'use', 'send', 'sending', 'add', 'adding', 'want', 'need', 'like', 'how', 'can', 'make', 'get'])
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 2 && !STOPWORDS.has(t))
+}
+
+/**
+ * Score each catalogue entry against the intent tokens.
+ *
+ * Weights:
+ *  - keywords: 3  (curated, high-signal)
+ *  - alternatives: 2 (what users would otherwise build — anti-reinvention)
+ *  - description: 1 (free-text fallback)
+ */
+function scoreModule(module: ModuleDefinition, intentTokens: string[]): MatchResult {
+  const reasons: string[] = []
+  let score = 0
+
+  const keywordSet = new Set(module.keywords.map((k) => k.toLowerCase()))
+  const matchedKeywords = intentTokens.filter((t) => keywordSet.has(t))
+  if (matchedKeywords.length > 0) {
+    score += matchedKeywords.length * 3
+    reasons.push(`keywords: ${matchedKeywords.join(', ')}`)
+  }
+
+  const altText = module.alternatives.join(' ').toLowerCase()
+  const matchedAlts = intentTokens.filter((t) => altText.includes(t))
+  if (matchedAlts.length > 0) {
+    score += matchedAlts.length * 2
+    reasons.push(`alternatives: ${matchedAlts.join(', ')}`)
+  }
+
+  const descText = module.description.toLowerCase()
+  const matchedDesc = intentTokens.filter((t) => descText.includes(t))
+  if (matchedDesc.length > 0) {
+    score += matchedDesc.length
+    reasons.push(`description: ${matchedDesc.join(', ')}`)
+  }
+
+  return { name: module.name, displayName: module.displayName, category: module.category, score, reasons }
+}
+
+async function runMatch(intent: string, json: boolean) {
+  if (!intent) {
+    console.error(chalk.red('Usage: sf modules match "<intent>" [--json]'))
+    process.exit(1)
+  }
+
+  const tokens = tokenize(intent)
+  const results = CATALOGUE.map((m) => scoreModule(m, tokens))
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score)
+
+  if (json) {
+    console.log(JSON.stringify({ cliVersion, intent, results }, null, 2))
+    return
+  }
+
+  console.log(chalk.blue(`\n  Modules matching: "${intent}"`))
+  console.log(chalk.blue('  ' + '─'.repeat(60)))
+  if (results.length === 0) {
+    console.log(chalk.gray('  No matching modules found.'))
+    console.log()
+    return
+  }
+  for (const r of results.slice(0, 3)) {
+    console.log(`  ${chalk.bold(r.displayName)} ${chalk.gray(`(${r.name}, ${r.category}, score ${r.score})`)}`)
+    for (const reason of r.reasons) console.log(chalk.gray(`    • ${reason}`))
+  }
+  console.log()
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import 'module-alias/register'
 import { version } from '../package.json'
+import { modulesCommand } from './commands/modules'
 import { newCommand } from './commands/new'
 import { updateCommand } from './commands/update'
 import { toolsCommand } from './commands/tools'
@@ -91,6 +92,13 @@ program
   .option('--figma-api-token <token>', 'Figma API token')
   .action((opts) => updateCommand(opts))
 program
+  .command('modules')
+  .description('Browse the SaaSFoundry module catalogue')
+  .argument('[subcommand]', 'Subcommand to execute (list, info, match)')
+  .argument('[args...]', 'Additional arguments for the subcommand (use --json for machine-readable output)')
+  .allowUnknownOption()
+  .action((subcommand, args) => modulesCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
+program
   .command('tools')
   .description('Manage multi-account credentials for advanced skills')
   .argument('[subcommand]', 'Subcommand to execute (list, accounts, add, use, current)')
@@ -104,4 +112,4 @@ program
   .action((subcommand, args) => workflowCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
 program.parse()
 
-export { newCommand, updateCommand, toolsCommand, workflowCommand }
+export { newCommand, updateCommand, modulesCommand, toolsCommand, workflowCommand }

--- a/src/prompts/update.prompts.ts
+++ b/src/prompts/update.prompts.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import { exec } from 'shelljs'
 
+import { CATALOGUE } from '../catalogue/modules'
 import { Answers, SaaSFoundryManifest } from '../types'
 import { PromptOptions, promptWithPrefill } from './helpers'
 import { AdvancedSkillCredentials, promptAtlassianCredentials, promptNotionCredentials, promptFigmaCredentials } from './skills.prompts'
@@ -12,57 +13,39 @@ interface AvailableModule {
 }
 
 /**
+ * Decide whether a catalogue entry is still addable given the project manifest.
+ *
+ * Structural modules (flagged `installOnly: 'scaffold'`) are never returned —
+ * they ship with `sf new` and cannot be added post-generation.
+ */
+function isModuleAvailable(moduleName: string, manifest: SaaSFoundryManifest): boolean {
+  switch (moduleName) {
+    case 'email':
+      return manifest.modules.emailService === 'none'
+    case 'storage':
+      return manifest.modules.s3Setup === 'manual'
+    case 'analytics':
+      return !manifest.modules.includeAnalytics
+    case 'sf-skill-context7':
+    case 'sf-skill-atlassian':
+    case 'sf-skill-notion':
+    case 'sf-skill-figma': {
+      const skillName = moduleName.replace(/^sf-skill-/, '')
+      const installed = manifest.modules.advancedSkills || []
+      return !installed.includes(skillName)
+    }
+    default:
+      return false
+  }
+}
+
+/**
  * Detect which modules are available but not installed based on the manifest.
  */
 export function getAvailableModules(manifest: SaaSFoundryManifest): AvailableModule[] {
-  const available: AvailableModule[] = []
-
-  if (manifest.modules.emailService === 'none') {
-    available.push({
-      name: 'MailerSend Email Service',
-      description: 'Transactional emails (account creation, password reset, invitations) via MailerSend [free, 3000 emails/month]',
-      value: 'email'
-    })
-  }
-
-  if (manifest.modules.s3Setup === 'manual') {
-    available.push({
-      name: 'S3 Object Storage',
-      description: 'File uploads (logos, documents) with S3-compatible storage (MinIO via Docker or existing server)',
-      value: 'storage'
-    })
-  }
-
-  if (!manifest.modules.includeAnalytics) {
-    available.push({
-      name: 'Umami Analytics',
-      description: 'Privacy-friendly anonymous user analytics (self-hosted, production only)',
-      value: 'analytics'
-    })
-  }
-
-  // Detect available advanced skills
-  const installedSkills = manifest.modules.advancedSkills || []
-  const allSkills = ['context7', 'atlassian', 'notion', 'figma']
-
-  for (const skill of allSkills) {
-    if (!installedSkills.includes(skill)) {
-      const skillDescriptions = {
-        context7: 'Up-to-date library documentation (React, Vite, Prisma, etc.) [free, no credentials]',
-        atlassian: 'Jira/Confluence integration (tickets, wiki, sprints)',
-        notion: 'Notion workspace integration (pages, databases, views)',
-        figma: 'Figma design system integration (designs, components)'
-      }
-
-      available.push({
-        name: `Advanced Skill: ${skill.charAt(0).toUpperCase() + skill.slice(1)}`,
-        description: skillDescriptions[skill as keyof typeof skillDescriptions],
-        value: `sf-skill-${skill}`
-      })
-    }
-  }
-
-  return available
+  return CATALOGUE.filter((m) => m.installOnly !== 'scaffold')
+    .filter((m) => isModuleAvailable(m.name, manifest))
+    .map((m) => ({ name: m.displayName, description: m.description, value: m.name }))
 }
 
 /**


### PR DESCRIPTION
Closes #60.

## Summary

- Promotes the module catalogue to a single source of truth in `src/catalogue/modules.ts` with enriched metadata (`keywords`, `provides`, `alternatives`, `introducedInVersion`, `minCliVersion`, `filesAffected`, `dependencies`, `category`, optional `installOnly`).
- Adds a new `sf modules` command group — `list`, `info <name>`, `match "<intent>"` — with human-readable output and a stable `--json` envelope keyed by `cliVersion` for skill consumers (`tool-saasfoundry`).
- `sf modules match` uses weighted keyword scoring (keywords × 3, alternatives × 2, description × 1) with stopword filtering.
- Routes the existing `sf update` filtering through the catalogue (no behavior change for `sf new` / `sf update`).
- Documents the JSON schema and consumer contract in `.claude/docs/modules-catalogue-schema.md`.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run test:pre-commit` — **383 / 383** passing (+28 from this PR: 13 catalogue integrity + 15 modules-command integration)
- [x] Pre-push docker scenarios — 2 / 2 passing
- [x] Manual scenarios S1–S9 validated in AI Testing (see issue comment)
- [x] Developer validation in Human Testing ✅

## Notes

- No E2E/Playwright tests added — this is a CLI-only feature, fully covered by integration tests (process-level `modulesCommand()` invocation with stdout/stderr assertions).
- All 6 subtasks (#73–#78) closed.
- `sf update` and `sf new` paths unchanged — verified by the 215 existing integration/e2e/smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)