### PR TITLE
chore(sf-workflow): enforce per-commit subtask closure + parent-transition gating

### DIFF
--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -136,9 +136,12 @@ See your tool-specific skill documentation for complete command reference:
 2. **NEVER skip steps** described in a status
 3. **NEVER move to the next status** without meeting all exit conditions
 4. **ASK if uncertain** - don't assume or guess
-5. **CLOSE SUBTASKS AS YOU GO** — after a subtask's commit lands, immediately run `workflow-cli.sh update-status <sub> Done` and verify `gh issue view <sub> --json state` prints `CLOSED` before starting the next one. Never batch closures at the end of the parent ticket.
-6. **GATE PARENT TRANSITIONS ON OPEN CHILDREN** — before any parent transition (`AI Testing` → `Human Testing` → `In Review` → `Done`), run `gh issue list --state open --search "parent #<N>"` and ensure it returns empty. If not, go back and close the children first.
-7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only override is an explicit developer request to pause.
+5. **CLOSE SUBTASKS AS YOU GO** — after a subtask's commit lands, immediately run `workflow-cli.sh update-status <sub> Done` and verify `gh issue view <sub> --json state` prints `CLOSED` before
+   starting the next one. Never batch closures at the end of the parent ticket.
+6. **GATE PARENT TRANSITIONS ON OPEN CHILDREN** — before any parent transition (`AI Testing` → `Human Testing` → `In Review` → `Done`), run `gh issue list --state open --search "parent #<N>"` and
+   ensure it returns empty. If not, go back and close the children first.
+7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only
+   override is an explicit developer request to pause.
 
 ## Implementation
 

--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -136,6 +136,9 @@ See your tool-specific skill documentation for complete command reference:
 2. **NEVER skip steps** described in a status
 3. **NEVER move to the next status** without meeting all exit conditions
 4. **ASK if uncertain** - don't assume or guess
+5. **CLOSE SUBTASKS AS YOU GO** — after a subtask's commit lands, immediately run `workflow-cli.sh update-status <sub> Done` and verify `gh issue view <sub> --json state` prints `CLOSED` before starting the next one. Never batch closures at the end of the parent ticket.
+6. **GATE PARENT TRANSITIONS ON OPEN CHILDREN** — before any parent transition (`AI Testing` → `Human Testing` → `In Review` → `Done`), run `gh issue list --state open --search "parent #<N>"` and ensure it returns empty. If not, go back and close the children first.
+7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only override is an explicit developer request to pause.
 
 ## Implementation
 

--- a/.claude/skills/sf-workflow/statuses/3-in-progress.md
+++ b/.claude/skills/sf-workflow/statuses/3-in-progress.md
@@ -103,4 +103,6 @@ For each subtask:
 
 ## Errors to Avoid
 
-❌ NEVER code without creating a branch first ❌ NEVER mix multiple tickets in the same branch ❌ NEVER move to AI Testing with lint errors ❌ NEVER forget to push before moving to AI Testing ❌ NEVER batch subtask closures at the end of the parent — close each one right after its commit lands ❌ NEVER start another ticket while this one is still In Progress / AI Testing / Human Testing / In Review (unless the developer explicitly asks you to pause)
+❌ NEVER code without creating a branch first ❌ NEVER mix multiple tickets in the same branch ❌ NEVER move to AI Testing with lint errors ❌ NEVER forget to push before moving to AI Testing ❌ NEVER
+batch subtask closures at the end of the parent — close each one right after its commit lands ❌ NEVER start another ticket while this one is still In Progress / AI Testing / Human Testing / In Review
+(unless the developer explicitly asks you to pause)

--- a/.claude/skills/sf-workflow/statuses/3-in-progress.md
+++ b/.claude/skills/sf-workflow/statuses/3-in-progress.md
@@ -76,17 +76,18 @@ For each subtask:
   - Example: `type(#{N}): description`
   - Use allowed types: `feat`, `fix`, `docs`, `refactor`, etc.
   - Replace `#{N}` with ticket number
-- d. Mark subtask "Done"
+- d. **Close the subtask immediately** — run `workflow-cli.sh update-status <sub> Done` and **verify** with `gh issue view <sub> --json state` that it prints `CLOSED`. Never batch closures.
 - e. Move to the next one
 
 ### 5. WHEN ALL SUBTASKS ARE DONE
 
-- a. Run: `npm run build && npm run lint`
-- b. Fix all lint/build errors
-- c. Run existing tests (unit tests)
-- d. Ensure nothing is broken
-- e. Final commit if corrections needed
-- f. Push the branch: `git push -u origin {branch-name}`
+- a. **Verify zero open children** — `gh issue list --state open --search "parent #{N}"` must return an empty array before going further. If not, close the remaining children first.
+- b. Run: `npm run build && npm run lint`
+- c. Fix all lint/build errors
+- d. Run existing tests (unit tests)
+- e. Ensure nothing is broken
+- f. Final commit if corrections needed
+- g. Push the branch: `git push -u origin {branch-name}`
 
 ## Exit Conditions
 
