### PR TITLE
feat(#62): add sf feedback command family (request/bug/list/vote)

### DIFF
--- a/.claude/docs/github-labels.md
+++ b/.claude/docs/github-labels.md
@@ -1,14 +1,15 @@
 # GitHub Labels — Feedback Loop
 
-The `sf feedback` command family expects these labels to exist on the SaaSFoundry upstream repository (`DiamondForgeFr/SaaSFoundry`). They're used for issue classification, dedup search, and voting filters.
+The `sf feedback` command family expects these labels to exist on the SaaSFoundry upstream repository (`DiamondForgeFr/SaaSFoundry`). They're used for issue classification, dedup search, and voting
+filters.
 
 ## Labels used by `sf feedback`
 
-| Label            | Color     | Purpose                                                                 |
-| ---------------- | --------- | ----------------------------------------------------------------------- |
+| Label            | Color     | Purpose                                                                                                |
+| ---------------- | --------- | ------------------------------------------------------------------------------------------------------ |
 | `module-request` | `#0e8a16` | A user-filed request for a new module or optional skill. Sortable by 👍 for `sf feedback vote --list`. |
-| `cli-bug`        | `#b60205` | A bug in the `sf` CLI itself (commands, prompts, non-interactive flags, etc.). |
-| `scaffold-bug`   | `#d93f0b` | A bug in generated project code (scaffolds/blueprints/overlays/modules). |
+| `cli-bug`        | `#b60205` | A bug in the `sf` CLI itself (commands, prompts, non-interactive flags, etc.).                         |
+| `scaffold-bug`   | `#d93f0b` | A bug in generated project code (scaffolds/blueprints/overlays/modules).                               |
 
 ## One-time setup on a fresh fork or repo
 

--- a/.claude/docs/github-labels.md
+++ b/.claude/docs/github-labels.md
@@ -1,0 +1,35 @@
+# GitHub Labels — Feedback Loop
+
+The `sf feedback` command family expects these labels to exist on the SaaSFoundry upstream repository (`DiamondForgeFr/SaaSFoundry`). They're used for issue classification, dedup search, and voting filters.
+
+## Labels used by `sf feedback`
+
+| Label            | Color     | Purpose                                                                 |
+| ---------------- | --------- | ----------------------------------------------------------------------- |
+| `module-request` | `#0e8a16` | A user-filed request for a new module or optional skill. Sortable by 👍 for `sf feedback vote --list`. |
+| `cli-bug`        | `#b60205` | A bug in the `sf` CLI itself (commands, prompts, non-interactive flags, etc.). |
+| `scaffold-bug`   | `#d93f0b` | A bug in generated project code (scaffolds/blueprints/overlays/modules). |
+
+## One-time setup on a fresh fork or repo
+
+Run once, from anywhere (requires `gh auth login`):
+
+```bash
+gh label create module-request --repo DiamondForgeFr/SaaSFoundry --color 0e8a16 --description "User-filed module request" || true
+gh label create cli-bug        --repo DiamondForgeFr/SaaSFoundry --color b60205 --description "Bug in the sf CLI"       || true
+gh label create scaffold-bug   --repo DiamondForgeFr/SaaSFoundry --color d93f0b --description "Bug in generated code"   || true
+```
+
+The `|| true` makes the command idempotent — existing labels return a non-zero exit code but we don't want to fail the script.
+
+## How the CLI uses these labels
+
+- **`sf feedback request`** creates issues with `module-request` and searches existing `module-request` issues to dedup.
+- **`sf feedback bug --source cli`** creates with `cli-bug`; `--source scaffold` uses `scaffold-bug`. Both search their own label for dedup.
+- **`sf feedback list`** filters by all three labels by default and shows them in a single table.
+- **`sf feedback vote --list`** ranks open `module-request` issues by 👍 reaction count.
+
+## Not managed here
+
+- `complexity: {bug,low,medium,complex}` — internal workflow labels, managed by `sf-tool-github-projects` (see `.claude/skills/sf-tool-github-projects/`).
+- Any custom label a maintainer adds manually — the CLI ignores unrecognized labels.

--- a/src/__tests__/integration/commands/feedback.spec.ts
+++ b/src/__tests__/integration/commands/feedback.spec.ts
@@ -1,0 +1,290 @@
+jest.mock('../../../feedback/gh', () => ({
+  ensureGhAuth: jest.fn(),
+  ghIssueSearch: jest.fn(),
+  ghIssueCreate: jest.fn(),
+  ghIssueComment: jest.fn(),
+  ghAddReaction: jest.fn(),
+  ghCurrentUser: jest.fn()
+}))
+
+jest.mock('../../../feedback/repo', () => ({
+  readFeedbackRepo: jest.fn()
+}))
+
+import { feedbackCommand } from '../../../commands/feedback'
+import { ensureGhAuth, ghAddReaction, ghCurrentUser, ghIssueComment, ghIssueCreate, ghIssueSearch } from '../../../feedback/gh'
+import { readFeedbackRepo } from '../../../feedback/repo'
+import { readPreferences } from '../../../skill/preferences'
+import { createTempDir } from '../../helpers/temp-dir'
+
+const mockEnsureGhAuth = ensureGhAuth as jest.Mock
+const mockGhIssueSearch = ghIssueSearch as jest.Mock
+const mockGhIssueCreate = ghIssueCreate as jest.Mock
+const mockGhIssueComment = ghIssueComment as jest.Mock
+const mockGhAddReaction = ghAddReaction as jest.Mock
+const mockGhCurrentUser = ghCurrentUser as jest.Mock
+const mockReadFeedbackRepo = readFeedbackRepo as jest.Mock
+
+describe('feedbackCommand (integration)', () => {
+  let originalHome: string | undefined
+  let tempHome: string
+  let cleanupHome: () => Promise<void>
+  let logSpy: jest.SpyInstance
+  let errorSpy: jest.SpyInstance
+  let exitSpy: jest.SpyInstance
+  let stdoutSpy: jest.SpyInstance
+  let isTty: boolean
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME
+    const { dir, cleanup } = await createTempDir()
+    tempHome = dir
+    cleanupHome = cleanup
+    process.env.HOME = tempHome
+
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined)
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never)
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((() => true) as never)
+
+    isTty = Boolean(process.stdin.isTTY)
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
+
+    mockEnsureGhAuth.mockReset().mockResolvedValue(undefined)
+    mockGhIssueSearch.mockReset().mockResolvedValue([])
+    mockGhIssueCreate.mockReset()
+    mockGhIssueComment.mockReset().mockResolvedValue(undefined)
+    mockGhAddReaction.mockReset().mockResolvedValue(undefined)
+    mockGhCurrentUser.mockReset().mockResolvedValue('octocat')
+    mockReadFeedbackRepo.mockReset().mockResolvedValue({
+      owner: 'DiamondForgeFr',
+      repo: 'SaaSFoundry',
+      slug: 'DiamondForgeFr/SaaSFoundry',
+      httpsUrl: 'https://github.com/DiamondForgeFr/SaaSFoundry'
+    })
+  })
+
+  afterEach(async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: isTty, configurable: true })
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
+    stdoutSpy.mockRestore()
+    await cleanupHome()
+  })
+
+  const allLog = () => logSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+  const allStdout = () => stdoutSpy.mock.calls.map((c) => String(c[0])).join('')
+
+  describe('dispatcher', () => {
+    it('prints help when no subcommand is given', async () => {
+      await feedbackCommand()
+      const out = allLog()
+      expect(out).toContain('SaaSFoundry Feedback')
+      expect(out).toContain('request <name>')
+      expect(out).toContain('bug')
+      expect(out).toContain('list')
+      expect(out).toContain('vote')
+    })
+
+    it('exits with an error for unknown subcommands', async () => {
+      await expect(feedbackCommand('bogus')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes('Unknown subcommand'))).toBe(true)
+    })
+
+    it('help mentions every documented flag', async () => {
+      await feedbackCommand()
+      const out = allLog()
+      expect(out).toContain('--description')
+      expect(out).toContain('--source cli|scaffold')
+      expect(out).toContain('--auto-repro')
+      expect(out).toContain('--status')
+      expect(out).toContain('--mine')
+      expect(out).toContain('--json')
+      expect(out).toContain('--stack-filter')
+    })
+  })
+
+  describe('request', () => {
+    it('files a new module-request when no dedup matches exist', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      mockGhIssueCreate.mockResolvedValue({
+        number: 101,
+        url: 'https://github.com/DiamondForgeFr/SaaSFoundry/issues/101',
+        title: 'Module request: Stripe',
+        state: 'OPEN',
+        labels: [{ name: 'module-request' }],
+        author: { login: '' }
+      })
+
+      await feedbackCommand('request', 'Stripe', '--description', 'Accept payments', '--non-interactive')
+
+      expect(mockGhIssueCreate).toHaveBeenCalledTimes(1)
+      const call = mockGhIssueCreate.mock.calls[0][0]
+      expect(call.labels).toEqual(['module-request'])
+      expect(call.title).toBe('Module request: Stripe')
+
+      const prefs = await readPreferences()
+      expect(prefs.filedRequests.map((r) => r.issueNumber)).toContain(101)
+      expect(allLog()).toContain('Filed request #101')
+    })
+
+    it('skips creation when dedup matches exist (non-interactive)', async () => {
+      mockGhIssueSearch.mockResolvedValue([
+        { number: 5, title: 'Add Stripe', state: 'OPEN', url: 'https://x/5', labels: [{ name: 'module-request' }], author: { login: 'a' } }
+      ])
+      await feedbackCommand('request', 'Stripe', '--description', 'd', '--non-interactive')
+      expect(mockGhIssueCreate).not.toHaveBeenCalled()
+      expect(allLog()).toContain('Similar requests found')
+    })
+
+    it('errors when <name> is missing', async () => {
+      await expect(feedbackCommand('request', '--non-interactive')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes('missing <name>'))).toBe(true)
+    })
+
+    it('errors in --non-interactive when --description is omitted', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      await expect(feedbackCommand('request', 'Stripe', '--non-interactive')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes('--description is required'))).toBe(true)
+    })
+  })
+
+  describe('bug', () => {
+    it('files a cli-bug with --source cli', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      mockGhIssueCreate.mockResolvedValue({ number: 7, url: 'https://x/7', title: 'crash', state: 'OPEN', labels: [{ name: 'cli-bug' }], author: { login: '' } })
+
+      await feedbackCommand('bug', '--source', 'cli', '--title', 'crash on new', '--description', 'stack trace', '--non-interactive')
+
+      expect(mockGhIssueCreate).toHaveBeenCalledTimes(1)
+      expect(mockGhIssueCreate.mock.calls[0][0].labels).toEqual(['cli-bug'])
+    })
+
+    it('files a scaffold-bug with --source scaffold', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      mockGhIssueCreate.mockResolvedValue({ number: 8, url: 'https://x/8', title: 'b', state: 'OPEN', labels: [{ name: 'scaffold-bug' }], author: { login: '' } })
+
+      await feedbackCommand('bug', '--source', 'scaffold', '--title', 'vite build fails', '--description', 'd', '--non-interactive')
+
+      expect(mockGhIssueCreate.mock.calls[0][0].labels).toEqual(['scaffold-bug'])
+    })
+
+    it('rejects an invalid --source', async () => {
+      await expect(feedbackCommand('bug', '--source', 'hardware', '--title', 't', '--description', 'd', '--non-interactive')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes("--source must be 'cli' or 'scaffold'"))).toBe(true)
+    })
+
+    it('requires --source in --non-interactive mode', async () => {
+      await expect(feedbackCommand('bug', '--title', 't', '--description', 'd', '--non-interactive')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes('--source is required'))).toBe(true)
+    })
+  })
+
+  describe('list', () => {
+    it('queries all three feedback labels and prints them', async () => {
+      mockGhIssueSearch
+        .mockResolvedValueOnce([{ number: 10, title: 'Req A', state: 'OPEN', url: 'https://x/10', labels: [{ name: 'module-request' }], author: { login: 'a' } }])
+        .mockResolvedValueOnce([{ number: 7, title: 'CLI bug', state: 'OPEN', url: 'https://x/7', labels: [{ name: 'cli-bug' }], author: { login: 'b' } }])
+        .mockResolvedValueOnce([{ number: 3, title: 'Scaf bug', state: 'OPEN', url: 'https://x/3', labels: [{ name: 'scaffold-bug' }], author: { login: 'c' } }])
+
+      await feedbackCommand('list')
+
+      expect(mockGhIssueSearch).toHaveBeenCalledTimes(3)
+      const out = allLog()
+      expect(out).toContain('#10')
+      expect(out).toContain('#7')
+      expect(out).toContain('#3')
+    })
+
+    it('emits JSON with --json', async () => {
+      mockGhIssueSearch
+        .mockResolvedValueOnce([{ number: 10, title: 'Req A', state: 'OPEN', url: 'https://x/10', labels: [{ name: 'module-request' }], author: { login: 'a' } }])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+
+      await feedbackCommand('list', '--json')
+      const json = JSON.parse(allStdout())
+      expect(Array.isArray(json)).toBe(true)
+      expect(json[0]).toMatchObject({ number: 10, kind: 'module-request', url: 'https://x/10', author: 'a' })
+    })
+
+    it('injects the current user when --mine is set', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      await feedbackCommand('list', '--mine')
+      expect(mockGhCurrentUser).toHaveBeenCalledTimes(1)
+      for (const call of mockGhIssueSearch.mock.calls) {
+        expect(call[0].author).toBe('octocat')
+      }
+    })
+
+    it('rejects an invalid --status', async () => {
+      await expect(feedbackCommand('list', '--status', 'sideways')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes("--status must be 'open', 'closed', or 'all'"))).toBe(true)
+    })
+  })
+
+  describe('vote', () => {
+    it('--list ranks module-request issues by 👍', async () => {
+      mockGhIssueSearch.mockResolvedValue([
+        {
+          number: 1,
+          title: 'A',
+          state: 'OPEN',
+          url: 'https://x/1',
+          labels: [{ name: 'module-request' }],
+          author: { login: 'a' },
+          reactionGroups: [{ content: 'THUMBS_UP', users: { totalCount: 2 } }]
+        },
+        {
+          number: 2,
+          title: 'B',
+          state: 'OPEN',
+          url: 'https://x/2',
+          labels: [{ name: 'module-request' }],
+          author: { login: 'b' },
+          reactionGroups: [{ content: 'THUMBS_UP', users: { totalCount: 9 } }]
+        }
+      ])
+
+      await feedbackCommand('vote', '--list')
+      const out = allLog()
+      const idxB = out.indexOf('#2')
+      const idxA = out.indexOf('#1')
+      expect(idxB).toBeGreaterThan(-1)
+      expect(idxA).toBeGreaterThan(-1)
+      expect(idxB).toBeLessThan(idxA)
+    })
+
+    it('casts a 👍 reaction and records it in prefs', async () => {
+      await feedbackCommand('vote', '42', 'up')
+      expect(mockGhAddReaction).toHaveBeenCalledWith({ repo: 'DiamondForgeFr/SaaSFoundry', issueNumber: 42, content: '+1' })
+      const prefs = await readPreferences()
+      expect(prefs.votesCast[0]).toMatchObject({ issueNumber: 42, direction: 'up' })
+    })
+
+    it('posts a comment with --comment', async () => {
+      await feedbackCommand('vote', '42', 'comment', '--comment', 'I need this for payroll.')
+      expect(mockGhIssueComment).toHaveBeenCalledWith('DiamondForgeFr/SaaSFoundry', 42, 'I need this for payroll.')
+    })
+
+    it('rejects an invalid issue number', async () => {
+      await expect(feedbackCommand('vote', 'banana', 'up')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes('expected a positive issue number'))).toBe(true)
+    })
+
+    it('rejects an invalid action', async () => {
+      await expect(feedbackCommand('vote', '1', 'sideways')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes("action must be 'up', 'down', or 'comment'"))).toBe(true)
+    })
+
+    it('requires --comment body for action=comment in --non-interactive mode', async () => {
+      await expect(feedbackCommand('vote', '1', 'comment', '--non-interactive')).rejects.toThrow(/process\.exit\(1\)/)
+      expect(errorSpy.mock.calls.some((c) => c.join(' ').includes('--comment is required'))).toBe(true)
+    })
+  })
+})

