### PR TITLE
feat(#103): add bootstrap helper scripts for tool-saasfoundry skill

### DIFF
--- a/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
+++ b/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
@@ -58,10 +58,26 @@ Before mutating, always prefer `--dry-run` where available (notably `sf update -
 | Cast a vote | `sf feedback vote <n> up\|down` | Recorded in `~/.saasfoundry/preferences.json` |
 | Comment on a request | `sf feedback vote <n> comment --comment "<body>"` | No vote recorded, just a comment |
 
+## Bootstrap
+
+Before running user-facing SaaSFoundry commands, the skill verifies the environment using bundled helper scripts under `~/.claude/skills/tool-saasfoundry/scripts/`:
+
+| Script | When to invoke | Contract |
+| --- | --- | --- |
+| `detect-env.sh` | Once per session, or whenever the skill needs to choose between `sf` and `npx saasfoundry-cli` | Prints a JSON snapshot on stdout (`os`, `nodeVersion`, `ghInstalled`, `ghAuthed`, `sfGlobalInstalled`). Always exits 0. |
+| `bootstrap-gh.sh` | Before any GitHub-dependent command (`sf feedback …`, voting, issue listing) | Exits 0 silently when `gh` is installed and authenticated. Exits 1 with guided install/login instructions on stderr otherwise. |
+| `bootstrap-cli.sh` | Before any `sf` invocation | Prints the exact command token to use (`sf`, `saasfoundry-cli`, or `npx saasfoundry-cli`) on stdout. Always exits 0. |
+
+Guidelines:
+
+- **Run `detect-env.sh` first** when the conversation starts to cache environment facts (OS, node version, CLI presence) for the rest of the turn
+- **Always gate `gh`-backed flows behind `bootstrap-gh.sh`** — on failure, surface its stderr verbatim to the user and stop rather than retrying blindly
+- **Resolve the CLI invocation via `bootstrap-cli.sh`** — never hardcode `sf` in examples if the user might be running via `npx`
+
 ## Interaction principles
 
 1. **Never bypass the CLI.** If the user asks for a file or layout that the CLI can generate, generate it via `sf`. Do not hand-write blueprints.
-2. **Always verify prerequisites first.** Before any GitHub-dependent command, check `gh auth status`. Before any project-scoped command, check that `.saasfoundry.json` exists and can be read (detailed in Phase 2B).
+2. **Always verify prerequisites first.** Run `bootstrap-gh.sh` before GitHub calls and `bootstrap-cli.sh` before any `sf` command. Project-scoped awareness (reading `.saasfoundry.json`) lands in Phase 2E.
 3. **Use `AskUserQuestion` for multi-choice.** Do not emulate Inquirer with plain prose questions — use the structured tool when presenting enumerated options (fleshed out in Phase 2C/2D).
 4. **Prefer `--dry-run` before mutations.** Especially for `sf update`, always show the user what would change before doing it.
 5. **Respect user preferences.** `~/.saasfoundry/preferences.json` tracks opt-out choices (skill prompts, voting surveys) — honor them across sessions.
@@ -70,7 +86,6 @@ Before mutating, always prefer `--dry-run` where available (notably `sf update -
 
 This SKILL.md is the foundation (Phase 2A, ticket #102). The following capabilities will be layered on in subsequent tickets:
 
-- **Phase 2B — Bootstrap helpers** (#103): environment detection scripts (`gh` auth, CLI presence, IDE, OS) and guided login flow.
 - **Phase 2C — Discovery for `sf new`** (#104): replaces Inquirer with a Guided / Express / Expert conversational flow.
 - **Phase 2D — Discovery for `sf update`** (#105): same treatment for module add/remove, catalogue-aware.
 - **Phase 2E — Project Awareness** (#106): read-only conversational queries over `.saasfoundry.json` and the module catalogue.

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/bootstrap-cli.sh
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/bootstrap-cli.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolves which invocation the tool-saasfoundry skill should use to
+# run the `sf` CLI. Prints exactly one command token (or tokens) on
+# stdout, terminated by a newline. Always exits 0 — the skill always
+# has a fallback path via `npx`.
+#
+# Resolution order:
+#   1. `sf` found on PATH            → prints: sf
+#   2. `saasfoundry-cli` on PATH     → prints: saasfoundry-cli
+#   3. neither available             → prints: npx saasfoundry-cli
+#
+# Intended usage from the skill:
+#     SF_CMD=$(bash scripts/bootstrap-cli.sh)
+#     $SF_CMD new --non-interactive ...
+
+if command -v sf >/dev/null 2>&1; then
+  echo sf
+  exit 0
+fi
+
+if command -v saasfoundry-cli >/dev/null 2>&1; then
+  echo saasfoundry-cli
+  exit 0
+fi
+
+echo "npx saasfoundry-cli"

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/bootstrap-gh.sh
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/bootstrap-gh.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensures the GitHub CLI is installed and authenticated before the
+# tool-saasfoundry skill runs any `gh`-dependent command (feedback,
+# voting, issue listing).
+#
+# Exit codes:
+#   0 — gh is installed and authenticated (silent, idempotent)
+#   1 — gh is missing OR not authenticated; guidance printed on stderr
+#
+# The message goes to stderr so stdout stays reserved for structured
+# output when the skill pipes this into other helpers.
+
+if ! command -v gh >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+GitHub CLI (`gh`) is not installed.
+
+Install it first, then retry:
+  macOS:   brew install gh
+  Linux:   https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+  Windows: winget install --id GitHub.cli
+
+Once installed, authenticate with:
+  gh auth login
+EOF
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+GitHub CLI is installed but not authenticated.
+
+Run the interactive login, then retry:
+  gh auth login
+
+Choose "GitHub.com" → "HTTPS" → "Login with a web browser"
+when prompted.
+EOF
+  exit 1
+fi
+
+exit 0

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/detect-env.sh
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/detect-env.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Emits a JSON object on stdout describing the local environment,
+# so the tool-saasfoundry skill can decide whether to bootstrap
+# GitHub auth or the `sf` CLI before running user-facing commands.
+#
+# Shape:
+#   {
+#     "os": "darwin" | "linux" | "windows" | "unknown",
+#     "nodeVersion": "20.19.0" | null,
+#     "ghInstalled": true | false,
+#     "ghAuthed": true | false,
+#     "sfGlobalInstalled": true | false
+#   }
+#
+# Always exits 0 — the skill inspects the payload rather than the exit code.
+
+detect_os() {
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    Darwin) echo darwin ;;
+    Linux) echo linux ;;
+    MINGW*|MSYS*|CYGWIN*) echo windows ;;
+    *) echo unknown ;;
+  esac
+}
+
+node_version() {
+  if command -v node >/dev/null 2>&1; then
+    node --version 2>/dev/null | sed 's/^v//'
+  fi
+}
+
+gh_installed() {
+  command -v gh >/dev/null 2>&1
+}
+
+gh_authed() {
+  gh_installed && gh auth status >/dev/null 2>&1
+}
+
+sf_global_installed() {
+  command -v sf >/dev/null 2>&1
+}
+
+json_bool() {
+  if "$@"; then echo true; else echo false; fi
+}
+
+json_string_or_null() {
+  local value="$1"
+  if [ -z "$value" ]; then
+    echo null
+  else
+    echo "\"$value\""
+  fi
+}
+
+os=$(detect_os)
+node_ver=$(node_version || true)
+gh_inst=$(json_bool gh_installed)
+gh_auth=$(json_bool gh_authed)
+sf_inst=$(json_bool sf_global_installed)
+
+cat <<EOF
+{
+  "os": "$os",
+  "nodeVersion": $(json_string_or_null "$node_ver"),
+  "ghInstalled": $gh_inst,
+  "ghAuthed": $gh_auth,
+  "sfGlobalInstalled": $sf_inst
+}
+EOF

--- a/src/__tests__/unit/skill/bootstrap-scripts.spec.ts
+++ b/src/__tests__/unit/skill/bootstrap-scripts.spec.ts
@@ -1,4 +1,7 @@
 import { execFile } from 'child_process'
+import { existsSync } from 'fs'
+import { mkdtemp, rm, symlink } from 'fs/promises'
+import { tmpdir } from 'os'
 import path from 'path'
 import { promisify } from 'util'
 
@@ -23,7 +26,38 @@ async function run(script: string, env: NodeJS.ProcessEnv = process.env): Promis
   }
 }
 
+/**
+ * Creates a temporary directory that acts as a minimal PATH: it contains
+ * symlinks only to the coreutils the bootstrap scripts need (`cat`, `uname`)
+ * so that `gh`, `node`, and `sf` are guaranteed to be absent regardless of
+ * what is installed on the host (Ubuntu CI runners ship gh in /usr/bin).
+ */
+async function createMinimalPath(): Promise<{ pathDir: string; cleanup: () => Promise<void> }> {
+  const pathDir = await mkdtemp(path.join(tmpdir(), 'sf-bootstrap-'))
+  const needed = ['cat', 'uname']
+  const candidateDirs = ['/bin', '/usr/bin']
+  for (const tool of needed) {
+    const source = candidateDirs.map((d) => path.join(d, tool)).find(existsSync)
+    if (!source) throw new Error(`required coreutil not found on host: ${tool}`)
+    await symlink(source, path.join(pathDir, tool))
+  }
+  return { pathDir, cleanup: () => rm(pathDir, { recursive: true, force: true }) }
+}
+
 describe('skill/bootstrap-scripts', () => {
+  let minimalPath: string
+  let cleanupPath: () => Promise<void>
+
+  beforeAll(async () => {
+    const created = await createMinimalPath()
+    minimalPath = created.pathDir
+    cleanupPath = created.cleanup
+  })
+
+  afterAll(async () => {
+    await cleanupPath()
+  })
+
   describe('detect-env.sh', () => {
     it('emits a JSON object with the expected shape', async () => {
       const { stdout, code } = await run('detect-env.sh')
@@ -37,27 +71,28 @@ describe('skill/bootstrap-scripts', () => {
       expect(payload.nodeVersion === null || typeof payload.nodeVersion === 'string').toBe(true)
     })
 
-    it('sets ghAuthed=false when gh and node are absent from PATH', async () => {
-      const { stdout, code } = await run('detect-env.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+    it('reports all booleans false when gh/node/sf are absent from PATH', async () => {
+      const { stdout, code } = await run('detect-env.sh', { ...process.env, PATH: minimalPath })
       expect(code).toBe(0)
       const payload = JSON.parse(stdout)
       expect(payload.ghInstalled).toBe(false)
       expect(payload.ghAuthed).toBe(false)
       expect(payload.sfGlobalInstalled).toBe(false)
+      expect(payload.nodeVersion).toBeNull()
     })
   })
 
   describe('bootstrap-gh.sh', () => {
     it('exits 1 with guided install instructions when gh is missing', async () => {
-      const { stderr, code } = await run('bootstrap-gh.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+      const { stderr, code } = await run('bootstrap-gh.sh', { ...process.env, PATH: minimalPath })
       expect(code).toBe(1)
       expect(stderr).toMatch(/GitHub CLI.*not installed/i)
       expect(stderr).toMatch(/gh auth login/)
     })
 
     it('is idempotent under repeated invocations with the same environment', async () => {
-      const first = await run('bootstrap-gh.sh', { ...process.env, PATH: '/bin:/usr/bin' })
-      const second = await run('bootstrap-gh.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+      const first = await run('bootstrap-gh.sh', { ...process.env, PATH: minimalPath })
+      const second = await run('bootstrap-gh.sh', { ...process.env, PATH: minimalPath })
       expect(first.code).toBe(second.code)
       expect(first.stderr).toBe(second.stderr)
     })
@@ -65,7 +100,7 @@ describe('skill/bootstrap-scripts', () => {
 
   describe('bootstrap-cli.sh', () => {
     it('falls back to `npx saasfoundry-cli` when sf is not on PATH', async () => {
-      const { stdout, code } = await run('bootstrap-cli.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+      const { stdout, code } = await run('bootstrap-cli.sh', { ...process.env, PATH: minimalPath })
       expect(code).toBe(0)
       expect(stdout.trim()).toBe('npx saasfoundry-cli')
     })

--- a/src/__tests__/unit/skill/bootstrap-scripts.spec.ts
+++ b/src/__tests__/unit/skill/bootstrap-scripts.spec.ts
@@ -1,0 +1,81 @@
+import { execFile } from 'child_process'
+import path from 'path'
+import { promisify } from 'util'
+
+const execFileP = promisify(execFile)
+
+const SCRIPTS_DIR = path.resolve(__dirname, '../../../../scaffolds/skills-templates/tool-saasfoundry/scripts')
+const BASH = '/bin/bash'
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+async function run(script: string, env: NodeJS.ProcessEnv = process.env): Promise<ExecResult> {
+  try {
+    const { stdout, stderr } = await execFileP(BASH, [path.join(SCRIPTS_DIR, script)], { env })
+    return { stdout, stderr, code: 0 }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; code?: number }
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: typeof e.code === 'number' ? e.code : 1 }
+  }
+}
+
+describe('skill/bootstrap-scripts', () => {
+  describe('detect-env.sh', () => {
+    it('emits a JSON object with the expected shape', async () => {
+      const { stdout, code } = await run('detect-env.sh')
+      expect(code).toBe(0)
+      const payload = JSON.parse(stdout)
+      expect(Object.keys(payload).sort()).toEqual(['ghAuthed', 'ghInstalled', 'nodeVersion', 'os', 'sfGlobalInstalled'])
+      expect(['darwin', 'linux', 'windows', 'unknown']).toContain(payload.os)
+      expect(typeof payload.ghInstalled).toBe('boolean')
+      expect(typeof payload.ghAuthed).toBe('boolean')
+      expect(typeof payload.sfGlobalInstalled).toBe('boolean')
+      expect(payload.nodeVersion === null || typeof payload.nodeVersion === 'string').toBe(true)
+    })
+
+    it('sets ghAuthed=false when gh and node are absent from PATH', async () => {
+      const { stdout, code } = await run('detect-env.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+      expect(code).toBe(0)
+      const payload = JSON.parse(stdout)
+      expect(payload.ghInstalled).toBe(false)
+      expect(payload.ghAuthed).toBe(false)
+      expect(payload.sfGlobalInstalled).toBe(false)
+    })
+  })
+
+  describe('bootstrap-gh.sh', () => {
+    it('exits 1 with guided install instructions when gh is missing', async () => {
+      const { stderr, code } = await run('bootstrap-gh.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+      expect(code).toBe(1)
+      expect(stderr).toMatch(/GitHub CLI.*not installed/i)
+      expect(stderr).toMatch(/gh auth login/)
+    })
+
+    it('is idempotent under repeated invocations with the same environment', async () => {
+      const first = await run('bootstrap-gh.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+      const second = await run('bootstrap-gh.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+      expect(first.code).toBe(second.code)
+      expect(first.stderr).toBe(second.stderr)
+    })
+  })
+
+  describe('bootstrap-cli.sh', () => {
+    it('falls back to `npx saasfoundry-cli` when sf is not on PATH', async () => {
+      const { stdout, code } = await run('bootstrap-cli.sh', { ...process.env, PATH: '/bin:/usr/bin' })
+      expect(code).toBe(0)
+      expect(stdout.trim()).toBe('npx saasfoundry-cli')
+    })
+
+    it('returns a single non-empty line', async () => {
+      const { stdout, code } = await run('bootstrap-cli.sh')
+      expect(code).toBe(0)
+      const lines = stdout.trim().split('\n')
+      expect(lines).toHaveLength(1)
+      expect(lines[0].length).toBeGreaterThan(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Ship three bash helpers under `scaffolds/skills-templates/tool-saasfoundry/scripts/`:
  - `detect-env.sh` — JSON snapshot (`os`, `nodeVersion`, `ghInstalled`, `ghAuthed`, `sfGlobalInstalled`), always exits 0
  - `bootstrap-gh.sh` — exits 0 silent when `gh` is installed + authenticated; exits 1 with guided install/login on stderr otherwise (idempotent)
  - `bootstrap-cli.sh` — resolves which invocation the skill should use (`sf` / `saasfoundry-cli` / `npx saasfoundry-cli`)
- Document the contract in `SKILL.md` under a new `## Bootstrap` section and drop the now-delivered Phase 2B entry from Future capabilities
- Cover the scripts with Jest tests (happy path + PATH-restricted scenario via `/bin:/usr/bin`)

## Context

Closes Phase 2B of epic #18. The helpers are the runtime prerequisite checks the skill uses before invoking any `sf` or `gh` command — they replace ad-hoc "try-and-fail" behavior with a deterministic JSON/exit-code contract.

Scripts are intentionally stdlib-only (bash builtins + coreutils) so they don't require additional tooling on the user's machine. No changes to `sf skill install` were needed — `fs-extra.copy()` already handles the new `scripts/` subdirectory and preserves the exec bit.

## Test plan

- [x] `detect-env.sh` emits JSON with the documented 5 keys and correct types
- [x] `detect-env.sh` reports `ghInstalled/ghAuthed/sfGlobalInstalled=false` when their binaries are absent from PATH
- [x] `bootstrap-gh.sh` exits 0 silently when authed; exits 1 with guided stderr message when not
- [x] `bootstrap-gh.sh` is idempotent across repeated invocations
- [x] `bootstrap-cli.sh` falls back to `npx saasfoundry-cli` when neither `sf` nor `saasfoundry-cli` is on PATH
- [x] `sf skill install` ships the scripts with exec perms preserved (`-rwxr-xr-x`)
- [x] Full Jest suite green (489/489 tests, 42 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)