@@ -102,4 +103,4 @@ For each subtask:
 
 ## Errors to Avoid
 
-❌ NEVER code without creating a branch first ❌ NEVER mix multiple tickets in the same branch ❌ NEVER move to AI Testing with lint errors ❌ NEVER forget to push before moving to AI Testing
+❌ NEVER code without creating a branch first ❌ NEVER mix multiple tickets in the same branch ❌ NEVER move to AI Testing with lint errors ❌ NEVER forget to push before moving to AI Testing ❌ NEVER batch subtask closures at the end of the parent — close each one right after its commit lands ❌ NEVER start another ticket while this one is still In Progress / AI Testing / Human Testing / In Review (unless the developer explicitly asks you to pause)

--- a/.claude/skills/sf-workflow/statuses/4-ai-testing.md
+++ b/.claude/skills/sf-workflow/statuses/4-ai-testing.md
@@ -18,7 +18,8 @@ Before doing anything else, verify the parent has no open children:
 gh issue list --state open --search "parent #{N}"
 ```
 
-Must return `[]`. If any children are still open, **go back to In Progress**, close them (`workflow-cli.sh update-status <sub> Done`), and only then proceed to step 1. This gate exists because merged-code-with-open-issues creates an inconsistent board state.
+Must return `[]`. If any children are still open, **go back to In Progress**, close them (`workflow-cli.sh update-status <sub> Done`), and only then proceed to step 1. This gate exists because
+merged-code-with-open-issues creates an inconsistent board state.
 
 ### 1. GENERATE THE TEST PLAN
 

--- a/.claude/skills/sf-workflow/statuses/4-ai-testing.md
+++ b/.claude/skills/sf-workflow/statuses/4-ai-testing.md
@@ -5,9 +5,20 @@
 ## When to Enter This Status
 
 - After completing all subtasks in In Progress
+- **All subtasks are CLOSED on GitHub** (not just merged — the issues themselves must be closed)
 - Code is pushed and ready to be tested
 
 ## Mandatory Actions (in this order)
+
+### 0. GATE CHECK — ZERO OPEN CHILDREN
+
+Before doing anything else, verify the parent has no open children:
+
+```bash
+gh issue list --state open --search "parent #{N}"
+```
+
+Must return `[]`. If any children are still open, **go back to In Progress**, close them (`workflow-cli.sh update-status <sub> Done`), and only then proceed to step 1. This gate exists because merged-code-with-open-issues creates an inconsistent board state.
 
 ### 1. GENERATE THE TEST PLAN
 
@@ -96,4 +107,4 @@
 ## Errors to Avoid
 
 ❌ NEVER move to Human Testing with failing tests ❌ NEVER skip test plan steps ❌ NEVER say "it should work" - RUN the tests ❌ If a test fails, do NOT move to Human Testing, FIX it first ❌ NEVER
-skip examine phase for complex tickets ❌ NEVER ignore Critical/High security findings
+skip examine phase for complex tickets ❌ NEVER ignore Critical/High security findings ❌ NEVER enter AI Testing while subtasks are still OPEN on GitHub — close them first (step 0 gate)

--- a/scaffolds/skills-templates/workflow/SKILL.md
+++ b/scaffolds/skills-templates/workflow/SKILL.md
@@ -131,6 +131,9 @@ See your tool-specific skill documentation for complete command reference:
 2. **NEVER skip steps** described in a status
 3. **NEVER move to the next status** without meeting all exit conditions
 4. **ASK if uncertain** - don't assume or guess
+5. **CLOSE SUBTASKS AS YOU GO** — after a subtask's commit lands, immediately run `workflow-cli.sh update-status <sub> Done` and verify `gh issue view <sub> --json state` prints `CLOSED` before starting the next one. Never batch closures at the end of the parent ticket.
+6. **GATE PARENT TRANSITIONS ON OPEN CHILDREN** — before any parent transition (`AI Testing` → `Human Testing` → `In Review` → `Done`), run `gh issue list --state open --search "parent #<N>"` and ensure it returns empty. If not, go back and close the children first.
+7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only override is an explicit developer request to pause.
 
 ## Implementation
 

--- a/scaffolds/skills-templates/workflow/statuses/3-in-progress.md
+++ b/scaffolds/skills-templates/workflow/statuses/3-in-progress.md
@@ -68,16 +68,17 @@ For each subtask:
   - Example: `type(#{N}): description`
   - Use allowed types: `feat`, `fix`, `docs`, `refactor`, etc.
   - Replace `#{N}` with ticket number
-- d. Mark subtask "Done"
+- d. **Close the subtask immediately** — run `workflow-cli.sh update-status <sub> Done` and **verify** with `gh issue view <sub> --json state` that it prints `CLOSED`. Never batch closures.
 - e. Move to the next one
 
 ### 5. WHEN ALL SUBTASKS ARE DONE
-- a. Run: `npm run build && npm run lint`
-- b. Fix all lint/build errors
-- c. Run existing tests (unit tests)
-- d. Ensure nothing is broken
-- e. Final commit if corrections needed
-- f. Push the branch: `git push -u origin {branch-name}`
+- a. **Verify zero open children** — `gh issue list --state open --search "parent #{N}"` must return an empty array before going further. If not, close the remaining children first.
+- b. Run: `npm run build && npm run lint`
+- c. Fix all lint/build errors
+- d. Run existing tests (unit tests)
+- e. Ensure nothing is broken
+- f. Final commit if corrections needed
+- g. Push the branch: `git push -u origin {branch-name}`
 
 ## Exit Conditions
 
@@ -97,3 +98,5 @@ For each subtask:
 ❌ NEVER mix multiple tickets in the same branch
 ❌ NEVER move to AI Testing with lint errors
 ❌ NEVER forget to push before moving to AI Testing
+❌ NEVER batch subtask closures at the end of the parent — close each one right after its commit lands
+❌ NEVER start another ticket while this one is still In Progress / AI Testing / Human Testing / In Review (unless the developer explicitly asks you to pause)

--- a/scaffolds/skills-templates/workflow/statuses/4-ai-testing.md
+++ b/scaffolds/skills-templates/workflow/statuses/4-ai-testing.md
@@ -5,9 +5,20 @@
 ## When to Enter This Status
 
 - After completing all subtasks in In Progress
+- **All subtasks are CLOSED on GitHub** (not just merged — the issues themselves must be closed)
 - Code is pushed and ready to be tested
 
 ## Mandatory Actions (in this order)
+
+### 0. GATE CHECK — ZERO OPEN CHILDREN
+
+Before doing anything else, verify the parent has no open children:
+
+```bash
+gh issue list --state open --search "parent #{N}"
+```
+
+Must return `[]`. If any children are still open, **go back to In Progress**, close them (`workflow-cli.sh update-status <sub> Done`), and only then proceed to step 1. This gate exists because merged-code-with-open-issues creates an inconsistent board state.
 
 ### 1. GENERATE THE TEST PLAN
 - Analyze all changes (git diff, commits)
@@ -93,3 +104,4 @@
 ❌ If a test fails, do NOT move to Human Testing, FIX it first
 ❌ NEVER skip examine phase for complex tickets
 ❌ NEVER ignore Critical/High security findings
+❌ NEVER enter AI Testing while subtasks are still OPEN on GitHub — close them first (step 0 gate)


### PR DESCRIPTION
Closes #79.

## Summary

Docs-only change. Propagates three workflow guardrails into both the scaffold template shipped to generated projects and the live copy used by this repo:

- **Rule 5 — Close subtasks as you go**: close + verify `CLOSED` state immediately after each subtask's commit, never batch.
- **Rule 6 — Gate parent transitions on open children**: `gh issue list --state open --search "parent #<N>"` must return `[]` before any parent transition.
- **Rule 7 — Finish current ticket before starting another**: drive In Progress / AI Testing / Human Testing / In Review tickets to Done first, unless the developer explicitly pauses.

Rules are stated in `SKILL.md#Critical Rules` and wired into the status files:

- `statuses/3-in-progress.md` — step 4d now requires close+verify; new step 5a zero-children gate; two new Errors-to-Avoid entries.
- `statuses/4-ai-testing.md` — new step 0 explicit gate; new "When to Enter" precondition; new Errors-to-Avoid entry.

Context: retrospective on #60 found the AI moved the parent to Human Testing while subtasks #75–#78 were still OPEN on GitHub (code was merged but issues weren't closed). These edits make that failure mode impossible to repeat by codifying the rules in the skill that drives every ticket.

## Files changed (6 total, 0 code)

| File | Change |
|---|---|
| `scaffolds/skills-templates/workflow/SKILL.md` | +3 Critical Rules |
| `scaffolds/skills-templates/workflow/statuses/3-in-progress.md` | +close+verify, +zero-children gate, +2 errors |
| `scaffolds/skills-templates/workflow/statuses/4-ai-testing.md` | +step 0 gate, +precondition, +1 error |
| `.claude/skills/sf-workflow/SKILL.md` | mirror |
| `.claude/skills/sf-workflow/statuses/3-in-progress.md` | mirror |
| `.claude/skills/sf-workflow/statuses/4-ai-testing.md` | mirror |

## Non-regression

No new tests — docs-only change, no code paths or CLI commands touched. Full existing suite (**412 tests, 34 suites**) stays green on every commit; pre-push Docker scenarios green.

## Test plan

Posted as [issue comment](https://github.com/DiamondForgeFr/SaaSFoundry/issues/79#issuecomment-4268503789). Key checks:

- [x] Scaffold ↔ live parity (only `{{WORKFLOW_NAME}}` placeholder + prettier line-wrap diffs)
- [x] Rules 5-7 render in both SKILL.md files
- [x] `statuses/3-in-progress.md` step 4d requires close+verify; step 5a verifies zero open children
- [x] `statuses/4-ai-testing.md` step 0 gate precedes step 1; precondition in "When to Enter" explicit
- [x] Pre-commit suite (412/412) green on all 3 commits; pre-push Docker (`monorepo-minimal` + `multirepo-minimal`) green