--- a/src/__tests__/integration/commands/feedback.spec.ts
+++ b/src/__tests__/integration/commands/feedback.spec.ts
@@ -134,9 +134,7 @@ describe('feedbackCommand (integration)', () => {
     })
 
     it('skips creation when dedup matches exist (non-interactive)', async () => {
-      mockGhIssueSearch.mockResolvedValue([
-        { number: 5, title: 'Add Stripe', state: 'OPEN', url: 'https://x/5', labels: [{ name: 'module-request' }], author: { login: 'a' } }
-      ])
+      mockGhIssueSearch.mockResolvedValue([{ number: 5, title: 'Add Stripe', state: 'OPEN', url: 'https://x/5', labels: [{ name: 'module-request' }], author: { login: 'a' } }])
       await feedbackCommand('request', 'Stripe', '--description', 'd', '--non-interactive')
       expect(mockGhIssueCreate).not.toHaveBeenCalled()
       expect(allLog()).toContain('Similar requests found')

--- a/src/__tests__/unit/feedback/bug.spec.ts
+++ b/src/__tests__/unit/feedback/bug.spec.ts
@@ -1,0 +1,164 @@
+jest.mock('../../../feedback/gh', () => ({
+  ensureGhAuth: jest.fn(),
+  ghIssueSearch: jest.fn(),
+  ghIssueCreate: jest.fn()
+}))
+
+jest.mock('../../../feedback/repo', () => ({
+  readFeedbackRepo: jest.fn()
+}))
+
+import { writeFile } from 'fs/promises'
+import path from 'path'
+
+import { bugLabel, collectReproContext, fileBug, formatBugBody, searchExistingBugs } from '../../../feedback/bug'
+import { ensureGhAuth, ghIssueCreate, ghIssueSearch } from '../../../feedback/gh'
+import { readFeedbackRepo } from '../../../feedback/repo'
+import { createTempDir } from '../../helpers/temp-dir'
+
+const mockEnsureGhAuth = ensureGhAuth as jest.Mock
+const mockGhIssueSearch = ghIssueSearch as jest.Mock
+const mockGhIssueCreate = ghIssueCreate as jest.Mock
+const mockReadFeedbackRepo = readFeedbackRepo as jest.Mock
+
+describe('feedback/bug', () => {
+  beforeEach(() => {
+    mockEnsureGhAuth.mockReset()
+    mockGhIssueSearch.mockReset()
+    mockGhIssueCreate.mockReset()
+    mockReadFeedbackRepo.mockReset()
+
+    mockEnsureGhAuth.mockResolvedValue(undefined)
+    mockReadFeedbackRepo.mockResolvedValue({
+      owner: 'DiamondForgeFr',
+      repo: 'SaaSFoundry',
+      slug: 'DiamondForgeFr/SaaSFoundry',
+      httpsUrl: 'https://github.com/DiamondForgeFr/SaaSFoundry'
+    })
+  })
+
+  describe('bugLabel', () => {
+    it('maps cli to cli-bug and scaffold to scaffold-bug', () => {
+      expect(bugLabel('cli')).toBe('cli-bug')
+      expect(bugLabel('scaffold')).toBe('scaffold-bug')
+    })
+  })
+
+  describe('searchExistingBugs', () => {
+    it('filters by cli-bug label for cli source', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      await searchExistingBugs('cli', 'crash on new')
+      expect(mockGhIssueSearch).toHaveBeenCalledWith({
+        repo: 'DiamondForgeFr/SaaSFoundry',
+        labels: ['cli-bug'],
+        state: 'all',
+        search: 'crash on new',
+        limit: 10
+      })
+    })
+
+    it('filters by scaffold-bug label for scaffold source', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      await searchExistingBugs('scaffold', 'nestjs build fails')
+      expect(mockGhIssueSearch).toHaveBeenCalledWith({
+        repo: 'DiamondForgeFr/SaaSFoundry',
+        labels: ['scaffold-bug'],
+        state: 'all',
+        search: 'nestjs build fails',
+        limit: 10
+      })
+    })
+  })
+
+  describe('collectReproContext', () => {
+    it('returns CLI version, Node version, platform, arch', async () => {
+      const { dir, cleanup } = await createTempDir()
+      try {
+        const ctx = await collectReproContext('1.0.0-beta', dir)
+        expect(ctx.cliVersion).toBe('1.0.0-beta')
+        expect(ctx.nodeVersion).toBe(process.version)
+        expect(ctx.platform).toBe(process.platform)
+        expect(ctx.arch).toBe(process.arch)
+        expect(ctx.saasfoundryJson).toBeNull()
+      } finally {
+        await cleanup()
+      }
+    })
+
+    it('reads .saasfoundry.json from cwd when present', async () => {
+      const { dir, cleanup } = await createTempDir()
+      try {
+        const json = JSON.stringify({ workflow: { workingBranch: 'develop' } }, null, 2)
+        await writeFile(path.join(dir, '.saasfoundry.json'), json, 'utf8')
+        const ctx = await collectReproContext('1.0.0-beta', dir)
+        expect(ctx.saasfoundryJson).toBe(json)
+      } finally {
+        await cleanup()
+      }
+    })
+  })
+
+  describe('formatBugBody', () => {
+    it('omits repro section when includeRepro is false', () => {
+      const body = formatBugBody({ title: 't', description: 'crash', source: 'cli', cliVersion: '1.0.0', includeRepro: false }, null)
+      expect(body).toContain('**Source:** cli')
+      expect(body).toContain('**CLI version:** 1.0.0')
+      expect(body).not.toContain('**Node:**')
+    })
+
+    it('includes repro metadata and .saasfoundry.json block when available', () => {
+      const body = formatBugBody(
+        { title: 't', description: 'crash', source: 'scaffold', cliVersion: '1.0.0', includeRepro: true },
+        {
+          cliVersion: '1.0.0',
+          nodeVersion: 'v22.0.0',
+          platform: 'darwin',
+          arch: 'arm64',
+          saasfoundryJson: '{"workflow":{"workingBranch":"develop"}}'
+        }
+      )
+      expect(body).toContain('**Source:** scaffold')
+      expect(body).toContain('**Node:** v22.0.0')
+      expect(body).toContain('**Platform:** darwin (arm64)')
+      expect(body).toContain('.saasfoundry.json')
+      expect(body).toContain('"workingBranch":"develop"')
+    })
+
+    it('notes missing .saasfoundry.json in repro mode', () => {
+      const body = formatBugBody(
+        { title: 't', description: 'crash', source: 'cli', cliVersion: '1.0.0', includeRepro: true },
+        { cliVersion: '1.0.0', nodeVersion: 'v22', platform: 'linux', arch: 'x64', saasfoundryJson: null }
+      )
+      expect(body).toContain('_(no .saasfoundry.json found in cwd)_')
+    })
+  })
+
+  describe('fileBug', () => {
+    it('creates an issue with the cli-bug label for source=cli', async () => {
+      mockGhIssueCreate.mockResolvedValue({ number: 7, url: 'https://x/7', title: 't', state: 'OPEN', labels: [], author: { login: '' } })
+      await fileBug({ title: 'crash', description: 'd', source: 'cli', cliVersion: '1.0.0', includeRepro: false })
+      const call = mockGhIssueCreate.mock.calls[0][0]
+      expect(call.labels).toEqual(['cli-bug'])
+    })
+
+    it('creates an issue with the scaffold-bug label for source=scaffold', async () => {
+      mockGhIssueCreate.mockResolvedValue({ number: 8, url: 'https://x/8', title: 't', state: 'OPEN', labels: [], author: { login: '' } })
+      await fileBug({ title: 'build fails', description: 'd', source: 'scaffold', cliVersion: '1.0.0', includeRepro: false })
+      const call = mockGhIssueCreate.mock.calls[0][0]
+      expect(call.labels).toEqual(['scaffold-bug'])
+    })
+
+    it('includes repro metadata in the body when includeRepro is true', async () => {
+      const { dir, cleanup } = await createTempDir()
+      try {
+        mockGhIssueCreate.mockResolvedValue({ number: 9, url: 'https://x/9', title: 't', state: 'OPEN', labels: [], author: { login: '' } })
+        await fileBug({ title: 'oops', description: 'd', source: 'cli', cliVersion: '1.0.0', includeRepro: true, cwd: dir })
+        const call = mockGhIssueCreate.mock.calls[0][0]
+        expect(call.body).toContain(`**Node:** ${process.version}`)
+        expect(call.body).toContain(`**Platform:** ${process.platform}`)
+      } finally {
+        await cleanup()
+      }
+    })
+  })
+})

