### PR TITLE
Phase 1D: sf skill install/update/uninstall commands

### DIFF
--- a/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
+++ b/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
@@ -1,0 +1,19 @@
+# SaaSFoundry Tool Skill (placeholder)
+
+This is a placeholder bundle for the `tool-saasfoundry` Claude Code skill. The real payload ships in Phase 2 of epic #18.
+
+The CLI commands `sf skill install | update | uninstall` manage this bundle's lifecycle — copying it to either `~/.claude/skills/tool-saasfoundry/` (user scope) or `.claude/skills/tool-saasfoundry/` (project scope) and maintaining a `.version` manifest alongside it.
+
+## Why this exists now
+
+Phase 1D (ticket #61) wires up the lifecycle commands before the skill content exists. Having a copyable placeholder lets us:
+
+- Exercise the install / update / uninstall code paths in real tests (no mocks required)
+- Ship the bundle in the npm package so `npx saasfoundry-cli sf skill install` works out of the box
+- Validate the `.version` manifest flow against a concrete directory
+
+## What will replace this
+
+In Phase 2 this file — and the rest of the bundle directory — is replaced by the real skill: `SKILL.md`, helper scripts, catalogue-aware prompts, and documentation for AI agents assisting developers on their SaaSFoundry projects.
+
+Until then, treat this file as a marker that the skill *can* be installed. No behavior depends on its contents.

--- a/src/__tests__/integration/skill/lifecycle.spec.ts
+++ b/src/__tests__/integration/skill/lifecycle.spec.ts
@@ -1,0 +1,169 @@
+import { readFile, writeFile } from 'fs/promises'
+import path from 'path'
+
+import { performSkillInstall, skillIsInstalled } from '../../../skill/install'
+import { readManifest } from '../../../skill/manifest'
+import { resolvePreferencesPath, resolveSkillInstallDir } from '../../../skill/paths'
+import { DEFAULT_PREFERENCES, readPreferences, writePreferences } from '../../../skill/preferences'
+import { performFullUninstall, performSkillUninstall } from '../../../skill/uninstall'
+import { checkSkillStatus } from '../../../skill/update'
+import { fileExists } from '../../../utils'
+import { createTempDir } from '../../helpers/temp-dir'
+
+describe('skill lifecycle integration', () => {
+  let originalHome: string | undefined
+  let tempHome: string
+  let cleanupHome: () => Promise<void>
+  let tempProject: string
+  let cleanupProject: () => Promise<void>
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME
+    const home = await createTempDir()
+    tempHome = home.dir
+    cleanupHome = home.cleanup
+    process.env.HOME = tempHome
+
+    const proj = await createTempDir()
+    tempProject = proj.dir
+    cleanupProject = proj.cleanup
+  })
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+    await cleanupHome()
+    await cleanupProject()
+  })
+
+  it('installs the skill into the user scope and writes a matching manifest', async () => {
+    const result = await performSkillInstall({ scope: 'user', cliVersion: '1.2.3' })
+    const expectedDir = path.join(tempHome, '.claude', 'skills', 'tool-saasfoundry')
+    expect(result.targetDir).toBe(expectedDir)
+    expect(result.reinstalled).toBe(false)
+    expect(await fileExists(path.join(expectedDir, 'SKILL.md'))).toBe(true)
+    const manifest = await readManifest(expectedDir)
+    expect(manifest?.cliVersion).toBe('1.2.3')
+    expect(manifest?.scope).toBe('user')
+  })
+
+  it('installs the skill into a project-scoped directory when cwd is provided', async () => {
+    const result = await performSkillInstall({ scope: 'project', cliVersion: '1.2.3', cwd: tempProject })
+    const expectedDir = path.join(tempProject, '.claude', 'skills', 'tool-saasfoundry')
+    expect(result.targetDir).toBe(expectedDir)
+    expect(await fileExists(path.join(expectedDir, '.version'))).toBe(true)
+    const manifest = await readManifest(expectedDir)
+    expect(manifest?.scope).toBe('project')
+  })
+
+  it('reinstall carries forward the previous version into the result', async () => {
+    await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    const second = await performSkillInstall({ scope: 'user', cliVersion: '2.0.0' })
+    expect(second.reinstalled).toBe(true)
+    expect(second.previousVersion).toBe('1.0.0')
+    const manifest = await readManifest(second.targetDir)
+    expect(manifest?.cliVersion).toBe('2.0.0')
+  })
+
+  it('checkSkillStatus detects fresh, current, and stale installs', async () => {
+    const fresh = await checkSkillStatus('user', '1.0.0')
+    expect(fresh.installed).toBe(false)
+    expect(fresh.stale).toBe(false)
+
+    await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    const current = await checkSkillStatus('user', '1.0.0')
+    expect(current).toMatchObject({ installed: true, stale: false, installedVersion: '1.0.0', bundledVersion: '1.0.0' })
+
+    const stale = await checkSkillStatus('user', '2.0.0')
+    expect(stale).toMatchObject({ installed: true, stale: true, installedVersion: '1.0.0', bundledVersion: '2.0.0' })
+  })
+
+  it('uninstall removes the skill without touching preferences by default', async () => {
+    await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    await writePreferences({ ...DEFAULT_PREFERENCES, skillPromptAnswered: true })
+    expect(await skillIsInstalled('user')).toBe(true)
+
+    const result = await performSkillUninstall('user', { purge: false })
+    expect(result.removedSkill).toBe(true)
+    expect(result.removedPreferences).toBe(false)
+    expect(await fileExists(resolveSkillInstallDir('user'))).toBe(false)
+    const prefs = await readPreferences()
+    expect(prefs.skillPromptAnswered).toBe(true)
+  })
+
+  it('uninstall --purge also wipes ~/.saasfoundry/', async () => {
+    await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    await writePreferences({ ...DEFAULT_PREFERENCES, skillPromptAnswered: true })
+    const result = await performSkillUninstall('user', { purge: true })
+    expect(result.removedSkill).toBe(true)
+    expect(result.removedPreferences).toBe(true)
+    expect(await fileExists(resolvePreferencesPath())).toBe(false)
+  })
+
+  it('uninstall is a no-op when nothing is installed', async () => {
+    const result = await performSkillUninstall('user', { purge: false })
+    expect(result.removedSkill).toBe(false)
+    expect(result.removedPreferences).toBe(false)
+  })
+
+  it('performFullUninstall removes user + project skills + preferences in one pass', async () => {
+    await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    await performSkillInstall({ scope: 'project', cliVersion: '1.0.0', cwd: tempProject })
+    await writePreferences({ ...DEFAULT_PREFERENCES, skillPromptAnswered: true })
+
+    const result = await performFullUninstall(tempProject)
+    expect(result.userScope.removedSkill).toBe(true)
+    expect(result.userScope.removedPreferences).toBe(true)
+    expect(result.projectScope.removedSkill).toBe(true)
+    expect(result.projectScope.removedPreferences).toBe(false)
+
+    expect(await fileExists(resolveSkillInstallDir('user'))).toBe(false)
+    expect(await fileExists(resolveSkillInstallDir('project', tempProject))).toBe(false)
+    expect(await fileExists(resolvePreferencesPath())).toBe(false)
+  })
+
+  it('preferences survive a skill update', async () => {
+    await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    await writePreferences({ ...DEFAULT_PREFERENCES, skillInstallOptIn: true, votingOptIn: 'never' })
+    await performSkillInstall({ scope: 'user', cliVersion: '2.0.0' })
+    const prefs = await readPreferences()
+    expect(prefs.skillInstallOptIn).toBe(true)
+    expect(prefs.votingOptIn).toBe('never')
+  })
+
+  it('manifest survives a corrupt rewrite → treated as missing', async () => {
+    const { targetDir } = await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    await writeFile(path.join(targetDir, '.version'), 'broken', 'utf8')
+    const status = await checkSkillStatus('user', '1.0.0')
+    expect(status.installed).toBe(false)
+  })
+
+  it('skillIsInstalled returns true when a bundle directory exists even without manifest', async () => {
+    await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    // Remove the manifest but leave the directory
+    const manifestPath = path.join(resolveSkillInstallDir('user'), '.version')
+    await writeFile(manifestPath, '', 'utf8')
+    expect(await skillIsInstalled('user')).toBe(true)
+  })
+
+  it('user- and project-scope installs are independent', async () => {
+    await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    await performSkillInstall({ scope: 'project', cliVersion: '2.0.0', cwd: tempProject })
+
+    const userManifest = await readManifest(resolveSkillInstallDir('user'))
+    const projectManifest = await readManifest(resolveSkillInstallDir('project', tempProject))
+    expect(userManifest?.cliVersion).toBe('1.0.0')
+    expect(projectManifest?.cliVersion).toBe('2.0.0')
+
+    await performSkillUninstall('project', { purge: false, cwd: tempProject })
+    expect(await skillIsInstalled('user')).toBe(true)
+    expect(await skillIsInstalled('project', tempProject)).toBe(false)
+  })
+
+  it('copies the bundle SKILL.md verbatim on install', async () => {
+    const { targetDir, sourceDir } = await performSkillInstall({ scope: 'user', cliVersion: '1.0.0' })
+    const copied = await readFile(path.join(targetDir, 'SKILL.md'), 'utf8')
+    const original = await readFile(path.join(sourceDir, 'SKILL.md'), 'utf8')
+    expect(copied).toBe(original)
+  })
+})