--- a/src/__tests__/unit/feedback/gh.spec.ts
+++ b/src/__tests__/unit/feedback/gh.spec.ts
@@ -1,0 +1,72 @@
+jest.mock('child_process', () => ({
+  execFile: jest.fn()
+}))
+
+import { execFile } from 'child_process'
+
+import { ghAddReaction, ghCurrentUser, ghIssueCreate, ghIssueSearch } from '../../../feedback/gh'
+
+const mockExecFile = execFile as unknown as jest.Mock
+
+function mockStdout(stdout: string): void {
+  mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+    cb(null, stdout, '')
+  })
+}
+
+function mockError(stderr: string): void {
+  mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error & { stderr?: string }, stdout: string, stderr: string) => void) => {
+    const err = new Error('Command failed') as Error & { stderr?: string }
+    err.stderr = stderr
+    cb(err, '', stderr)
+  })
+}
+
+describe('feedback/gh', () => {
+  beforeEach(() => {
+    mockExecFile.mockReset()
+  })
+
+  it('ghIssueSearch parses JSON output and forwards flags', async () => {
+    mockStdout(JSON.stringify([{ number: 1, title: 'Add Stripe', state: 'OPEN', url: 'https://x', labels: [], author: { login: 'alice' } }]))
+    const issues = await ghIssueSearch({ repo: 'OWNER/REPO', labels: ['module-request'], state: 'open', search: 'stripe', limit: 5 })
+    expect(issues).toHaveLength(1)
+    expect(issues[0].title).toBe('Add Stripe')
+
+    const call = mockExecFile.mock.calls[0]
+    const args: string[] = call[1]
+    expect(args.slice(0, 4)).toEqual(['issue', 'list', '--repo', 'OWNER/REPO'])
+    expect(args).toContain('--state')
+    expect(args).toContain('--label')
+    expect(args).toContain('module-request')
+    expect(args).toContain('--limit')
+    expect(args).toContain('5')
+  })
+
+  it('ghIssueCreate extracts the new issue number from the URL', async () => {
+    mockStdout('https://github.com/OWNER/REPO/issues/42\n')
+    const created = await ghIssueCreate({ repo: 'OWNER/REPO', title: 't', body: 'b', labels: ['module-request'] })
+    expect(created.number).toBe(42)
+    expect(created.url).toBe('https://github.com/OWNER/REPO/issues/42')
+  })
+
+  it('ghAddReaction calls the reactions endpoint with correct content', async () => {
+    mockStdout('{}')
+    await ghAddReaction({ repo: 'OWNER/REPO', issueNumber: 99, content: '+1' })
+    const args: string[] = mockExecFile.mock.calls[0][1]
+    expect(args[0]).toBe('api')
+    expect(args).toContain('/repos/OWNER/REPO/issues/99/reactions')
+    expect(args).toContain('content=+1')
+  })
+
+  it('ghCurrentUser trims the login', async () => {
+    mockStdout('octocat\n')
+    const login = await ghCurrentUser()
+    expect(login).toBe('octocat')
+  })
+
+  it('execGh surfaces stderr on failure', async () => {
+    mockError('HTTP 404: Not Found')
+    await expect(ghIssueSearch({ repo: 'OWNER/REPO' })).rejects.toThrow(/HTTP 404/)
+  })
+})

--- a/src/__tests__/unit/feedback/list.spec.ts
+++ b/src/__tests__/unit/feedback/list.spec.ts
@@ -1,0 +1,126 @@
+jest.mock('../../../feedback/gh', () => ({
+  ensureGhAuth: jest.fn(),
+  ghIssueSearch: jest.fn(),
+  ghCurrentUser: jest.fn()
+}))
+
+jest.mock('../../../feedback/repo', () => ({
+  readFeedbackRepo: jest.fn()
+}))
+
+import { ensureGhAuth, ghCurrentUser, ghIssueSearch } from '../../../feedback/gh'
+import { readFeedbackRepo } from '../../../feedback/repo'
+import { classifyIssue, FEEDBACK_LABELS, listFeedback } from '../../../feedback/list'
+
+const mockEnsureGhAuth = ensureGhAuth as jest.Mock
+const mockGhIssueSearch = ghIssueSearch as jest.Mock
+const mockGhCurrentUser = ghCurrentUser as jest.Mock
+const mockReadFeedbackRepo = readFeedbackRepo as jest.Mock
+
+function issue(number: number, labelName: string, state: 'OPEN' | 'CLOSED' = 'OPEN', login = 'alice') {
+  return {
+    number,
+    title: `Issue #${number}`,
+    state,
+    url: `https://x/${number}`,
+    labels: [{ name: labelName }],
+    author: { login }
+  }
+}
+
+describe('feedback/list', () => {
+  beforeEach(() => {
+    mockEnsureGhAuth.mockReset()
+    mockGhIssueSearch.mockReset()
+    mockGhCurrentUser.mockReset()
+    mockReadFeedbackRepo.mockReset()
+
+    mockEnsureGhAuth.mockResolvedValue(undefined)
+    mockReadFeedbackRepo.mockResolvedValue({
+      owner: 'DiamondForgeFr',
+      repo: 'SaaSFoundry',
+      slug: 'DiamondForgeFr/SaaSFoundry',
+      httpsUrl: 'https://github.com/DiamondForgeFr/SaaSFoundry'
+    })
+  })
+
+  describe('classifyIssue', () => {
+    it('picks module-request, cli-bug, scaffold-bug, or other', () => {
+      expect(classifyIssue(issue(1, 'module-request'))).toBe('module-request')
+      expect(classifyIssue(issue(1, 'cli-bug'))).toBe('cli-bug')
+      expect(classifyIssue(issue(1, 'scaffold-bug'))).toBe('scaffold-bug')
+      expect(classifyIssue(issue(1, 'something-else'))).toBe('other')
+    })
+  })
+
+  describe('listFeedback', () => {
+    it('queries each feedback label and merges results sorted by number desc', async () => {
+      mockGhIssueSearch
+        .mockResolvedValueOnce([issue(10, 'module-request'), issue(5, 'module-request')])
+        .mockResolvedValueOnce([issue(7, 'cli-bug')])
+        .mockResolvedValueOnce([issue(3, 'scaffold-bug')])
+
+      const result = await listFeedback({})
+      expect(result.issues.map((i) => i.number)).toEqual([10, 7, 5, 3])
+      expect(mockGhIssueSearch).toHaveBeenCalledTimes(FEEDBACK_LABELS.length)
+      expect(mockEnsureGhAuth).toHaveBeenCalled()
+    })
+
+    it('defaults to state=open', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      await listFeedback({})
+      for (const call of mockGhIssueSearch.mock.calls) {
+        expect(call[0].state).toBe('open')
+      }
+    })
+
+    it('honors --status=all', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      await listFeedback({ status: 'all' })
+      for (const call of mockGhIssueSearch.mock.calls) {
+        expect(call[0].state).toBe('all')
+      }
+    })
+
+    it('passes current user as author when --mine is set', async () => {
+      mockGhCurrentUser.mockResolvedValue('octocat')
+      mockGhIssueSearch.mockResolvedValue([])
+      await listFeedback({ mine: true })
+      expect(mockGhCurrentUser).toHaveBeenCalledTimes(1)
+      for (const call of mockGhIssueSearch.mock.calls) {
+        expect(call[0].author).toBe('octocat')
+      }
+    })
+
+    it('does not set author when --mine is false', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      await listFeedback({})
+      expect(mockGhCurrentUser).not.toHaveBeenCalled()
+      for (const call of mockGhIssueSearch.mock.calls) {
+        expect(call[0].author).toBeUndefined()
+      }
+    })
+
+    it('deduplicates when the same issue carries two feedback labels', async () => {
+      mockGhIssueSearch
+        .mockResolvedValueOnce([issue(42, 'module-request')])
+        .mockResolvedValueOnce([issue(42, 'cli-bug')])
+        .mockResolvedValueOnce([])
+
+      const result = await listFeedback({})
+      expect(result.issues).toHaveLength(1)
+      expect(result.issues[0].number).toBe(42)
+    })
+
+    it('respects the final limit after merging', async () => {
+      mockGhIssueSearch
+        .mockResolvedValueOnce([issue(10, 'module-request'), issue(9, 'module-request'), issue(8, 'module-request')])
+        .mockResolvedValueOnce([issue(7, 'cli-bug'), issue(6, 'cli-bug')])
+        .mockResolvedValueOnce([issue(5, 'scaffold-bug')])
+
+      const result = await listFeedback({ limit: 3 })
+      expect(result.issues).toHaveLength(3)
+      expect(result.issues.map((i) => i.number)).toEqual([10, 9, 8])
+    })
+  })
+})

--- a/src/__tests__/unit/feedback/repo.spec.ts
+++ b/src/__tests__/unit/feedback/repo.spec.ts
@@ -1,0 +1,34 @@
+import { parseGitHubUrl, readFeedbackRepo } from '../../../feedback/repo'
+
+describe('feedback/repo.parseGitHubUrl', () => {
+  it.each([
+    ['git+https://github.com/DiamondForgeFr/SaaSFoundry.git', 'DiamondForgeFr', 'SaaSFoundry'],
+    ['https://github.com/DiamondForgeFr/SaaSFoundry.git', 'DiamondForgeFr', 'SaaSFoundry'],
+    ['https://github.com/DiamondForgeFr/SaaSFoundry', 'DiamondForgeFr', 'SaaSFoundry'],
+    ['git@github.com:DiamondForgeFr/SaaSFoundry.git', 'DiamondForgeFr', 'SaaSFoundry'],
+    ['DiamondForgeFr/SaaSFoundry', 'DiamondForgeFr', 'SaaSFoundry']
+  ])('parses %s', (input, owner, repo) => {
+    const result = parseGitHubUrl(input)
+    expect(result).not.toBeNull()
+    expect(result!.owner).toBe(owner)
+    expect(result!.repo).toBe(repo)
+    expect(result!.slug).toBe(`${owner}/${repo}`)
+    expect(result!.httpsUrl).toBe(`https://github.com/${owner}/${repo}`)
+  })
+
+  it('returns null for unrecognized urls', () => {
+    expect(parseGitHubUrl('https://gitlab.com/foo/bar')).toBeNull()
+    expect(parseGitHubUrl('not-a-url')).toBeNull()
+    expect(parseGitHubUrl('')).toBeNull()
+  })
+})
+
+describe('feedback/repo.readFeedbackRepo', () => {
+  it('reads the CLI package.json#repository.url', async () => {
+    const repo = await readFeedbackRepo()
+    expect(repo.owner).toBe('DiamondForgeFr')
+    expect(repo.repo).toBe('SaaSFoundry')
+    expect(repo.slug).toBe('DiamondForgeFr/SaaSFoundry')
+    expect(repo.httpsUrl).toBe('https://github.com/DiamondForgeFr/SaaSFoundry')
+  })
+})

--- a/src/__tests__/unit/feedback/request.spec.ts
+++ b/src/__tests__/unit/feedback/request.spec.ts
@@ -1,0 +1,154 @@
+jest.mock('../../../feedback/gh', () => ({
+  ensureGhAuth: jest.fn(),
+  ghIssueSearch: jest.fn(),
+  ghIssueCreate: jest.fn()
+}))
+
+jest.mock('../../../feedback/repo', () => ({
+  readFeedbackRepo: jest.fn()
+}))
+
+import { ensureGhAuth, ghIssueCreate, ghIssueSearch } from '../../../feedback/gh'
+import { readFeedbackRepo } from '../../../feedback/repo'
+import { fileRequest, formatRequestBody, formatRequestTitle, searchExistingRequests } from '../../../feedback/request'
+import { DEFAULT_PREFERENCES, readPreferences, writePreferences } from '../../../skill/preferences'
+import { createTempDir } from '../../helpers/temp-dir'
+
+const mockEnsureGhAuth = ensureGhAuth as jest.Mock
+const mockGhIssueSearch = ghIssueSearch as jest.Mock
+const mockGhIssueCreate = ghIssueCreate as jest.Mock
+const mockReadFeedbackRepo = readFeedbackRepo as jest.Mock
+
+describe('feedback/request', () => {
+  let originalHome: string | undefined
+  let tempHome: string
+  let cleanupHome: () => Promise<void>
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME
+    const { dir, cleanup } = await createTempDir()
+    tempHome = dir
+    cleanupHome = cleanup
+    process.env.HOME = tempHome
+
+    mockEnsureGhAuth.mockReset()
+    mockGhIssueSearch.mockReset()
+    mockGhIssueCreate.mockReset()
+    mockReadFeedbackRepo.mockReset()
+
+    mockEnsureGhAuth.mockResolvedValue(undefined)
+    mockReadFeedbackRepo.mockResolvedValue({
+      owner: 'DiamondForgeFr',
+      repo: 'SaaSFoundry',
+      slug: 'DiamondForgeFr/SaaSFoundry',
+      httpsUrl: 'https://github.com/DiamondForgeFr/SaaSFoundry'
+    })
+  })
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+    await cleanupHome()
+  })
+
+  describe('formatRequestTitle', () => {
+    it('prefixes the trimmed name', () => {
+      expect(formatRequestTitle('  Stripe  ')).toBe('Module request: Stripe')
+    })
+  })
+
+  describe('formatRequestBody', () => {
+    it('includes description, CLI version, and platform metadata', () => {
+      const body = formatRequestBody({ name: 'Stripe', description: 'Accept payments', cliVersion: '1.0.0-beta' })
+      expect(body).toContain('Accept payments')
+      expect(body).toContain('**CLI version:** 1.0.0-beta')
+      expect(body).toContain(`**Platform:** ${process.platform}`)
+      expect(body).toContain(`**Node:** ${process.version}`)
+    })
+
+    it('falls back to a placeholder when description is blank', () => {
+      const body = formatRequestBody({ name: 'Stripe', description: '   ', cliVersion: '1.0.0-beta' })
+      expect(body).toContain('_(no description provided)_')
+    })
+  })
+
+  describe('searchExistingRequests', () => {
+    it('ensures gh auth and searches with module-request label', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      const result = await searchExistingRequests('Stripe')
+      expect(mockEnsureGhAuth).toHaveBeenCalled()
+      expect(mockGhIssueSearch).toHaveBeenCalledWith({
+        repo: 'DiamondForgeFr/SaaSFoundry',
+        labels: ['module-request'],
+        state: 'all',
+        search: 'Stripe',
+        limit: 10
+      })
+      expect(result.repo.slug).toBe('DiamondForgeFr/SaaSFoundry')
+      expect(result.matches).toEqual([])
+    })
+
+    it('returns matches when gh finds similar issues', async () => {
+      mockGhIssueSearch.mockResolvedValue([{ number: 10, title: 'Add Stripe', state: 'OPEN', url: 'https://x', labels: [], author: { login: 'a' } }])
+      const result = await searchExistingRequests('Stripe')
+      expect(result.matches).toHaveLength(1)
+      expect(result.matches[0].number).toBe(10)
+    })
+  })
+
+  describe('fileRequest', () => {
+    it('creates an issue with the module-request label and records it in preferences', async () => {
+      mockGhIssueCreate.mockResolvedValue({
+        number: 42,
+        url: 'https://github.com/DiamondForgeFr/SaaSFoundry/issues/42',
+        title: 'Module request: Stripe',
+        state: 'OPEN',
+        labels: [{ name: 'module-request' }],
+        author: { login: '' }
+      })
+
+      const result = await fileRequest({ name: 'Stripe', description: 'Accept payments', cliVersion: '1.0.0-beta' })
+
+      expect(mockGhIssueCreate).toHaveBeenCalledTimes(1)
+      const call = mockGhIssueCreate.mock.calls[0][0]
+      expect(call.repo).toBe('DiamondForgeFr/SaaSFoundry')
+      expect(call.title).toBe('Module request: Stripe')
+      expect(call.labels).toEqual(['module-request'])
+      expect(call.body).toContain('Accept payments')
+
+      expect(result.issue.number).toBe(42)
+
+      const prefs = await readPreferences()
+      expect(prefs.filedRequests).toHaveLength(1)
+      expect(prefs.filedRequests[0]).toMatchObject({
+        issueNumber: 42,
+        repoUrl: 'https://github.com/DiamondForgeFr/SaaSFoundry/issues/42',
+        title: 'Module request: Stripe'
+      })
+      expect(typeof prefs.filedRequests[0].openedAt).toBe('string')
+    })
+
+    it('appends rather than overwriting existing filedRequests', async () => {
+      await writePreferences({
+        ...DEFAULT_PREFERENCES,
+        filedRequests: [{ issueNumber: 1, repoUrl: 'u1', title: 'First', openedAt: '2026-04-16T00:00:00.000Z' }]
+      })
+
+      mockGhIssueCreate.mockResolvedValue({
+        number: 99,
+        url: 'https://x/99',
+        title: 'Module request: Second',
+        state: 'OPEN',
+        labels: [{ name: 'module-request' }],
+        author: { login: '' }
+      })
+
+      await fileRequest({ name: 'Second', description: 'd', cliVersion: '1.0.0' })
+
+      const prefs = await readPreferences()
+      expect(prefs.filedRequests).toHaveLength(2)
+      expect(prefs.filedRequests[0].issueNumber).toBe(1)
+      expect(prefs.filedRequests[1].issueNumber).toBe(99)
+    })
+  })
+})

--- a/src/__tests__/unit/feedback/vote.spec.ts
+++ b/src/__tests__/unit/feedback/vote.spec.ts
@@ -1,0 +1,157 @@
+jest.mock('../../../feedback/gh', () => ({
+  ensureGhAuth: jest.fn(),
+  ghIssueSearch: jest.fn(),
+  ghAddReaction: jest.fn(),
+  ghIssueComment: jest.fn()
+}))
+
+jest.mock('../../../feedback/repo', () => ({
+  readFeedbackRepo: jest.fn()
+}))
+
+import { ensureGhAuth, ghAddReaction, ghIssueComment, ghIssueSearch } from '../../../feedback/gh'
+import { readFeedbackRepo } from '../../../feedback/repo'
+import { castVote, countReaction, listVotable } from '../../../feedback/vote'
+import { DEFAULT_PREFERENCES, readPreferences, writePreferences } from '../../../skill/preferences'
+import { createTempDir } from '../../helpers/temp-dir'
+
+const mockEnsureGhAuth = ensureGhAuth as jest.Mock
+const mockGhIssueSearch = ghIssueSearch as jest.Mock
+const mockGhAddReaction = ghAddReaction as jest.Mock
+const mockGhIssueComment = ghIssueComment as jest.Mock
+const mockReadFeedbackRepo = readFeedbackRepo as jest.Mock
+
+function issue(number: number, thumbsUp: number, thumbsDown = 0) {
+  return {
+    number,
+    title: `Issue ${number}`,
+    state: 'OPEN' as const,
+    url: `https://x/${number}`,
+    labels: [{ name: 'module-request' }],
+    author: { login: 'a' },
+    reactionGroups: [
+      { content: 'THUMBS_UP', users: { totalCount: thumbsUp } },
+      { content: 'THUMBS_DOWN', users: { totalCount: thumbsDown } }
+    ]
+  }
+}
+
+describe('feedback/vote', () => {
+  let originalHome: string | undefined
+  let tempHome: string
+  let cleanupHome: () => Promise<void>
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME
+    const { dir, cleanup } = await createTempDir()
+    tempHome = dir
+    cleanupHome = cleanup
+    process.env.HOME = tempHome
+
+    mockEnsureGhAuth.mockReset()
+    mockGhIssueSearch.mockReset()
+    mockGhAddReaction.mockReset()
+    mockGhIssueComment.mockReset()
+    mockReadFeedbackRepo.mockReset()
+
+    mockEnsureGhAuth.mockResolvedValue(undefined)
+    mockReadFeedbackRepo.mockResolvedValue({
+      owner: 'DiamondForgeFr',
+      repo: 'SaaSFoundry',
+      slug: 'DiamondForgeFr/SaaSFoundry',
+      httpsUrl: 'https://github.com/DiamondForgeFr/SaaSFoundry'
+    })
+  })
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+    await cleanupHome()
+  })
+
+  describe('countReaction', () => {
+    it('returns 0 when reactionGroups is missing', () => {
+      const i = { number: 1, title: 't', state: 'OPEN' as const, url: 'u', labels: [], author: { login: 'a' } }
+      expect(countReaction(i, 'THUMBS_UP')).toBe(0)
+    })
+
+    it('returns the totalCount for the matching group', () => {
+      expect(countReaction(issue(1, 5, 2), 'THUMBS_UP')).toBe(5)
+      expect(countReaction(issue(1, 5, 2), 'THUMBS_DOWN')).toBe(2)
+    })
+  })
+
+  describe('listVotable', () => {
+    it('searches open module-request issues and ranks by 👍 desc', async () => {
+      mockGhIssueSearch.mockResolvedValue([issue(1, 3), issue(2, 10), issue(3, 7), issue(4, 0)])
+      const result = await listVotable({})
+      expect(result.issues.map((r) => r.issue.number)).toEqual([2, 3, 1, 4])
+      expect(result.issues[0].thumbsUp).toBe(10)
+
+      const call = mockGhIssueSearch.mock.calls[0][0]
+      expect(call.labels).toEqual(['module-request'])
+      expect(call.state).toBe('open')
+    })
+
+    it('caps at the requested limit (default 10)', async () => {
+      const many = Array.from({ length: 15 }, (_, i) => issue(i + 1, 15 - i))
+      mockGhIssueSearch.mockResolvedValue(many)
+      const result = await listVotable({})
+      expect(result.issues).toHaveLength(10)
+    })
+
+    it('forwards --stack-filter as the search term', async () => {
+      mockGhIssueSearch.mockResolvedValue([])
+      await listVotable({ stackFilter: 'stripe' })
+      expect(mockGhIssueSearch.mock.calls[0][0].search).toBe('stripe')
+    })
+
+    it('breaks ties by issue number ascending', async () => {
+      mockGhIssueSearch.mockResolvedValue([issue(10, 5), issue(5, 5), issue(7, 5)])
+      const result = await listVotable({})
+      expect(result.issues.map((r) => r.issue.number)).toEqual([5, 7, 10])
+    })
+  })
+
+  describe('castVote', () => {
+    it('adds a +1 reaction for up and records in votesCast', async () => {
+      const result = await castVote({ issueNumber: 42, action: 'up' })
+      expect(mockGhAddReaction).toHaveBeenCalledWith({ repo: 'DiamondForgeFr/SaaSFoundry', issueNumber: 42, content: '+1' })
+      expect(result.action).toBe('up')
+
+      const prefs = await readPreferences()
+      expect(prefs.votesCast).toHaveLength(1)
+      expect(prefs.votesCast[0].issueNumber).toBe(42)
+      expect(prefs.votesCast[0].direction).toBe('up')
+    })
+
+    it('adds a -1 reaction for down and records direction=down', async () => {
+      await castVote({ issueNumber: 77, action: 'down' })
+      expect(mockGhAddReaction).toHaveBeenCalledWith({ repo: 'DiamondForgeFr/SaaSFoundry', issueNumber: 77, content: '-1' })
+      const prefs = await readPreferences()
+      expect(prefs.votesCast[0].direction).toBe('down')
+    })
+
+    it('posts a comment for action=comment and does NOT touch votesCast', async () => {
+      await castVote({ issueNumber: 5, action: 'comment', comment: 'I need this for payroll.' })
+      expect(mockGhIssueComment).toHaveBeenCalledWith('DiamondForgeFr/SaaSFoundry', 5, 'I need this for payroll.')
+      expect(mockGhAddReaction).not.toHaveBeenCalled()
+      const prefs = await readPreferences()
+      expect(prefs.votesCast).toHaveLength(0)
+    })
+
+    it('rejects an empty comment body', async () => {
+      await expect(castVote({ issueNumber: 5, action: 'comment', comment: '   ' })).rejects.toThrow(/empty/)
+    })
+
+    it('appends rather than overwriting existing votesCast', async () => {
+      await writePreferences({
+        ...DEFAULT_PREFERENCES,
+        votesCast: [{ issueNumber: 1, direction: 'up', castAt: '2026-04-16T00:00:00.000Z' }]
+      })
+      await castVote({ issueNumber: 2, action: 'up' })
+      const prefs = await readPreferences()
+      expect(prefs.votesCast.map((v) => v.issueNumber)).toEqual([1, 2])
+    })
+  })
+})