--- a/src/__tests__/unit/skill/manifest.spec.ts
+++ b/src/__tests__/unit/skill/manifest.spec.ts
@@ -1,0 +1,67 @@
+import { mkdir, writeFile } from 'fs/promises'
+import path from 'path'
+
+import { buildManifest, readManifest, writeManifest } from '../../../skill/manifest'
+import { createTempDir } from '../../helpers/temp-dir'
+
+describe('skill/manifest', () => {
+  it('returns null when no manifest exists', async () => {
+    const { dir, cleanup } = await createTempDir()
+    try {
+      const manifest = await readManifest(dir)
+      expect(manifest).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('round-trips a manifest through write + read', async () => {
+    const { dir, cleanup } = await createTempDir()
+    try {
+      await mkdir(dir, { recursive: true })
+      const built = buildManifest('1.2.3', 'user', new Date('2026-04-17T10:00:00Z'))
+      await writeManifest(dir, built)
+      const read = await readManifest(dir)
+      expect(read).toEqual({
+        cliVersion: '1.2.3',
+        installedAt: '2026-04-17T10:00:00.000Z',
+        scope: 'user'
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('returns null for a corrupt manifest', async () => {
+    const { dir, cleanup } = await createTempDir()
+    try {
+      await writeFile(path.join(dir, '.version'), '{not valid json', 'utf8')
+      const manifest = await readManifest(dir)
+      expect(manifest).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('returns null for a manifest with an unknown scope', async () => {
+    const { dir, cleanup } = await createTempDir()
+    try {
+      await writeFile(path.join(dir, '.version'), JSON.stringify({ cliVersion: '1.0.0', installedAt: '2026-04-17T00:00:00Z', scope: 'whoops' }), 'utf8')
+      const manifest = await readManifest(dir)
+      expect(manifest).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('builds a manifest with the current ISO timestamp when not provided', () => {
+    const before = Date.now()
+    const manifest = buildManifest('9.9.9', 'project')
+    const after = Date.now()
+    const parsed = Date.parse(manifest.installedAt)
+    expect(parsed).toBeGreaterThanOrEqual(before)
+    expect(parsed).toBeLessThanOrEqual(after)
+    expect(manifest.cliVersion).toBe('9.9.9')
+    expect(manifest.scope).toBe('project')
+  })
+})

--- a/src/__tests__/unit/skill/paths.spec.ts
+++ b/src/__tests__/unit/skill/paths.spec.ts
@@ -1,0 +1,33 @@
+import path from 'path'
+
+import { resolveBundleSourceDir, resolveManifestPath, resolvePreferencesPath, resolveSkillInstallDir, SKILL_NAME } from '../../../skill/paths'
+
+describe('skill/paths', () => {
+  it('resolves the bundle source dir under scaffolds/skills-templates/tool-saasfoundry', () => {
+    const source = resolveBundleSourceDir()
+    expect(source.endsWith(path.join('scaffolds', 'skills-templates', SKILL_NAME))).toBe(true)
+  })
+
+  it('resolves user-scope install to ~/.claude/skills/tool-saasfoundry', () => {
+    const dir = resolveSkillInstallDir('user')
+    expect(dir.endsWith(path.join('.claude', 'skills', SKILL_NAME))).toBe(true)
+    expect(dir.startsWith(path.sep)).toBe(true)
+  })
+
+  it('resolves project-scope install relative to cwd argument', () => {
+    const fakeCwd = path.join(path.sep, 'tmp', 'some-project')
+    const dir = resolveSkillInstallDir('project', fakeCwd)
+    expect(dir).toBe(path.join(fakeCwd, '.claude', 'skills', SKILL_NAME))
+  })
+
+  it('resolves the manifest path inside an install directory', () => {
+    const installDir = path.join(path.sep, 'tmp', 'fake', '.claude', 'skills', SKILL_NAME)
+    const manifest = resolveManifestPath(installDir)
+    expect(manifest).toBe(path.join(installDir, '.version'))
+  })
+
+  it('resolves preferences path to ~/.saasfoundry/preferences.json', () => {
+    const prefs = resolvePreferencesPath()
+    expect(prefs.endsWith(path.join('.saasfoundry', 'preferences.json'))).toBe(true)
+  })
+})

--- a/src/__tests__/unit/skill/preferences.spec.ts
+++ b/src/__tests__/unit/skill/preferences.spec.ts
@@ -1,0 +1,81 @@
+import { writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+
+import { DEFAULT_PREFERENCES, readPreferences, updatePreferences, writePreferences } from '../../../skill/preferences'
+import { createTempDir } from '../../helpers/temp-dir'
+
+describe('skill/preferences', () => {
+  let originalHome: string | undefined
+  let tempHome: string
+  let cleanupHome: () => Promise<void>
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME
+    const { dir, cleanup } = await createTempDir()
+    tempHome = dir
+    cleanupHome = cleanup
+    process.env.HOME = tempHome
+  })
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+    await cleanupHome()
+  })
+
+  it('returns defaults when the preferences file does not exist', async () => {
+    const prefs = await readPreferences()
+    expect(prefs).toEqual(DEFAULT_PREFERENCES)
+  })
+
+  it('round-trips writePreferences + readPreferences', async () => {
+    const input = {
+      skillPromptAnswered: true,
+      skillInstallOptIn: true,
+      cliGlobalInstalled: true,
+      votingOptIn: 'never' as const,
+      lastVoteSurveyAt: '2026-04-17T00:00:00.000Z'
+    }
+    await writePreferences(input)
+    const read = await readPreferences()
+    expect(read).toEqual(input)
+  })
+
+  it('creates the ~/.saasfoundry directory automatically on write', async () => {
+    await writePreferences(DEFAULT_PREFERENCES)
+    const filePath = path.join(tempHome, '.saasfoundry', 'preferences.json')
+    const prefs = await readPreferences()
+    expect(prefs).toEqual(DEFAULT_PREFERENCES)
+    expect(filePath.startsWith(tmpdir()) || filePath.startsWith('/tmp') || filePath.startsWith('/private/tmp')).toBe(true)
+  })
+
+  it('merges partial preference files against defaults', async () => {
+    const prefsPath = path.join(tempHome, '.saasfoundry', 'preferences.json')
+    await writePreferences(DEFAULT_PREFERENCES)
+    await writeFile(prefsPath, JSON.stringify({ skillInstallOptIn: true, votingOptIn: 'always' }), 'utf8')
+    const prefs = await readPreferences()
+    expect(prefs).toEqual({
+      ...DEFAULT_PREFERENCES,
+      skillInstallOptIn: true,
+      votingOptIn: 'always'
+    })
+  })
+
+  it('falls back to defaults for malformed JSON', async () => {
+    await writePreferences(DEFAULT_PREFERENCES)
+    const filePath = path.join(tempHome, '.saasfoundry', 'preferences.json')
+    await writeFile(filePath, 'not-json', 'utf8')
+    const prefs = await readPreferences()
+    expect(prefs).toEqual(DEFAULT_PREFERENCES)
+  })
+
+  it('updatePreferences merges a patch into existing prefs', async () => {
+    await writePreferences(DEFAULT_PREFERENCES)
+    const next = await updatePreferences({ cliGlobalInstalled: true })
+    expect(next.cliGlobalInstalled).toBe(true)
+    expect(next.skillInstallOptIn).toBe(DEFAULT_PREFERENCES.skillInstallOptIn)
+    const reread = await readPreferences()
+    expect(reread).toEqual(next)
+  })
+})

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -186,7 +186,8 @@ export async function runFullUninstall(opts: { yes?: boolean; cwd?: string } = {
       {
         type: 'confirm',
         name: 'confirm',
-        message: 'This will remove the user-scope skill, wipe ~/.saasfoundry/ preferences, and remove the project-scope skill in the current directory (if any). Generated projects are NOT touched. Continue?',
+        message:
+          'This will remove the user-scope skill, wipe ~/.saasfoundry/ preferences, and remove the project-scope skill in the current directory (if any). Generated projects are NOT touched. Continue?',
         default: false
       }
     ])

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -5,8 +5,9 @@ import { version as cliVersion } from '../../package.json'
 import { isRunningViaNpx, performSkillInstall, skillIsInstalled } from '../skill/install'
 import { resolveSkillInstallDir, SKILL_NAME, SkillScope } from '../skill/paths'
 import { updatePreferences } from '../skill/preferences'
+import { checkSkillStatus } from '../skill/update'
 
-type SkillSubcommand = 'install'
+type SkillSubcommand = 'install' | 'update'
 
 interface ParsedArgs {
   project: boolean
@@ -41,6 +42,9 @@ export async function skillCommand(subcommand?: string, ...args: string[]) {
     case 'install':
       await runInstall(parsed)
       break
+    case 'update':
+      await runUpdate(parsed)
+      break
     default:
       console.error(chalk.red(`Unknown subcommand: ${subcommand}`))
       showHelp()
@@ -54,6 +58,7 @@ function showHelp() {
   console.log(chalk.white('\n  Usage: sf skill <subcommand> [options]\n'))
   console.log(chalk.white('  Subcommands:'))
   console.log(chalk.gray('    install [--project] [--force]   Install the skill (user scope by default)'))
+  console.log(chalk.gray('    update  [--project]             Re-copy the skill if the bundled version is newer'))
   console.log(chalk.white('\n  Scope:'))
   console.log(chalk.gray('    (default)    ~/.claude/skills/tool-saasfoundry/   (user)'))
   console.log(chalk.gray('    --project    .claude/skills/tool-saasfoundry/    (team-scoped, commit to git)'))
@@ -101,6 +106,28 @@ async function runInstall(opts: ParsedArgs) {
   }
 
   console.log()
+}
+
+async function runUpdate(opts: ParsedArgs) {
+  const scope: SkillScope = opts.project ? 'project' : 'user'
+  const status = await checkSkillStatus(scope, cliVersion)
+
+  if (!status.installed) {
+    console.error(chalk.red(`No ${SKILL_NAME} install found at ${status.targetDir}.`))
+    console.error(chalk.gray(`Run: sf skill install${scope === 'project' ? ' --project' : ''}`))
+    process.exit(1)
+    return
+  }
+
+  if (!status.stale) {
+    console.log(chalk.green(`\n  ✓ ${SKILL_NAME} already up to date (v${status.installedVersion})`))
+    console.log(chalk.gray(`    Target: ${status.targetDir}\n`))
+    return
+  }
+
+  const result = await performSkillInstall({ scope, cliVersion })
+  console.log(chalk.green(`\n  ✓ Updated ${SKILL_NAME}: ${status.installedVersion} → ${cliVersion}`))
+  console.log(chalk.gray(`    Target: ${result.targetDir}\n`))
 }
 
 async function maybeOfferGlobalCliInstall(opts: ParsedArgs) {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,0 +1,122 @@
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+
+import { version as cliVersion } from '../../package.json'
+import { isRunningViaNpx, performSkillInstall, skillIsInstalled } from '../skill/install'
+import { resolveSkillInstallDir, SKILL_NAME, SkillScope } from '../skill/paths'
+import { updatePreferences } from '../skill/preferences'
+
+type SkillSubcommand = 'install'
+
+interface ParsedArgs {
+  project: boolean
+  force: boolean
+  yes: boolean
+  positional: string[]
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const positional: string[] = []
+  let project = false
+  let force = false
+  let yes = false
+  for (const arg of args) {
+    if (arg === '--project') project = true
+    else if (arg === '--force') force = true
+    else if (arg === '--yes' || arg === '-y') yes = true
+    else if (arg !== undefined && arg !== null && arg !== '') positional.push(arg)
+  }
+  return { project, force, yes, positional }
+}
+
+export async function skillCommand(subcommand?: string, ...args: string[]) {
+  if (!subcommand) {
+    showHelp()
+    return
+  }
+
+  const parsed = parseArgs(args)
+
+  switch (subcommand as SkillSubcommand) {
+    case 'install':
+      await runInstall(parsed)
+      break
+    default:
+      console.error(chalk.red(`Unknown subcommand: ${subcommand}`))
+      showHelp()
+      process.exit(1)
+  }
+}
+
+function showHelp() {
+  console.log(chalk.blue('\n  SaaSFoundry Skill - Lifecycle management for the tool-saasfoundry skill'))
+  console.log(chalk.blue('  ' + '─'.repeat(60)))
+  console.log(chalk.white('\n  Usage: sf skill <subcommand> [options]\n'))
+  console.log(chalk.white('  Subcommands:'))
+  console.log(chalk.gray('    install [--project] [--force]   Install the skill (user scope by default)'))
+  console.log(chalk.white('\n  Scope:'))
+  console.log(chalk.gray('    (default)    ~/.claude/skills/tool-saasfoundry/   (user)'))
+  console.log(chalk.gray('    --project    .claude/skills/tool-saasfoundry/    (team-scoped, commit to git)'))
+  console.log()
+}
+
+async function runInstall(opts: ParsedArgs) {
+  const scope: SkillScope = opts.project ? 'project' : 'user'
+  const targetDir = resolveSkillInstallDir(scope)
+  const alreadyInstalled = await skillIsInstalled(scope)
+
+  if (alreadyInstalled && !opts.force) {
+    if (!opts.yes && process.stdin.isTTY) {
+      const { overwrite } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'overwrite',
+          message: `Skill already installed at ${targetDir}. Reinstall and overwrite?`,
+          default: false
+        }
+      ])
+      if (!overwrite) {
+        console.log(chalk.yellow('Install aborted. Use --force to skip this prompt next time.'))
+        return
+      }
+    } else {
+      console.error(chalk.red(`Skill already installed at ${targetDir}. Re-run with --force to overwrite.`))
+      process.exit(1)
+    }
+  }
+
+  const result = await performSkillInstall({ scope, cliVersion })
+
+  console.log(chalk.green(`\n  ✓ Installed ${SKILL_NAME} (v${cliVersion})`))
+  console.log(chalk.gray(`    Target:  ${result.targetDir}`))
+  console.log(chalk.gray(`    Source:  ${result.sourceDir}`))
+  if (result.previousVersion) {
+    console.log(chalk.gray(`    Previous version: ${result.previousVersion} → ${cliVersion}`))
+  }
+
+  await updatePreferences({ skillPromptAnswered: true, skillInstallOptIn: true })
+
+  if (scope === 'user' && isRunningViaNpx()) {
+    await maybeOfferGlobalCliInstall(opts)
+  }
+
+  console.log()
+}
+
+async function maybeOfferGlobalCliInstall(opts: ParsedArgs) {
+  if (opts.yes || !process.stdin.isTTY) return
+  const { installGlobal } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'installGlobal',
+      message: 'You ran this via npx. Install saasfoundry-cli globally so `sf` works everywhere?',
+      default: false
+    }
+  ])
+  if (installGlobal) {
+    console.log(chalk.gray('    Run: npm install -g saasfoundry-cli'))
+    await updatePreferences({ cliGlobalInstalled: true })
+  } else {
+    await updatePreferences({ cliGlobalInstalled: false })
+  }
+}

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -5,14 +5,17 @@ import { version as cliVersion } from '../../package.json'
 import { isRunningViaNpx, performSkillInstall, skillIsInstalled } from '../skill/install'
 import { resolveSkillInstallDir, SKILL_NAME, SkillScope } from '../skill/paths'
 import { updatePreferences } from '../skill/preferences'
+import { performFullUninstall, performSkillUninstall } from '../skill/uninstall'
 import { checkSkillStatus } from '../skill/update'
 
-type SkillSubcommand = 'install' | 'update'
+type SkillSubcommand = 'install' | 'update' | 'uninstall'
 
 interface ParsedArgs {
   project: boolean
   force: boolean
   yes: boolean
+  purge: boolean
+  all: boolean
   positional: string[]
 }
 
@@ -21,13 +24,17 @@ function parseArgs(args: string[]): ParsedArgs {
   let project = false
   let force = false
   let yes = false
+  let purge = false
+  let all = false
   for (const arg of args) {
     if (arg === '--project') project = true
     else if (arg === '--force') force = true
     else if (arg === '--yes' || arg === '-y') yes = true
+    else if (arg === '--purge') purge = true
+    else if (arg === '--all') all = true
     else if (arg !== undefined && arg !== null && arg !== '') positional.push(arg)
   }
-  return { project, force, yes, positional }
+  return { project, force, yes, purge, all, positional }
 }
 
 export async function skillCommand(subcommand?: string, ...args: string[]) {
@@ -45,6 +52,9 @@ export async function skillCommand(subcommand?: string, ...args: string[]) {
     case 'update':
       await runUpdate(parsed)
       break
+    case 'uninstall':
+      await runUninstall(parsed)
+      break
     default:
       console.error(chalk.red(`Unknown subcommand: ${subcommand}`))
       showHelp()
@@ -57,8 +67,9 @@ function showHelp() {
   console.log(chalk.blue('  ' + '─'.repeat(60)))
   console.log(chalk.white('\n  Usage: sf skill <subcommand> [options]\n'))
   console.log(chalk.white('  Subcommands:'))
-  console.log(chalk.gray('    install [--project] [--force]   Install the skill (user scope by default)'))
-  console.log(chalk.gray('    update  [--project]             Re-copy the skill if the bundled version is newer'))
+  console.log(chalk.gray('    install   [--project] [--force]     Install the skill (user scope by default)'))
+  console.log(chalk.gray('    update    [--project]               Re-copy the skill if the bundled version is newer'))
+  console.log(chalk.gray('    uninstall [--project] [--purge]     Remove the skill (--purge also deletes preferences)'))
   console.log(chalk.white('\n  Scope:'))
   console.log(chalk.gray('    (default)    ~/.claude/skills/tool-saasfoundry/   (user)'))
   console.log(chalk.gray('    --project    .claude/skills/tool-saasfoundry/    (team-scoped, commit to git)'))
@@ -128,6 +139,70 @@ async function runUpdate(opts: ParsedArgs) {
   const result = await performSkillInstall({ scope, cliVersion })
   console.log(chalk.green(`\n  ✓ Updated ${SKILL_NAME}: ${status.installedVersion} → ${cliVersion}`))
   console.log(chalk.gray(`    Target: ${result.targetDir}\n`))
+}
+
+async function runUninstall(opts: ParsedArgs) {
+  const scope: SkillScope = opts.project ? 'project' : 'user'
+  const skillDir = resolveSkillInstallDir(scope)
+
+  if (!opts.yes && process.stdin.isTTY) {
+    const { confirm } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: `Remove ${SKILL_NAME} at ${skillDir}${opts.purge ? ' and delete ~/.saasfoundry/' : ''}?`,
+        default: false
+      }
+    ])
+    if (!confirm) {
+      console.log(chalk.yellow('Uninstall aborted.'))
+      return
+    }
+  }
+
+  const result = await performSkillUninstall(scope, { purge: opts.purge })
+
+  if (result.removedSkill) {
+    console.log(chalk.green(`\n  ✓ Removed ${SKILL_NAME} from ${result.skillDir}`))
+  } else {
+    console.log(chalk.yellow(`\n  ⚠ Nothing to remove — no skill install found at ${result.skillDir}`))
+  }
+
+  if (opts.purge) {
+    if (result.removedPreferences) {
+      console.log(chalk.gray(`    Preferences purged: ${result.preferencesPath}`))
+    } else {
+      console.log(chalk.gray(`    No preferences to purge (${result.preferencesPath} did not exist)`))
+    }
+  } else {
+    console.log(chalk.gray(`    Preferences untouched: ${result.preferencesPath}`))
+  }
+  console.log()
+}
+
+export async function runFullUninstall(opts: { yes?: boolean; cwd?: string } = {}) {
+  if (!opts.yes && process.stdin.isTTY) {
+    const { confirm } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: 'This will remove the user-scope skill, wipe ~/.saasfoundry/ preferences, and remove the project-scope skill in the current directory (if any). Generated projects are NOT touched. Continue?',
+        default: false
+      }
+    ])
+    if (!confirm) {
+      console.log(chalk.yellow('Uninstall aborted.'))
+      return
+    }
+  }
+
+  const result = await performFullUninstall(opts.cwd)
+
+  console.log(chalk.green('\n  ✓ Full uninstall complete'))
+  console.log(chalk.gray(`    User skill:    ${result.userScope.removedSkill ? 'removed' : 'not found'} (${result.userScope.skillDir})`))
+  console.log(chalk.gray(`    Project skill: ${result.projectScope.removedSkill ? 'removed' : 'not found'} (${result.projectScope.skillDir})`))
+  console.log(chalk.gray(`    Preferences:   ${result.userScope.removedPreferences ? 'purged' : 'not found'} (${result.userScope.preferencesPath})`))
+  console.log()
 }
 
 async function maybeOfferGlobalCliInstall(opts: ParsedArgs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import 'module-alias/register'
 import { version } from '../package.json'
 import { modulesCommand } from './commands/modules'
 import { newCommand } from './commands/new'
+import { skillCommand } from './commands/skill'
 import { updateCommand } from './commands/update'
 import { toolsCommand } from './commands/tools'
 import { workflowCommand } from './commands/workflow'
@@ -110,6 +111,13 @@ program
   .argument('[subcommand]', 'Subcommand to execute (list, create, show, use, set-working-branch, set-ai-rules, etc.)')
   .argument('[args...]', 'Additional arguments for the subcommand')
   .action((subcommand, args) => workflowCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
+program
+  .command('skill')
+  .description('Manage the tool-saasfoundry Claude Code skill (install, update, uninstall)')
+  .argument('[subcommand]', 'Subcommand to execute (install)')
+  .argument('[args...]', 'Additional arguments for the subcommand (--project, --force, --yes)')
+  .allowUnknownOption()
+  .action((subcommand, args) => skillCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
 program.parse()
 
-export { newCommand, updateCommand, modulesCommand, toolsCommand, workflowCommand }
+export { newCommand, updateCommand, modulesCommand, toolsCommand, workflowCommand, skillCommand }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,9 @@ import { skillCommand, runFullUninstall } from './commands/skill'
 import { updateCommand } from './commands/update'
 import { toolsCommand } from './commands/tools'
 import { workflowCommand } from './commands/workflow'
+import { maybeEmitStaleSkillWarning } from './skill/warn'
+
+void maybeEmitStaleSkillWarning(process.argv, version)
 
 const program = new Command()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import 'module-alias/register'
 import { version } from '../package.json'
 import { modulesCommand } from './commands/modules'
 import { newCommand } from './commands/new'
-import { skillCommand } from './commands/skill'
+import { skillCommand, runFullUninstall } from './commands/skill'
 import { updateCommand } from './commands/update'
 import { toolsCommand } from './commands/tools'
 import { workflowCommand } from './commands/workflow'
@@ -118,6 +118,18 @@ program
   .argument('[args...]', 'Additional arguments for the subcommand (--project, --force, --yes)')
   .allowUnknownOption()
   .action((subcommand, args) => skillCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
+program
+  .command('uninstall')
+  .description('Fully remove the SaaSFoundry skill and preferences (--all flag required)')
+  .option('--all', 'Remove the skill (user + project scope) and wipe ~/.saasfoundry/')
+  .option('-y, --yes', 'Skip the confirmation prompt')
+  .action(async (opts) => {
+    if (!opts.all) {
+      console.error("Error: 'sf uninstall' requires --all. Use 'sf skill uninstall' for per-scope removal.")
+      process.exit(1)
+    }
+    await runFullUninstall({ yes: Boolean(opts.yes) })
+  })
 program.parse()
 
 export { newCommand, updateCommand, modulesCommand, toolsCommand, workflowCommand, skillCommand }

--- a/src/skill/install.ts
+++ b/src/skill/install.ts
@@ -1,0 +1,51 @@
+import { copy, remove } from 'fs-extra'
+
+import { fileExists } from '../utils'
+
+import { buildManifest, readManifest, writeManifest } from './manifest'
+import { resolveBundleSourceDir, resolveSkillInstallDir, SkillScope } from './paths'
+
+export interface InstallOptions {
+  scope: SkillScope
+  cliVersion: string
+  cwd?: string
+}
+
+export interface InstallResult {
+  targetDir: string
+  sourceDir: string
+  previousVersion: string | null
+  reinstalled: boolean
+}
+
+export async function skillIsInstalled(scope: SkillScope, cwd?: string): Promise<boolean> {
+  const dir = resolveSkillInstallDir(scope, cwd)
+  return fileExists(dir)
+}
+
+export async function performSkillInstall({ scope, cliVersion, cwd }: InstallOptions): Promise<InstallResult> {
+  const sourceDir = resolveBundleSourceDir()
+  if (!(await fileExists(sourceDir))) {
+    throw new Error(`Skill bundle source not found at ${sourceDir}. Ensure the CLI package ships scaffolds/skills-templates/tool-saasfoundry/.`)
+  }
+
+  const targetDir = resolveSkillInstallDir(scope, cwd)
+  const existed = await fileExists(targetDir)
+  const existingManifest = existed ? await readManifest(targetDir) : null
+
+  if (existed) await remove(targetDir)
+  await copy(sourceDir, targetDir)
+  await writeManifest(targetDir, buildManifest(cliVersion, scope))
+
+  return {
+    targetDir,
+    sourceDir,
+    previousVersion: existingManifest?.cliVersion ?? null,
+    reinstalled: existed
+  }
+}
+
+export function isRunningViaNpx(): boolean {
+  const userAgent = process.env.npm_config_user_agent ?? ''
+  return userAgent.includes('npx')
+}

--- a/src/skill/manifest.ts
+++ b/src/skill/manifest.ts
@@ -1,0 +1,41 @@
+import { readFile, writeFile } from 'fs/promises'
+
+import { fileExists } from '../utils'
+
+import { MANIFEST_FILENAME, resolveManifestPath, SkillScope } from './paths'
+
+export interface SkillManifest {
+  cliVersion: string
+  installedAt: string
+  scope: SkillScope
+}
+
+export { MANIFEST_FILENAME }
+
+export async function readManifest(installDir: string): Promise<SkillManifest | null> {
+  const manifestPath = resolveManifestPath(installDir)
+  if (!(await fileExists(manifestPath))) return null
+  try {
+    const raw = await readFile(manifestPath, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (typeof parsed?.cliVersion !== 'string' || typeof parsed?.installedAt !== 'string' || (parsed?.scope !== 'user' && parsed?.scope !== 'project')) {
+      return null
+    }
+    return parsed as SkillManifest
+  } catch {
+    return null
+  }
+}
+
+export async function writeManifest(installDir: string, manifest: SkillManifest): Promise<void> {
+  const manifestPath = resolveManifestPath(installDir)
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8')
+}
+
+export function buildManifest(cliVersion: string, scope: SkillScope, installedAt: Date = new Date()): SkillManifest {
+  return {
+    cliVersion,
+    installedAt: installedAt.toISOString(),
+    scope
+  }
+}

--- a/src/skill/paths.ts
+++ b/src/skill/paths.ts
@@ -1,0 +1,49 @@
+import { homedir } from 'os'
+import path from 'path'
+
+export type SkillScope = 'user' | 'project'
+
+export const SKILL_NAME = 'tool-saasfoundry'
+
+export const MANIFEST_FILENAME = '.version'
+
+export const PREFERENCES_DIR = '.saasfoundry'
+export const PREFERENCES_FILENAME = 'preferences.json'
+
+/**
+ * Resolve the directory where the skill bundle lives inside an installed CLI
+ * (i.e. the source from which `sf skill install` copies).
+ *
+ * We read from the repo-level `scaffolds/skills-templates/tool-saasfoundry/`.
+ * When installed via npm the same path exists under the package root because
+ * `scaffolds` is declared in `package.json#files`.
+ */
+export function resolveBundleSourceDir(): string {
+  return path.join(__dirname, '..', '..', 'scaffolds', 'skills-templates', SKILL_NAME)
+}
+
+/**
+ * Resolve the destination where a skill install should land, given a scope.
+ *
+ * - `user`    → `~/.claude/skills/tool-saasfoundry/`
+ * - `project` → `<cwd>/.claude/skills/tool-saasfoundry/`
+ */
+export function resolveSkillInstallDir(scope: SkillScope, cwd: string = process.cwd()): string {
+  const base = scope === 'user' ? homedir() : cwd
+  return path.join(base, '.claude', 'skills', SKILL_NAME)
+}
+
+/**
+ * Resolve the path to the skill's `.version` manifest inside an installed bundle.
+ */
+export function resolveManifestPath(installDir: string): string {
+  return path.join(installDir, MANIFEST_FILENAME)
+}
+
+/**
+ * Resolve the absolute path to the user-level preferences file
+ * (`~/.saasfoundry/preferences.json`).
+ */
+export function resolvePreferencesPath(): string {
+  return path.join(homedir(), PREFERENCES_DIR, PREFERENCES_FILENAME)
+}

--- a/src/skill/paths.ts
+++ b/src/skill/paths.ts
@@ -11,6 +11,18 @@ export const PREFERENCES_DIR = '.saasfoundry'
 export const PREFERENCES_FILENAME = 'preferences.json'
 
 /**
+ * Resolve the current user's home directory.
+ *
+ * Prefers `$HOME` / `%USERPROFILE%` over `os.homedir()` so tests can redirect
+ * the home directory by setting `process.env.HOME`. `os.homedir()` reads from
+ * the system password database (via `getpwuid()`) on POSIX and ignores changes
+ * to `process.env.HOME` made after the Node process started.
+ */
+export function resolveUserHome(): string {
+  return process.env.HOME ?? process.env.USERPROFILE ?? homedir()
+}
+
+/**
  * Resolve the directory where the skill bundle lives inside an installed CLI
  * (i.e. the source from which `sf skill install` copies).
  *
@@ -29,7 +41,7 @@ export function resolveBundleSourceDir(): string {
  * - `project` → `<cwd>/.claude/skills/tool-saasfoundry/`
  */
 export function resolveSkillInstallDir(scope: SkillScope, cwd: string = process.cwd()): string {
-  const base = scope === 'user' ? homedir() : cwd
+  const base = scope === 'user' ? resolveUserHome() : cwd
   return path.join(base, '.claude', 'skills', SKILL_NAME)
 }
 
@@ -45,5 +57,5 @@ export function resolveManifestPath(installDir: string): string {
  * (`~/.saasfoundry/preferences.json`).
  */
 export function resolvePreferencesPath(): string {
-  return path.join(homedir(), PREFERENCES_DIR, PREFERENCES_FILENAME)
+  return path.join(resolveUserHome(), PREFERENCES_DIR, PREFERENCES_FILENAME)
 }

--- a/src/skill/preferences.ts
+++ b/src/skill/preferences.ts
@@ -1,0 +1,60 @@
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import path from 'path'
+
+import { fileExists } from '../utils'
+
+import { resolvePreferencesPath } from './paths'
+
+export type VotingOptIn = 'never' | 'ask' | 'always'
+
+export interface Preferences {
+  skillPromptAnswered: boolean
+  skillInstallOptIn: boolean
+  cliGlobalInstalled: boolean
+  votingOptIn: VotingOptIn
+  lastVoteSurveyAt: string | null
+}
+
+export const DEFAULT_PREFERENCES: Preferences = {
+  skillPromptAnswered: false,
+  skillInstallOptIn: false,
+  cliGlobalInstalled: false,
+  votingOptIn: 'ask',
+  lastVoteSurveyAt: null
+}
+
+export async function readPreferences(): Promise<Preferences> {
+  const filePath = resolvePreferencesPath()
+  if (!(await fileExists(filePath))) return { ...DEFAULT_PREFERENCES }
+  try {
+    const raw = await readFile(filePath, 'utf8')
+    const parsed = JSON.parse(raw)
+    return mergeWithDefaults(parsed)
+  } catch {
+    return { ...DEFAULT_PREFERENCES }
+  }
+}
+
+export async function writePreferences(prefs: Preferences): Promise<void> {
+  const filePath = resolvePreferencesPath()
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, JSON.stringify(prefs, null, 2) + '\n', 'utf8')
+}
+
+export async function updatePreferences(patch: Partial<Preferences>): Promise<Preferences> {
+  const current = await readPreferences()
+  const next = { ...current, ...patch }
+  await writePreferences(next)
+  return next
+}
+
+function mergeWithDefaults(parsed: unknown): Preferences {
+  const p = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>
+  return {
+    skillPromptAnswered: typeof p.skillPromptAnswered === 'boolean' ? p.skillPromptAnswered : DEFAULT_PREFERENCES.skillPromptAnswered,
+    skillInstallOptIn: typeof p.skillInstallOptIn === 'boolean' ? p.skillInstallOptIn : DEFAULT_PREFERENCES.skillInstallOptIn,
+    cliGlobalInstalled: typeof p.cliGlobalInstalled === 'boolean' ? p.cliGlobalInstalled : DEFAULT_PREFERENCES.cliGlobalInstalled,
+    votingOptIn: p.votingOptIn === 'never' || p.votingOptIn === 'ask' || p.votingOptIn === 'always' ? p.votingOptIn : DEFAULT_PREFERENCES.votingOptIn,
+    lastVoteSurveyAt: typeof p.lastVoteSurveyAt === 'string' ? p.lastVoteSurveyAt : DEFAULT_PREFERENCES.lastVoteSurveyAt
+  }
+}

--- a/src/skill/uninstall.ts
+++ b/src/skill/uninstall.ts
@@ -1,0 +1,49 @@
+import { remove } from 'fs-extra'
+import path from 'path'
+
+import { fileExists } from '../utils'
+
+import { resolvePreferencesPath, resolveSkillInstallDir, SkillScope } from './paths'
+
+export interface UninstallResult {
+  removedSkill: boolean
+  removedPreferences: boolean
+  skillDir: string
+  preferencesPath: string
+}
+
+/**
+ * Remove the skill install at the given scope. Optionally wipe preferences too.
+ * Never touches generated projects or CLI itself.
+ */
+export async function performSkillUninstall(scope: SkillScope, options: { purge: boolean; cwd?: string }): Promise<UninstallResult> {
+  const skillDir = resolveSkillInstallDir(scope, options.cwd)
+  const preferencesPath = resolvePreferencesPath()
+
+  let removedSkill = false
+  if (await fileExists(skillDir)) {
+    await remove(skillDir)
+    removedSkill = true
+  }
+
+  let removedPreferences = false
+  if (options.purge) {
+    const prefsDir = path.dirname(preferencesPath)
+    if (await fileExists(prefsDir)) {
+      await remove(prefsDir)
+      removedPreferences = true
+    }
+  }
+
+  return { removedSkill, removedPreferences, skillDir, preferencesPath }
+}
+
+/**
+ * Full cleanup: remove skill (both scopes where applicable) + preferences.
+ * The caller is responsible for prompting confirmation in interactive mode.
+ */
+export async function performFullUninstall(cwd?: string): Promise<{ userScope: UninstallResult; projectScope: UninstallResult }> {
+  const userScope = await performSkillUninstall('user', { purge: true, cwd })
+  const projectScope = await performSkillUninstall('project', { purge: false, cwd })
+  return { userScope, projectScope }
+}

--- a/src/skill/update.ts
+++ b/src/skill/update.ts
@@ -1,0 +1,30 @@
+import { readManifest } from './manifest'
+import { resolveSkillInstallDir, SkillScope } from './paths'
+
+export interface StaleCheck {
+  installed: boolean
+  stale: boolean
+  installedVersion: string | null
+  bundledVersion: string
+  targetDir: string
+}
+
+/**
+ * Compare the installed skill's manifest against the bundled CLI version.
+ * Returns installed=false when no manifest exists (i.e. no install in this scope).
+ * Returns stale=true when the installed cliVersion differs from the bundled one.
+ */
+export async function checkSkillStatus(scope: SkillScope, bundledVersion: string, cwd?: string): Promise<StaleCheck> {
+  const targetDir = resolveSkillInstallDir(scope, cwd)
+  const manifest = await readManifest(targetDir)
+  if (!manifest) {
+    return { installed: false, stale: false, installedVersion: null, bundledVersion, targetDir }
+  }
+  return {
+    installed: true,
+    stale: manifest.cliVersion !== bundledVersion,
+    installedVersion: manifest.cliVersion,
+    bundledVersion,
+    targetDir
+  }
+}

--- a/src/skill/warn.ts
+++ b/src/skill/warn.ts
@@ -1,0 +1,35 @@
+import chalk from 'chalk'
+
+import { SKILL_NAME } from './paths'
+import { checkSkillStatus } from './update'
+
+/**
+ * Emit a soft warning to stderr when the user-scope skill install is stale
+ * relative to the CLI bundle. This is called at the start of every `sf *`
+ * invocation — it must never throw, never block, and never perform I/O that
+ * noticeably slows down the CLI.
+ *
+ * Opt-out: set `SF_SKILL_NO_WARN=1` in the environment.
+ * Skipped: when the user has no install at all (fresh users are not nagged)
+ *          and when the subcommand is the skill manager itself (install/update/uninstall),
+ *          since the warning would duplicate that command's own output.
+ */
+export async function maybeEmitStaleSkillWarning(argv: string[], bundledVersion: string): Promise<void> {
+  if (process.env.SF_SKILL_NO_WARN === '1' || process.env.SF_SKILL_NO_WARN === 'true') return
+  if (isSkillLifecycleInvocation(argv)) return
+
+  try {
+    const status = await checkSkillStatus('user', bundledVersion)
+    if (!status.installed || !status.stale) return
+    process.stderr.write(chalk.yellow(`⚠  ${SKILL_NAME} skill is out of date (${status.installedVersion} → ${bundledVersion}). Run: sf skill update\n`))
+  } catch {
+    // never block on a best-effort advisory
+  }
+}
+
+function isSkillLifecycleInvocation(argv: string[]): boolean {
+  const command = argv[2]
+  if (command === 'skill') return true
+  if (command === 'uninstall') return true
+  return false
+}


### PR DESCRIPTION
Closes #61 (Phase 1D of epic #18).

## Summary

- Add `sf skill install [--project] [--force] [--yes]` → writes bundle + `.version` manifest under `~/.claude/skills/tool-saasfoundry/` (user scope) or `<cwd>/.claude/skills/tool-saasfoundry/` (project scope). TTY-aware overwrite prompt; non-TTY exits `1` without `--force`.
- Add `sf skill update` → diff-check installed manifest vs bundled CLI version, re-copy if stale, no-op if current. Preserves `~/.saasfoundry/preferences.json` across updates.
- Add `sf skill uninstall [--purge] [--yes]` and top-level `sf uninstall --all` → per-scope or full teardown; `--purge` / `--all` also wipes preferences.
- Fire-and-forget stale-skill warning on every `sf *` invocation (silenced by `SF_SKILL_NO_WARN=1`, skipped on `skill`/`uninstall` subcommands to avoid double-noise).
- npx detection (via `npm_config_user_agent`) surfaces an optional global-install hint after a fresh user install.
- Preferences file at `~/.saasfoundry/preferences.json` with schema `{ skillPromptAnswered, skillInstallOptIn, cliGlobalInstalled, votingOptIn, lastVoteSurveyAt }`, merge-with-defaults read path, corrupt-JSON-safe.
- `scaffolds/skills-templates/tool-saasfoundry/SKILL.md` shipped as a stub (real content lands in Phase 2). Bundle is already covered by the existing `scaffolds/` entry in `package.json#files`.

## Non-regression coverage

29 new tests, split:
- `unit/skill/paths.spec.ts` — 5 tests (bundle source, user/project scope, manifest, preferences)
- `unit/skill/manifest.spec.ts` — 5 tests (missing, round-trip, corrupt, unknown-scope, default timestamp)
- `unit/skill/preferences.spec.ts` — 6 tests (defaults, round-trip, auto-mkdir, merge, malformed fallback, updatePreferences)
- `integration/skill/lifecycle.spec.ts` — 13 tests (fresh/reinstall/project install, checkSkillStatus fresh/current/stale, uninstall with and without purge, no-op uninstall, `performFullUninstall`, preferences survive update, corrupt manifest, manifest-less bundle detection, scope independence, SKILL.md byte-equal copy)

Total test suite: **412/412** passing. Docker pre-push scenarios (`monorepo-minimal` + `multirepo-minimal`) green.

No E2E (Playwright) tests — this is a CLI command surface, covered at the correct layer by Jest unit + integration specs that drive the real filesystem in a scratch HOME. E2E suites in this repo are reserved for generated-project smoke.

## Implementation notes

- `src/skill/paths.ts::resolveUserHome()` reads `$HOME` / `$USERPROFILE` before falling back to `os.homedir()`. Needed because `os.homedir()` on POSIX reads from `getpwuid()` and ignores later `process.env.HOME` changes, which made jest worker tests unable to redirect `~`.
- `src/skill/warn.ts::maybeEmitStaleSkillWarning` is fire-and-forget (`void ...`) at CLI entry so it never blocks the command. Consequence: Commander's synchronous `--version` / `--help` exit before the async check resolves — by design, since those trivial invocations don't need the warning.

## Test plan (copied from ticket)

Full 17-scenario plan posted as issue comment; all scenarios validated manually in Human Testing. See [AI Testing report](https://github.com/DiamondForgeFr/SaaSFoundry/issues/61#issuecomment-4268030075) for the matrix.

- [x] Install user scope (fresh + `--force` reinstall + non-TTY refuse)
- [x] Install project scope
- [x] Update up-to-date / stale / missing
- [x] Uninstall default / `--purge` / no-op
- [x] `sf uninstall --all` and `sf uninstall` (flag required)
- [x] Stale warning fires / silenced by env / skipped for lifecycle cmds
- [x] npx hint surfaces on fresh install
- [x] `sf --help` lists new `skill` + `uninstall` commands