--- a/src/__tests__/unit/skill/preferences.spec.ts
+++ b/src/__tests__/unit/skill/preferences.spec.ts
@@ -79,7 +79,10 @@ describe('skill/preferences', () => {
       prefsPath,
       JSON.stringify({
         filedRequests: [{ issueNumber: 1, repoUrl: 'u', title: 't', openedAt: 'ts' }, { garbage: true }, 'not-an-object'],
-        votesCast: [{ issueNumber: 9, direction: 'up', castAt: 'ts' }, { issueNumber: 10, direction: 'sideways', castAt: 'ts' }]
+        votesCast: [
+          { issueNumber: 9, direction: 'up', castAt: 'ts' },
+          { issueNumber: 10, direction: 'sideways', castAt: 'ts' }
+        ]
       }),
       'utf8'
     )

--- a/src/__tests__/unit/skill/preferences.spec.ts
+++ b/src/__tests__/unit/skill/preferences.spec.ts
@@ -35,7 +35,9 @@ describe('skill/preferences', () => {
       skillInstallOptIn: true,
       cliGlobalInstalled: true,
       votingOptIn: 'never' as const,
-      lastVoteSurveyAt: '2026-04-17T00:00:00.000Z'
+      lastVoteSurveyAt: '2026-04-17T00:00:00.000Z',
+      filedRequests: [{ issueNumber: 42, repoUrl: 'https://github.com/DiamondForgeFr/SaaSFoundry/issues/42', title: 'Add Stripe', openedAt: '2026-04-17T10:00:00.000Z' }],
+      votesCast: [{ issueNumber: 99, direction: 'up' as const, castAt: '2026-04-17T11:00:00.000Z' }]
     }
     await writePreferences(input)
     const read = await readPreferences()
@@ -68,6 +70,22 @@ describe('skill/preferences', () => {
     await writeFile(filePath, 'not-json', 'utf8')
     const prefs = await readPreferences()
     expect(prefs).toEqual(DEFAULT_PREFERENCES)
+  })
+
+  it('drops invalid entries in filedRequests / votesCast', async () => {
+    const prefsPath = path.join(tempHome, '.saasfoundry', 'preferences.json')
+    await writePreferences(DEFAULT_PREFERENCES)
+    await writeFile(
+      prefsPath,
+      JSON.stringify({
+        filedRequests: [{ issueNumber: 1, repoUrl: 'u', title: 't', openedAt: 'ts' }, { garbage: true }, 'not-an-object'],
+        votesCast: [{ issueNumber: 9, direction: 'up', castAt: 'ts' }, { issueNumber: 10, direction: 'sideways', castAt: 'ts' }]
+      }),
+      'utf8'
+    )
+    const prefs = await readPreferences()
+    expect(prefs.filedRequests).toEqual([{ issueNumber: 1, repoUrl: 'u', title: 't', openedAt: 'ts' }])
+    expect(prefs.votesCast).toEqual([{ issueNumber: 9, direction: 'up', castAt: 'ts' }])
   })
 
   it('updatePreferences merges a patch into existing prefs', async () => {

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import inquirer from 'inquirer'
 
 import { version as cliVersion } from '../../package.json'
+import { fileBug, searchExistingBugs, type BugSource } from '../feedback/bug'
 import { fileRequest, searchExistingRequests } from '../feedback/request'
 import type { GhIssue } from '../feedback/gh'
 
@@ -10,6 +11,9 @@ type FeedbackSubcommand = 'request' | 'bug' | 'list' | 'vote'
 interface ParsedArgs {
   positional: string[]
   description?: string
+  title?: string
+  source?: string
+  autoRepro: boolean
   force: boolean
   yes: boolean
   nonInteractive: boolean
@@ -18,26 +22,27 @@ interface ParsedArgs {
 function parseArgs(args: string[]): ParsedArgs {
   const positional: string[] = []
   let description: string | undefined
+  let title: string | undefined
+  let source: string | undefined
+  let autoRepro = false
   let force = false
   let yes = false
   let nonInteractive = false
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
-    if (arg === '--description') {
-      description = args[++i]
-    } else if (arg?.startsWith('--description=')) {
-      description = arg.slice('--description='.length)
-    } else if (arg === '--force') {
-      force = true
-    } else if (arg === '--yes' || arg === '-y') {
-      yes = true
-    } else if (arg === '--non-interactive') {
-      nonInteractive = true
-    } else if (arg !== undefined && arg !== null && arg !== '') {
-      positional.push(arg)
-    }
+    if (arg === '--description') description = args[++i]
+    else if (arg?.startsWith('--description=')) description = arg.slice('--description='.length)
+    else if (arg === '--title') title = args[++i]
+    else if (arg?.startsWith('--title=')) title = arg.slice('--title='.length)
+    else if (arg === '--source') source = args[++i]
+    else if (arg?.startsWith('--source=')) source = arg.slice('--source='.length)
+    else if (arg === '--auto-repro') autoRepro = true
+    else if (arg === '--force') force = true
+    else if (arg === '--yes' || arg === '-y') yes = true
+    else if (arg === '--non-interactive') nonInteractive = true
+    else if (arg !== undefined && arg !== null && arg !== '') positional.push(arg)
   }
-  return { positional, description, force, yes, nonInteractive }
+  return { positional, description, title, source, autoRepro, force, yes, nonInteractive }
 }
 
 export async function feedbackCommand(subcommand?: string, ...args: string[]) {
@@ -51,6 +56,9 @@ export async function feedbackCommand(subcommand?: string, ...args: string[]) {
   switch (subcommand as FeedbackSubcommand) {
     case 'request':
       await runRequest(parsed)
+      break
+    case 'bug':
+      await runBug(parsed)
       break
     default:
       console.error(chalk.red(`Unknown subcommand: ${subcommand}`))
@@ -66,6 +74,9 @@ function showHelp() {
   console.log(chalk.white('  Subcommands:'))
   console.log(chalk.gray('    request <name>  [--description <text>] [--force] [--yes]'))
   console.log(chalk.gray('                    Open a new module-request issue on the SaaSFoundry repo.'))
+  console.log(chalk.gray('    bug             [--source cli|scaffold] [--title <t>] [--description <d>]'))
+  console.log(chalk.gray('                    [--auto-repro] [--force]'))
+  console.log(chalk.gray('                    Open a bug report against the CLI or generated scaffolds.'))
   console.log()
 }
 
@@ -132,6 +143,120 @@ async function runRequest(opts: ParsedArgs) {
 
 function printMatches(matches: GhIssue[]): void {
   console.log(chalk.yellow(`\n  Found ${matches.length} similar request${matches.length === 1 ? '' : 's'}:\n`))
+  for (const issue of matches) {
+    const state = issue.state === 'OPEN' ? chalk.green('OPEN  ') : chalk.gray('CLOSED')
+    console.log(chalk.gray(`    ${state}  #${issue.number}  ${issue.title}`))
+    console.log(chalk.gray(`            ${issue.url}`))
+  }
+}
+
+async function runBug(opts: ParsedArgs) {
+  const source = await resolveBugSource(opts)
+  if (!source) return
+
+  const title = await resolveBugTitle(opts)
+  if (!title) return
+
+  const { matches } = await searchExistingBugs(source, title)
+  if (matches.length > 0 && !opts.force) {
+    printBugMatches(matches)
+    if (opts.nonInteractive || opts.yes || !process.stdin.isTTY) {
+      console.log(chalk.yellow('\n  Similar bugs found. Re-run with --force to file a new one anyway.'))
+      return
+    }
+    const { proceed } = await inquirer.prompt([{ type: 'confirm', name: 'proceed', message: 'File a new bug anyway?', default: false }])
+    if (!proceed) {
+      console.log(chalk.yellow('  Bug report aborted.'))
+      return
+    }
+  }
+
+  let description = opts.description ?? ''
+  if (!description.trim()) {
+    if (opts.nonInteractive) {
+      console.error(chalk.red('Error: --description is required in --non-interactive mode.'))
+      process.exit(1)
+    }
+    if (process.stdin.isTTY) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'description',
+          message: 'Describe the bug (steps, expected vs actual):',
+          validate: (v: string) => v.trim().length > 0 || 'Description cannot be empty.'
+        }
+      ])
+      description = answer.description
+    }
+  }
+
+  const result = await fileBug({
+    title,
+    description,
+    source,
+    cliVersion,
+    includeRepro: opts.autoRepro
+  })
+
+  console.log(chalk.green(`\n  ✓ Filed bug #${result.issue.number}`))
+  console.log(chalk.gray(`    Title: ${result.issue.title}`))
+  console.log(chalk.gray(`    URL:   ${result.issue.url}`))
+  console.log(chalk.gray(`    Label: ${source === 'cli' ? 'cli-bug' : 'scaffold-bug'}`))
+  console.log()
+}
+
+async function resolveBugSource(opts: ParsedArgs): Promise<BugSource | null> {
+  if (opts.source === 'cli' || opts.source === 'scaffold') return opts.source
+  if (opts.source !== undefined) {
+    console.error(chalk.red(`Error: --source must be 'cli' or 'scaffold' (got: ${opts.source})`))
+    process.exit(1)
+  }
+  if (opts.nonInteractive) {
+    console.error(chalk.red('Error: --source is required in --non-interactive mode.'))
+    process.exit(1)
+  }
+  if (!process.stdin.isTTY) {
+    console.error(chalk.red('Error: --source is required when stdin is not a TTY.'))
+    process.exit(1)
+  }
+  const { picked } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'picked',
+      message: 'Where did the bug happen?',
+      choices: [
+        { name: 'In the sf CLI itself (commands, prompts, flags)', value: 'cli' },
+        { name: 'In a generated project (scaffold/blueprint/overlay)', value: 'scaffold' }
+      ]
+    }
+  ])
+  return picked as BugSource
+}
+
+async function resolveBugTitle(opts: ParsedArgs): Promise<string | null> {
+  const fromArg = opts.title ?? opts.positional[0]
+  if (fromArg && fromArg.trim()) return fromArg.trim()
+  if (opts.nonInteractive) {
+    console.error(chalk.red('Error: --title is required in --non-interactive mode.'))
+    process.exit(1)
+  }
+  if (!process.stdin.isTTY) {
+    console.error(chalk.red('Error: a title is required when stdin is not a TTY. Use --title.'))
+    process.exit(1)
+  }
+  const { picked } = await inquirer.prompt([
+    {
+      type: 'input',
+      name: 'picked',
+      message: 'Bug title (one-line summary):',
+      validate: (v: string) => v.trim().length > 0 || 'Title cannot be empty.'
+    }
+  ])
+  return picked.trim()
+}
+
+function printBugMatches(matches: GhIssue[]): void {
+  console.log(chalk.yellow(`\n  Found ${matches.length} similar bug${matches.length === 1 ? '' : 's'}:\n`))
   for (const issue of matches) {
     const state = issue.state === 'OPEN' ? chalk.green('OPEN  ') : chalk.gray('CLOSED')
     console.log(chalk.gray(`    ${state}  #${issue.number}  ${issue.title}`))

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer'
 
 import { version as cliVersion } from '../../package.json'
 import { fileBug, searchExistingBugs, type BugSource } from '../feedback/bug'
+import { classifyIssue, listFeedback, type ListStatus } from '../feedback/list'
 import { fileRequest, searchExistingRequests } from '../feedback/request'
 import type { GhIssue } from '../feedback/gh'
 
@@ -13,6 +14,10 @@ interface ParsedArgs {
   description?: string
   title?: string
   source?: string
+  status?: string
+  limit?: number
+  mine: boolean
+  json: boolean
   autoRepro: boolean
   force: boolean
   yes: boolean
@@ -24,6 +29,10 @@ function parseArgs(args: string[]): ParsedArgs {
   let description: string | undefined
   let title: string | undefined
   let source: string | undefined
+  let status: string | undefined
+  let limit: number | undefined
+  let mine = false
+  let json = false
   let autoRepro = false
   let force = false
   let yes = false
@@ -36,13 +45,25 @@ function parseArgs(args: string[]): ParsedArgs {
     else if (arg?.startsWith('--title=')) title = arg.slice('--title='.length)
     else if (arg === '--source') source = args[++i]
     else if (arg?.startsWith('--source=')) source = arg.slice('--source='.length)
+    else if (arg === '--status') status = args[++i]
+    else if (arg?.startsWith('--status=')) status = arg.slice('--status='.length)
+    else if (arg === '--limit') limit = parseLimit(args[++i])
+    else if (arg?.startsWith('--limit=')) limit = parseLimit(arg.slice('--limit='.length))
+    else if (arg === '--mine') mine = true
+    else if (arg === '--json') json = true
     else if (arg === '--auto-repro') autoRepro = true
     else if (arg === '--force') force = true
     else if (arg === '--yes' || arg === '-y') yes = true
     else if (arg === '--non-interactive') nonInteractive = true
     else if (arg !== undefined && arg !== null && arg !== '') positional.push(arg)
   }
-  return { positional, description, title, source, autoRepro, force, yes, nonInteractive }
+  return { positional, description, title, source, status, limit, mine, json, autoRepro, force, yes, nonInteractive }
+}
+
+function parseLimit(raw: string | undefined): number | undefined {
+  if (!raw) return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : undefined
 }
 
 export async function feedbackCommand(subcommand?: string, ...args: string[]) {
@@ -59,6 +80,9 @@ export async function feedbackCommand(subcommand?: string, ...args: string[]) {
       break
     case 'bug':
       await runBug(parsed)
+      break
+    case 'list':
+      await runList(parsed)
       break
     default:
       console.error(chalk.red(`Unknown subcommand: ${subcommand}`))
@@ -77,6 +101,8 @@ function showHelp() {
   console.log(chalk.gray('    bug             [--source cli|scaffold] [--title <t>] [--description <d>]'))
   console.log(chalk.gray('                    [--auto-repro] [--force]'))
   console.log(chalk.gray('                    Open a bug report against the CLI or generated scaffolds.'))
+  console.log(chalk.gray('    list            [--status open|closed|all] [--mine] [--json] [--limit <n>]'))
+  console.log(chalk.gray('                    List feedback issues (module-request + cli-bug + scaffold-bug).'))
   console.log()
 }
 
@@ -262,4 +288,49 @@ function printBugMatches(matches: GhIssue[]): void {
     console.log(chalk.gray(`    ${state}  #${issue.number}  ${issue.title}`))
     console.log(chalk.gray(`            ${issue.url}`))
   }
+}
+
+async function runList(opts: ParsedArgs) {
+  const status = resolveListStatus(opts.status)
+  const { repo, issues } = await listFeedback({ status, mine: opts.mine, limit: opts.limit })
+
+  if (opts.json) {
+    const payload = issues.map((i) => ({
+      number: i.number,
+      title: i.title,
+      state: i.state,
+      url: i.url,
+      kind: classifyIssue(i),
+      labels: i.labels.map((l) => l.name),
+      author: i.author.login
+    }))
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n')
+    return
+  }
+
+  if (issues.length === 0) {
+    console.log(chalk.yellow(`\n  No feedback issues found in ${repo.slug} (status=${status}${opts.mine ? ', mine' : ''}).`))
+    console.log()
+    return
+  }
+
+  console.log(chalk.blue(`\n  ${issues.length} feedback issue${issues.length === 1 ? '' : 's'} in ${repo.slug}  (status=${status}${opts.mine ? ', mine' : ''})`))
+  console.log(chalk.blue('  ' + '─'.repeat(72)))
+  for (const issue of issues) {
+    const state = issue.state === 'OPEN' ? chalk.green('OPEN  ') : chalk.gray('CLOSED')
+    const kind = classifyIssue(issue)
+    const kindTag = kind === 'module-request' ? chalk.cyan('[request] ') : kind === 'cli-bug' ? chalk.red('[cli-bug]  ') : kind === 'scaffold-bug' ? chalk.magenta('[scaf-bug] ') : chalk.gray('[other]   ')
+    console.log(`  ${state}  ${kindTag}#${issue.number}  ${issue.title}`)
+    console.log(chalk.gray(`                      ${issue.url}`))
+  }
+  console.log()
+}
+
+function resolveListStatus(raw: string | undefined): ListStatus {
+  if (raw === 'open' || raw === 'closed' || raw === 'all') return raw
+  if (raw !== undefined) {
+    console.error(chalk.red(`Error: --status must be 'open', 'closed', or 'all' (got: ${raw})`))
+    process.exit(1)
+  }
+  return 'open'
 }

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,0 +1,140 @@
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+
+import { version as cliVersion } from '../../package.json'
+import { fileRequest, searchExistingRequests } from '../feedback/request'
+import type { GhIssue } from '../feedback/gh'
+
+type FeedbackSubcommand = 'request' | 'bug' | 'list' | 'vote'
+
+interface ParsedArgs {
+  positional: string[]
+  description?: string
+  force: boolean
+  yes: boolean
+  nonInteractive: boolean
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const positional: string[] = []
+  let description: string | undefined
+  let force = false
+  let yes = false
+  let nonInteractive = false
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === '--description') {
+      description = args[++i]
+    } else if (arg?.startsWith('--description=')) {
+      description = arg.slice('--description='.length)
+    } else if (arg === '--force') {
+      force = true
+    } else if (arg === '--yes' || arg === '-y') {
+      yes = true
+    } else if (arg === '--non-interactive') {
+      nonInteractive = true
+    } else if (arg !== undefined && arg !== null && arg !== '') {
+      positional.push(arg)
+    }
+  }
+  return { positional, description, force, yes, nonInteractive }
+}
+
+export async function feedbackCommand(subcommand?: string, ...args: string[]) {
+  if (!subcommand) {
+    showHelp()
+    return
+  }
+
+  const parsed = parseArgs(args)
+
+  switch (subcommand as FeedbackSubcommand) {
+    case 'request':
+      await runRequest(parsed)
+      break
+    default:
+      console.error(chalk.red(`Unknown subcommand: ${subcommand}`))
+      showHelp()
+      process.exit(1)
+  }
+}
+
+function showHelp() {
+  console.log(chalk.blue('\n  SaaSFoundry Feedback - File requests, bugs, and vote on proposals'))
+  console.log(chalk.blue('  ' + '─'.repeat(60)))
+  console.log(chalk.white('\n  Usage: sf feedback <subcommand> [options]\n'))
+  console.log(chalk.white('  Subcommands:'))
+  console.log(chalk.gray('    request <name>  [--description <text>] [--force] [--yes]'))
+  console.log(chalk.gray('                    Open a new module-request issue on the SaaSFoundry repo.'))
+  console.log()
+}
+
+async function runRequest(opts: ParsedArgs) {
+  const name = opts.positional[0]
+  if (!name) {
+    console.error(chalk.red('Error: missing <name>. Usage: sf feedback request <name>'))
+    process.exit(1)
+  }
+
+  const { repo, matches } = await searchExistingRequests(name)
+
+  if (matches.length > 0 && !opts.force) {
+    printMatches(matches)
+    if (opts.nonInteractive || opts.yes) {
+      console.log(chalk.yellow('\n  Similar requests found. Re-run with --force to file a new one anyway.'))
+      return
+    }
+    if (!process.stdin.isTTY) {
+      console.log(chalk.yellow('\n  Similar requests found. Re-run with --force to file a new one anyway.'))
+      return
+    }
+    const { proceed } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'proceed',
+        message: 'File a new request anyway?',
+        default: false
+      }
+    ])
+    if (!proceed) {
+      console.log(chalk.yellow('  Request aborted. Consider voting on one of the above with `sf feedback vote`.'))
+      return
+    }
+  }
+
+  let description = opts.description ?? ''
+  if (!description.trim()) {
+    if (opts.nonInteractive) {
+      console.error(chalk.red('Error: --description is required in --non-interactive mode.'))
+      process.exit(1)
+    }
+    if (process.stdin.isTTY) {
+      const answer = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'description',
+          message: 'Describe the module you want (one or two sentences):',
+          validate: (v: string) => v.trim().length > 0 || 'Description cannot be empty.'
+        }
+      ])
+      description = answer.description
+    }
+  }
+
+  const result = await fileRequest({ name, description, cliVersion, forceCreate: opts.force })
+
+  console.log(chalk.green(`\n  ✓ Filed request #${result.issue.number}`))
+  console.log(chalk.gray(`    Title: ${result.issue.title}`))
+  console.log(chalk.gray(`    URL:   ${result.issue.url}`))
+  console.log(chalk.gray(`    Repo:  ${repo.slug}`))
+  console.log()
+}
+
+function printMatches(matches: GhIssue[]): void {
+  console.log(chalk.yellow(`\n  Found ${matches.length} similar request${matches.length === 1 ? '' : 's'}:\n`))
+  for (const issue of matches) {
+    const state = issue.state === 'OPEN' ? chalk.green('OPEN  ') : chalk.gray('CLOSED')
+    console.log(chalk.gray(`    ${state}  #${issue.number}  ${issue.title}`))
+    console.log(chalk.gray(`            ${issue.url}`))
+  }
+}

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -319,7 +319,8 @@ async function runList(opts: ParsedArgs) {
   for (const issue of issues) {
     const state = issue.state === 'OPEN' ? chalk.green('OPEN  ') : chalk.gray('CLOSED')
     const kind = classifyIssue(issue)
-    const kindTag = kind === 'module-request' ? chalk.cyan('[request] ') : kind === 'cli-bug' ? chalk.red('[cli-bug]  ') : kind === 'scaffold-bug' ? chalk.magenta('[scaf-bug] ') : chalk.gray('[other]   ')
+    const kindTag =
+      kind === 'module-request' ? chalk.cyan('[request] ') : kind === 'cli-bug' ? chalk.red('[cli-bug]  ') : kind === 'scaffold-bug' ? chalk.magenta('[scaf-bug] ') : chalk.gray('[other]   ')
     console.log(`  ${state}  ${kindTag}#${issue.number}  ${issue.title}`)
     console.log(chalk.gray(`                      ${issue.url}`))
   }

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -5,6 +5,7 @@ import { version as cliVersion } from '../../package.json'
 import { fileBug, searchExistingBugs, type BugSource } from '../feedback/bug'
 import { classifyIssue, listFeedback, type ListStatus } from '../feedback/list'
 import { fileRequest, searchExistingRequests } from '../feedback/request'
+import { castVote, listVotable, type VoteAction } from '../feedback/vote'
 import type { GhIssue } from '../feedback/gh'
 
 type FeedbackSubcommand = 'request' | 'bug' | 'list' | 'vote'
@@ -16,6 +17,9 @@ interface ParsedArgs {
   source?: string
   status?: string
   limit?: number
+  stackFilter?: string
+  comment?: string
+  list: boolean
   mine: boolean
   json: boolean
   autoRepro: boolean
@@ -31,6 +35,9 @@ function parseArgs(args: string[]): ParsedArgs {
   let source: string | undefined
   let status: string | undefined
   let limit: number | undefined
+  let stackFilter: string | undefined
+  let comment: string | undefined
+  let list = false
   let mine = false
   let json = false
   let autoRepro = false
@@ -49,6 +56,11 @@ function parseArgs(args: string[]): ParsedArgs {
     else if (arg?.startsWith('--status=')) status = arg.slice('--status='.length)
     else if (arg === '--limit') limit = parseLimit(args[++i])
     else if (arg?.startsWith('--limit=')) limit = parseLimit(arg.slice('--limit='.length))
+    else if (arg === '--stack-filter') stackFilter = args[++i]
+    else if (arg?.startsWith('--stack-filter=')) stackFilter = arg.slice('--stack-filter='.length)
+    else if (arg === '--comment') comment = args[++i]
+    else if (arg?.startsWith('--comment=')) comment = arg.slice('--comment='.length)
+    else if (arg === '--list') list = true
     else if (arg === '--mine') mine = true
     else if (arg === '--json') json = true
     else if (arg === '--auto-repro') autoRepro = true
@@ -57,7 +69,7 @@ function parseArgs(args: string[]): ParsedArgs {
     else if (arg === '--non-interactive') nonInteractive = true
     else if (arg !== undefined && arg !== null && arg !== '') positional.push(arg)
   }
-  return { positional, description, title, source, status, limit, mine, json, autoRepro, force, yes, nonInteractive }
+  return { positional, description, title, source, status, limit, stackFilter, comment, list, mine, json, autoRepro, force, yes, nonInteractive }
 }
 
 function parseLimit(raw: string | undefined): number | undefined {
@@ -84,6 +96,9 @@ export async function feedbackCommand(subcommand?: string, ...args: string[]) {
     case 'list':
       await runList(parsed)
       break
+    case 'vote':
+      await runVote(parsed)
+      break
     default:
       console.error(chalk.red(`Unknown subcommand: ${subcommand}`))
       showHelp()
@@ -103,6 +118,10 @@ function showHelp() {
   console.log(chalk.gray('                    Open a bug report against the CLI or generated scaffolds.'))
   console.log(chalk.gray('    list            [--status open|closed|all] [--mine] [--json] [--limit <n>]'))
   console.log(chalk.gray('                    List feedback issues (module-request + cli-bug + scaffold-bug).'))
+  console.log(chalk.gray('    vote --list     [--stack-filter <term>] [--limit <n>] [--json]'))
+  console.log(chalk.gray('                    Top module requests ranked by 👍 reaction count.'))
+  console.log(chalk.gray('    vote <n> up|down|comment [--comment <body>]'))
+  console.log(chalk.gray('                    Cast a 👍/👎 reaction or post a comment on request #n.'))
   console.log()
 }
 
@@ -334,4 +353,90 @@ function resolveListStatus(raw: string | undefined): ListStatus {
     process.exit(1)
   }
   return 'open'
+}
+
+async function runVote(opts: ParsedArgs) {
+  if (opts.list) {
+    await runVoteList(opts)
+    return
+  }
+  await runVoteCast(opts)
+}
+
+async function runVoteList(opts: ParsedArgs) {
+  const { repo, issues } = await listVotable({ stackFilter: opts.stackFilter, limit: opts.limit })
+
+  if (opts.json) {
+    const payload = issues.map((r) => ({
+      number: r.issue.number,
+      title: r.issue.title,
+      url: r.issue.url,
+      thumbsUp: r.thumbsUp,
+      thumbsDown: r.thumbsDown
+    }))
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n')
+    return
+  }
+
+  if (issues.length === 0) {
+    console.log(chalk.yellow(`\n  No module requests found in ${repo.slug}${opts.stackFilter ? ` matching "${opts.stackFilter}"` : ''}.\n`))
+    return
+  }
+
+  console.log(chalk.blue(`\n  Top ${issues.length} module request${issues.length === 1 ? '' : 's'} in ${repo.slug}${opts.stackFilter ? ` (filter: "${opts.stackFilter}")` : ''}`))
+  console.log(chalk.blue('  ' + '─'.repeat(72)))
+  for (const { issue, thumbsUp, thumbsDown } of issues) {
+    const score = `${chalk.green('👍 ' + String(thumbsUp).padStart(3))}  ${chalk.red('👎 ' + String(thumbsDown).padStart(2))}`
+    console.log(`  ${score}  #${issue.number}  ${issue.title}`)
+    console.log(chalk.gray(`                 ${issue.url}`))
+  }
+  console.log(chalk.gray('\n  Cast a vote with: sf feedback vote <number> up|down|comment\n'))
+}
+
+async function runVoteCast(opts: ParsedArgs) {
+  const issueNumber = parseIssueNumber(opts.positional[0])
+  const action = parseVoteAction(opts.positional[1])
+
+  let comment = opts.comment
+  if (action === 'comment' && !comment?.trim()) {
+    if (opts.nonInteractive) {
+      console.error(chalk.red('Error: --comment is required with action=comment in --non-interactive mode.'))
+      process.exit(1)
+    }
+    if (!process.stdin.isTTY) {
+      console.error(chalk.red('Error: --comment is required with action=comment when stdin is not a TTY.'))
+      process.exit(1)
+    }
+    const answer = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'comment',
+        message: `Comment to post on #${issueNumber}:`,
+        validate: (v: string) => v.trim().length > 0 || 'Comment cannot be empty.'
+      }
+    ])
+    comment = answer.comment
+  }
+
+  const result = await castVote({ issueNumber, action, comment })
+
+  if (action === 'up') console.log(chalk.green(`\n  ✓ 👍 on #${result.issueNumber} in ${result.repo.slug}`))
+  else if (action === 'down') console.log(chalk.red(`\n  ✓ 👎 on #${result.issueNumber} in ${result.repo.slug}`))
+  else console.log(chalk.green(`\n  ✓ Comment posted on #${result.issueNumber} in ${result.repo.slug}`))
+  console.log()
+}
+
+function parseIssueNumber(raw: string | undefined): number {
+  const n = raw === undefined ? NaN : Number(raw)
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) {
+    console.error(chalk.red('Error: expected a positive issue number. Usage: sf feedback vote <n> up|down|comment'))
+    process.exit(1)
+  }
+  return n
+}
+
+function parseVoteAction(raw: string | undefined): VoteAction {
+  if (raw === 'up' || raw === 'down' || raw === 'comment') return raw
+  console.error(chalk.red(`Error: action must be 'up', 'down', or 'comment' (got: ${raw ?? '<missing>'})`))
+  process.exit(1)
 }

--- a/src/feedback/bug.ts
+++ b/src/feedback/bug.ts
@@ -1,0 +1,112 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+
+import { fileExists } from '../utils'
+import { ensureGhAuth, ghIssueCreate, ghIssueSearch, type GhIssue } from './gh'
+import { readFeedbackRepo, type FeedbackRepo } from './repo'
+
+export type BugSource = 'cli' | 'scaffold'
+
+export interface BugReproContext {
+  cliVersion: string
+  nodeVersion: string
+  platform: string
+  arch: string
+  saasfoundryJson: string | null
+}
+
+export interface FileBugInput {
+  title: string
+  description: string
+  source: BugSource
+  cliVersion: string
+  includeRepro: boolean
+  cwd?: string
+}
+
+export interface BugSearchResult {
+  repo: FeedbackRepo
+  matches: GhIssue[]
+}
+
+export interface FileBugResult {
+  repo: FeedbackRepo
+  issue: GhIssue
+}
+
+export function bugLabel(source: BugSource): string {
+  return source === 'cli' ? 'cli-bug' : 'scaffold-bug'
+}
+
+export async function searchExistingBugs(source: BugSource, title: string): Promise<BugSearchResult> {
+  await ensureGhAuth()
+  const repo = await readFeedbackRepo()
+  const matches = await ghIssueSearch({
+    repo: repo.slug,
+    labels: [bugLabel(source)],
+    state: 'all',
+    search: title,
+    limit: 10
+  })
+  return { repo, matches }
+}
+
+export async function collectReproContext(cliVersion: string, cwd: string = process.cwd()): Promise<BugReproContext> {
+  return {
+    cliVersion,
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    saasfoundryJson: await readSaasFoundryJson(cwd)
+  }
+}
+
+export async function fileBug(input: FileBugInput): Promise<FileBugResult> {
+  await ensureGhAuth()
+  const repo = await readFeedbackRepo()
+  const repro = input.includeRepro ? await collectReproContext(input.cliVersion, input.cwd) : null
+  const body = formatBugBody(input, repro)
+  const issue = await ghIssueCreate({
+    repo: repo.slug,
+    title: input.title,
+    body,
+    labels: [bugLabel(input.source)]
+  })
+  return { repo, issue }
+}
+
+export function formatBugBody(input: FileBugInput, repro: BugReproContext | null): string {
+  const lines = ['## Bug', '', input.description.trim() || '_(no description provided)_', '', '---', '', `**Source:** ${input.source}`]
+  if (repro) {
+    lines.push(`**CLI version:** ${repro.cliVersion}`)
+    lines.push(`**Node:** ${repro.nodeVersion}`)
+    lines.push(`**Platform:** ${repro.platform} (${repro.arch})`)
+    lines.push('')
+    if (repro.saasfoundryJson) {
+      lines.push('<details>')
+      lines.push('<summary>.saasfoundry.json</summary>')
+      lines.push('')
+      lines.push('```json')
+      lines.push(repro.saasfoundryJson)
+      lines.push('```')
+      lines.push('</details>')
+    } else {
+      lines.push('_(no .saasfoundry.json found in cwd)_')
+    }
+  } else {
+    lines.push(`**CLI version:** ${input.cliVersion}`)
+  }
+  lines.push('')
+  lines.push('_Filed via `sf feedback bug`._')
+  return lines.join('\n')
+}
+
+async function readSaasFoundryJson(cwd: string): Promise<string | null> {
+  const filePath = path.join(cwd, '.saasfoundry.json')
+  if (!(await fileExists(filePath))) return null
+  try {
+    return (await readFile(filePath, 'utf8')).trim()
+  } catch {
+    return null
+  }
+}

--- a/src/feedback/gh.ts
+++ b/src/feedback/gh.ts
@@ -41,7 +41,7 @@ export async function execGh(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile('gh', args, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
       if (err) {
-        const stderrText = typeof stderr === 'string' ? stderr : (stderr as Buffer | undefined)?.toString() ?? ''
+        const stderrText = typeof stderr === 'string' ? stderr : ((stderr as Buffer | undefined)?.toString() ?? '')
         reject(new Error(`gh ${args.join(' ')} failed: ${stderrText.trim() || err.message}`))
         return
       }

--- a/src/feedback/gh.ts
+++ b/src/feedback/gh.ts
@@ -1,0 +1,93 @@
+import { execFile } from 'child_process'
+
+export interface GhIssue {
+  number: number
+  title: string
+  state: 'OPEN' | 'CLOSED'
+  url: string
+  labels: { name: string }[]
+  author: { login: string }
+  reactionGroups?: { content: string; users: { totalCount: number } }[]
+}
+
+export interface GhIssueSearchOptions {
+  repo: string
+  labels?: string[]
+  state?: 'open' | 'closed' | 'all'
+  search?: string
+  author?: string
+  limit?: number
+}
+
+export interface GhIssueCreateOptions {
+  repo: string
+  title: string
+  body: string
+  labels?: string[]
+}
+
+export interface GhReactionOptions {
+  repo: string
+  issueNumber: number
+  content: '+1' | '-1'
+}
+
+/**
+ * Thin wrapper around the `gh` CLI. We call it via `execFile` (no shell
+ * interpolation) to avoid quoting pitfalls. Callers are expected to check
+ * `gh auth status` separately (see {@link ensureGhAuth}).
+ */
+export async function execGh(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('gh', args, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (err) {
+        const stderrText = typeof stderr === 'string' ? stderr : (stderr as Buffer | undefined)?.toString() ?? ''
+        reject(new Error(`gh ${args.join(' ')} failed: ${stderrText.trim() || err.message}`))
+        return
+      }
+      resolve(typeof stdout === 'string' ? stdout : (stdout as Buffer).toString())
+    })
+  })
+}
+
+export async function ensureGhAuth(): Promise<void> {
+  try {
+    await execGh(['auth', 'status'])
+  } catch {
+    throw new Error('GitHub CLI is not authenticated. Run: gh auth login')
+  }
+}
+
+export async function ghIssueSearch(opts: GhIssueSearchOptions): Promise<GhIssue[]> {
+  const args = ['issue', 'list', '--repo', opts.repo, '--json', 'number,title,state,url,labels,author,reactionGroups']
+  if (opts.state) args.push('--state', opts.state)
+  if (opts.author) args.push('--author', opts.author)
+  if (opts.labels && opts.labels.length > 0) args.push('--label', opts.labels.join(','))
+  if (opts.search) args.push('--search', opts.search)
+  if (opts.limit) args.push('--limit', String(opts.limit))
+  const raw = await execGh(args)
+  return JSON.parse(raw) as GhIssue[]
+}
+
+export async function ghIssueCreate(opts: GhIssueCreateOptions): Promise<GhIssue> {
+  const args = ['issue', 'create', '--repo', opts.repo, '--title', opts.title, '--body', opts.body]
+  if (opts.labels && opts.labels.length > 0) args.push('--label', opts.labels.join(','))
+  const raw = await execGh(args)
+  const url = raw.trim().split('\n').pop()?.trim() ?? ''
+  const match = url.match(/\/issues\/(\d+)/)
+  const number = match ? Number(match[1]) : 0
+  return { number, url, title: opts.title, state: 'OPEN', labels: (opts.labels ?? []).map((name) => ({ name })), author: { login: '' } }
+}
+
+export async function ghIssueComment(repo: string, issueNumber: number, body: string): Promise<void> {
+  await execGh(['issue', 'comment', String(issueNumber), '--repo', repo, '--body', body])
+}
+
+export async function ghAddReaction(opts: GhReactionOptions): Promise<void> {
+  await execGh(['api', '--method', 'POST', '-H', 'Accept: application/vnd.github+json', `/repos/${opts.repo}/issues/${opts.issueNumber}/reactions`, '-f', `content=${opts.content}`])
+}
+
+export async function ghCurrentUser(): Promise<string> {
+  const raw = await execGh(['api', 'user', '--jq', '.login'])
+  return raw.trim()
+}

--- a/src/feedback/list.ts
+++ b/src/feedback/list.ts
@@ -1,0 +1,55 @@
+import { ensureGhAuth, ghCurrentUser, ghIssueSearch, type GhIssue } from './gh'
+import { readFeedbackRepo, type FeedbackRepo } from './repo'
+
+export type ListStatus = 'open' | 'closed' | 'all'
+
+export const FEEDBACK_LABELS = ['module-request', 'cli-bug', 'scaffold-bug'] as const
+
+export interface ListFeedbackOptions {
+  status?: ListStatus
+  mine?: boolean
+  limit?: number
+}
+
+export interface ListFeedbackResult {
+  repo: FeedbackRepo
+  issues: GhIssue[]
+}
+
+export async function listFeedback(opts: ListFeedbackOptions = {}): Promise<ListFeedbackResult> {
+  await ensureGhAuth()
+  const repo = await readFeedbackRepo()
+  const state: ListStatus = opts.status ?? 'open'
+  const limit = opts.limit ?? 50
+  const author = opts.mine ? await ghCurrentUser() : undefined
+
+  const perLabelLimit = Math.max(1, Math.ceil(limit / FEEDBACK_LABELS.length))
+  const results: GhIssue[] = []
+  const seen = new Set<number>()
+
+  for (const label of FEEDBACK_LABELS) {
+    const batch = await ghIssueSearch({
+      repo: repo.slug,
+      labels: [label],
+      state,
+      author,
+      limit: perLabelLimit
+    })
+    for (const issue of batch) {
+      if (seen.has(issue.number)) continue
+      seen.add(issue.number)
+      results.push(issue)
+    }
+  }
+
+  results.sort((a, b) => b.number - a.number)
+  return { repo, issues: results.slice(0, limit) }
+}
+
+export function classifyIssue(issue: GhIssue): 'module-request' | 'cli-bug' | 'scaffold-bug' | 'other' {
+  const names = issue.labels.map((l) => l.name)
+  if (names.includes('module-request')) return 'module-request'
+  if (names.includes('cli-bug')) return 'cli-bug'
+  if (names.includes('scaffold-bug')) return 'scaffold-bug'
+  return 'other'
+}

--- a/src/feedback/repo.ts
+++ b/src/feedback/repo.ts
@@ -32,7 +32,10 @@ export async function readFeedbackRepo(): Promise<FeedbackRepo> {
 }
 
 export function parseGitHubUrl(url: string): FeedbackRepo | null {
-  const cleaned = url.replace(/^git\+/, '').replace(/\.git$/, '').trim()
+  const cleaned = url
+    .replace(/^git\+/, '')
+    .replace(/\.git$/, '')
+    .trim()
   const patterns = [/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/i, /^git@github\.com:([^/]+)\/([^/]+)\/?$/i, /^([^/\s]+)\/([^/\s]+)$/]
   for (const pattern of patterns) {
     const match = cleaned.match(pattern)

--- a/src/feedback/repo.ts
+++ b/src/feedback/repo.ts
@@ -1,0 +1,54 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+
+export interface FeedbackRepo {
+  owner: string
+  repo: string
+  slug: string
+  httpsUrl: string
+}
+
+/**
+ * Resolve the CLI package root by walking up from this file's runtime location.
+ *
+ * At runtime the compiled output lives at `dist/feedback/repo.js`, so
+ * `__dirname/../..` points at the published package root (which contains
+ * `package.json`). The same shape is preserved in source (`src/feedback/`)
+ * for jest runs via ts-jest.
+ */
+export function resolveCliPackageRoot(): string {
+  return path.resolve(__dirname, '..', '..')
+}
+
+export async function readFeedbackRepo(): Promise<FeedbackRepo> {
+  const pkgPath = path.join(resolveCliPackageRoot(), 'package.json')
+  const raw = await readFile(pkgPath, 'utf8')
+  const pkg = JSON.parse(raw) as { repository?: unknown }
+  const url = extractRepositoryUrl(pkg.repository)
+  if (!url) throw new Error(`SaaSFoundry feedback: package.json#repository is missing or malformed at ${pkgPath}`)
+  const parsed = parseGitHubUrl(url)
+  if (!parsed) throw new Error(`SaaSFoundry feedback: could not parse GitHub repo from ${url}`)
+  return parsed
+}
+
+export function parseGitHubUrl(url: string): FeedbackRepo | null {
+  const cleaned = url.replace(/^git\+/, '').replace(/\.git$/, '').trim()
+  const patterns = [/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/i, /^git@github\.com:([^/]+)\/([^/]+)\/?$/i, /^([^/\s]+)\/([^/\s]+)$/]
+  for (const pattern of patterns) {
+    const match = cleaned.match(pattern)
+    if (!match) continue
+    const owner = match[1]
+    const repo = match[2]
+    return { owner, repo, slug: `${owner}/${repo}`, httpsUrl: `https://github.com/${owner}/${repo}` }
+  }
+  return null
+}
+
+function extractRepositoryUrl(repository: unknown): string | null {
+  if (typeof repository === 'string') return repository
+  if (repository && typeof repository === 'object') {
+    const r = repository as { url?: unknown }
+    if (typeof r.url === 'string') return r.url
+  }
+  return null
+}

--- a/src/feedback/request.ts
+++ b/src/feedback/request.ts
@@ -1,0 +1,81 @@
+import { ensureGhAuth, ghIssueCreate, ghIssueSearch, type GhIssue } from './gh'
+import { readFeedbackRepo, type FeedbackRepo } from './repo'
+import { readPreferences, writePreferences } from '../skill/preferences'
+
+export interface FileRequestInput {
+  name: string
+  description: string
+  cliVersion: string
+  forceCreate?: boolean
+}
+
+export interface DedupResult {
+  repo: FeedbackRepo
+  matches: GhIssue[]
+}
+
+export interface FileRequestResult {
+  repo: FeedbackRepo
+  issue: GhIssue
+}
+
+export async function searchExistingRequests(name: string): Promise<DedupResult> {
+  await ensureGhAuth()
+  const repo = await readFeedbackRepo()
+  const matches = await ghIssueSearch({
+    repo: repo.slug,
+    labels: ['module-request'],
+    state: 'all',
+    search: name,
+    limit: 10
+  })
+  return { repo, matches }
+}
+
+export async function fileRequest(input: FileRequestInput): Promise<FileRequestResult> {
+  await ensureGhAuth()
+  const repo = await readFeedbackRepo()
+  const title = formatRequestTitle(input.name)
+  const body = formatRequestBody(input)
+  const issue = await ghIssueCreate({
+    repo: repo.slug,
+    title,
+    body,
+    labels: ['module-request']
+  })
+  const prefs = await readPreferences()
+  await writePreferences({
+    ...prefs,
+    filedRequests: [
+      ...prefs.filedRequests,
+      {
+        issueNumber: issue.number,
+        repoUrl: issue.url,
+        title,
+        openedAt: new Date().toISOString()
+      }
+    ]
+  })
+  return { repo, issue }
+}
+
+export function formatRequestTitle(name: string): string {
+  return `Module request: ${name.trim()}`
+}
+
+export function formatRequestBody(input: FileRequestInput): string {
+  const lines = [
+    '## Request',
+    '',
+    input.description.trim() || '_(no description provided)_',
+    '',
+    '---',
+    '',
+    `**CLI version:** ${input.cliVersion}`,
+    `**Platform:** ${process.platform} (${process.arch})`,
+    `**Node:** ${process.version}`,
+    '',
+    '_Filed via `sf feedback request`._'
+  ]
+  return lines.join('\n')
+}

--- a/src/feedback/vote.ts
+++ b/src/feedback/vote.ts
@@ -1,0 +1,98 @@
+import { ensureGhAuth, ghAddReaction, ghIssueComment, ghIssueSearch, type GhIssue } from './gh'
+import { readFeedbackRepo, type FeedbackRepo } from './repo'
+import { readPreferences, writePreferences } from '../skill/preferences'
+
+export type VoteAction = 'up' | 'down' | 'comment'
+
+export interface ListVotableOptions {
+  stackFilter?: string
+  limit?: number
+}
+
+export interface ListVotableResult {
+  repo: FeedbackRepo
+  issues: RankedIssue[]
+}
+
+export interface RankedIssue {
+  issue: GhIssue
+  thumbsUp: number
+  thumbsDown: number
+}
+
+export interface CastVoteInput {
+  issueNumber: number
+  action: VoteAction
+  comment?: string
+}
+
+export interface CastVoteResult {
+  repo: FeedbackRepo
+  action: VoteAction
+  issueNumber: number
+}
+
+export async function listVotable(opts: ListVotableOptions = {}): Promise<ListVotableResult> {
+  await ensureGhAuth()
+  const repo = await readFeedbackRepo()
+  const limit = opts.limit ?? 10
+  const raw = await ghIssueSearch({
+    repo: repo.slug,
+    labels: ['module-request'],
+    state: 'open',
+    search: opts.stackFilter,
+    limit: 100
+  })
+
+  const ranked = raw.map((issue) => ({
+    issue,
+    thumbsUp: countReaction(issue, 'THUMBS_UP'),
+    thumbsDown: countReaction(issue, 'THUMBS_DOWN')
+  }))
+
+  ranked.sort((a, b) => b.thumbsUp - a.thumbsUp || a.issue.number - b.issue.number)
+  return { repo, issues: ranked.slice(0, limit) }
+}
+
+export async function castVote(input: CastVoteInput): Promise<CastVoteResult> {
+  await ensureGhAuth()
+  const repo = await readFeedbackRepo()
+
+  if (input.action === 'up' || input.action === 'down') {
+    await ghAddReaction({
+      repo: repo.slug,
+      issueNumber: input.issueNumber,
+      content: input.action === 'up' ? '+1' : '-1'
+    })
+    await recordVote(input.issueNumber, input.action === 'up' ? 'up' : 'down')
+  } else {
+    const body = (input.comment ?? '').trim()
+    if (!body) throw new Error('sf feedback vote comment: --comment body cannot be empty')
+    await ghIssueComment(repo.slug, input.issueNumber, body)
+  }
+
+  return { repo, action: input.action, issueNumber: input.issueNumber }
+}
+
+export function countReaction(issue: GhIssue, content: string): number {
+  if (!issue.reactionGroups) return 0
+  for (const g of issue.reactionGroups) {
+    if (g.content === content) return g.users.totalCount
+  }
+  return 0
+}
+
+async function recordVote(issueNumber: number, direction: 'up' | 'down'): Promise<void> {
+  const prefs = await readPreferences()
+  await writePreferences({
+    ...prefs,
+    votesCast: [
+      ...prefs.votesCast,
+      {
+        issueNumber,
+        direction,
+        castAt: new Date().toISOString()
+      }
+    ]
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import 'module-alias/register'
 import { version } from '../package.json'
+import { feedbackCommand } from './commands/feedback'
 import { modulesCommand } from './commands/modules'
 import { newCommand } from './commands/new'
 import { skillCommand, runFullUninstall } from './commands/skill'
@@ -122,6 +123,13 @@ program
   .allowUnknownOption()
   .action((subcommand, args) => skillCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
 program
+  .command('feedback')
+  .description('File requests, bugs, and vote on SaaSFoundry proposals')
+  .argument('[subcommand]', 'Subcommand to execute (request, bug, list, vote)')
+  .argument('[args...]', 'Additional arguments for the subcommand')
+  .allowUnknownOption()
+  .action((subcommand, args) => feedbackCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
+program
   .command('uninstall')
   .description('Fully remove the SaaSFoundry skill and preferences (--all flag required)')
   .option('--all', 'Remove the skill (user + project scope) and wipe ~/.saasfoundry/')
@@ -135,4 +143,4 @@ program
   })
 program.parse()
 
-export { newCommand, updateCommand, modulesCommand, toolsCommand, workflowCommand, skillCommand }
+export { newCommand, updateCommand, modulesCommand, toolsCommand, workflowCommand, skillCommand, feedbackCommand }

--- a/src/skill/preferences.ts
+++ b/src/skill/preferences.ts
@@ -7,12 +7,29 @@ import { resolvePreferencesPath } from './paths'
 
 export type VotingOptIn = 'never' | 'ask' | 'always'
 
+export type VoteDirection = 'up' | 'down'
+
+export interface FiledRequest {
+  issueNumber: number
+  repoUrl: string
+  title: string
+  openedAt: string
+}
+
+export interface VoteRecord {
+  issueNumber: number
+  direction: VoteDirection
+  castAt: string
+}
+
 export interface Preferences {
   skillPromptAnswered: boolean
   skillInstallOptIn: boolean
   cliGlobalInstalled: boolean
   votingOptIn: VotingOptIn
   lastVoteSurveyAt: string | null
+  filedRequests: FiledRequest[]
+  votesCast: VoteRecord[]
 }
 
 export const DEFAULT_PREFERENCES: Preferences = {
@@ -20,7 +37,9 @@ export const DEFAULT_PREFERENCES: Preferences = {
   skillInstallOptIn: false,
   cliGlobalInstalled: false,
   votingOptIn: 'ask',
-  lastVoteSurveyAt: null
+  lastVoteSurveyAt: null,
+  filedRequests: [],
+  votesCast: []
 }
 
 export async function readPreferences(): Promise<Preferences> {
@@ -55,6 +74,20 @@ function mergeWithDefaults(parsed: unknown): Preferences {
     skillInstallOptIn: typeof p.skillInstallOptIn === 'boolean' ? p.skillInstallOptIn : DEFAULT_PREFERENCES.skillInstallOptIn,
     cliGlobalInstalled: typeof p.cliGlobalInstalled === 'boolean' ? p.cliGlobalInstalled : DEFAULT_PREFERENCES.cliGlobalInstalled,
     votingOptIn: p.votingOptIn === 'never' || p.votingOptIn === 'ask' || p.votingOptIn === 'always' ? p.votingOptIn : DEFAULT_PREFERENCES.votingOptIn,
-    lastVoteSurveyAt: typeof p.lastVoteSurveyAt === 'string' ? p.lastVoteSurveyAt : DEFAULT_PREFERENCES.lastVoteSurveyAt
+    lastVoteSurveyAt: typeof p.lastVoteSurveyAt === 'string' ? p.lastVoteSurveyAt : DEFAULT_PREFERENCES.lastVoteSurveyAt,
+    filedRequests: Array.isArray(p.filedRequests) ? p.filedRequests.filter(isFiledRequest) : [],
+    votesCast: Array.isArray(p.votesCast) ? p.votesCast.filter(isVoteRecord) : []
   }
+}
+
+function isFiledRequest(value: unknown): value is FiledRequest {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  return typeof v.issueNumber === 'number' && typeof v.repoUrl === 'string' && typeof v.title === 'string' && typeof v.openedAt === 'string'
+}
+
+function isVoteRecord(value: unknown): value is VoteRecord {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  return typeof v.issueNumber === 'number' && (v.direction === 'up' || v.direction === 'down') && typeof v.castAt === 'string'
 }


### PR DESCRIPTION
## Summary

Ships the `sf feedback` command family (epic #18, Phase 1E): 5 subcommands wrapping the `gh` CLI to let users file module requests, report bugs, list open feedback, and vote on proposals — all from inside their SaaSFoundry project.

Closes #62.

**Subcommands**

- `sf feedback request <name>` — file a module-request issue (with dedup search + `--force`)
- `sf feedback bug [--source cli|scaffold]` — file a bug with optional `--auto-repro` (embeds `.saasfoundry.json`)
- `sf feedback list [--status|--mine|--json|--limit]` — list open feedback issues across all 3 labels
- `sf feedback vote --list [--stack-filter|--limit|--json]` — rank open module requests by 👍
- `sf feedback vote <n> up|down|comment [--comment <body>]` — cast a reaction or post a comment

All subcommands support interactive TTY prompts **and** `--non-interactive` strict mode (exit 1 on missing flags, no hidden defaults).

## Architecture

- `src/feedback/gh.ts` — thin typed wrappers over the `gh` CLI (`execFile`, not HTTP — no new runtime dependencies)
- `src/feedback/repo.ts` — parses `package.json#repository.url` to resolve the upstream slug
- `src/feedback/{request,bug,list,vote}.ts` — one file per subcommand, pure logic, fully unit-testable
- `src/commands/feedback.ts` — thin dispatcher with manual arg parsing + help output
- `src/skill/preferences.ts` — extended with `filedRequests[]` and `votesCast[]` (type-guarded mergeWithDefaults)
- `.claude/docs/github-labels.md` — documents the one-time label setup (`module-request`, `cli-bug`, `scaffold-bug`)

## Test plan

Automated gates:
- `npm run build` ✅
- `npm run lint` ✅
- `npm test` — **483 tests / 41 suites** (from 412 → +71)

Non-regression coverage added:
- `src/__tests__/unit/feedback/gh.spec.ts` — execFile invocation shape
- `src/__tests__/unit/feedback/repo.spec.ts` — URL parsing (git+https, ssh, short forms)
- `src/__tests__/unit/feedback/request.spec.ts` — 8 tests (title/body formatting, dedup, prefs append)
- `src/__tests__/unit/feedback/bug.spec.ts` — 11 tests (label routing, repro collection, body branches)
- `src/__tests__/unit/feedback/list.spec.ts` — 7 tests (3-label fan-out, dedup, filters)
- `src/__tests__/unit/feedback/vote.spec.ts` — 11 tests (ranking, tie-break, all 3 cast paths, empty-comment)
- `src/__tests__/integration/commands/feedback.spec.ts` — 21 tests (full dispatcher pipeline, all subcommands, happy + error paths)
- `src/__tests__/unit/skill/preferences.spec.ts` — extended for new fields

Manual smokes (executed during AI Testing on the real repo):
- [x] Dispatcher help + unknown subcommand
- [x] `request` happy path + dedup + missing name/description
- [x] `bug --source cli` + `bug --source scaffold --auto-repro` (verified `.saasfoundry.json` embedded) + invalid/missing source
- [x] `list` default/all/--mine/--json + invalid status
- [x] `vote --list` ranking + `vote <n> up` reaction + `vote <n> comment` + invalid number/action/missing comment

One-time setup performed during AI Testing: created `module-request`, `cli-bug`, `scaffold-bug` labels on the repo (documented in `.claude/docs/github-labels.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)