### PR TITLE
Phase 2C: Discovery conversationnelle pour sf new (#104)

### DIFF
--- a/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
+++ b/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
@@ -74,6 +74,59 @@ Guidelines:
 - **Always gate `gh`-backed flows behind `bootstrap-gh.sh`** — on failure, surface its stderr verbatim to the user and stop rather than retrying blindly
 - **Resolve the CLI invocation via `bootstrap-cli.sh`** — never hardcode `sf` in examples if the user might be running via `npx`
 
+## Discovery: `sf new`
+
+When the user wants to start a new SaaSFoundry project, the skill replaces the CLI's Inquirer prompts with a conversational discovery flow. The goal is to produce a complete **intent** object that `plan-new.sh` can translate into a single `sf new --non-interactive …` command. The intent schema and flag mapping are documented in `reference/new-flags.json` — consult it before inventing field names.
+
+### Three discovery modes
+
+Pick the mode from the user's first message, not from a menu:
+
+| Mode | When it fits | Flow |
+| --- | --- | --- |
+| **Guided** *(default)* | User says "I want a new SaaS project" with little detail, or explicitly asks for help choosing | Ask one question at a time, explain each choice briefly, recommend based on the table below, allow bail-out |
+| **Express** | User gives enough signal upfront ("scaffold a monorepo with mailersend and analytics") | Infer the intent, echo it back as a plan, ask for single-shot validation |
+| **Expert** | User pastes a full or partial `sf new --non-interactive …` command | Pass it through verbatim after sanity-checking flag names against the manifest |
+
+### Discovery workflow
+
+1. **Bootstrap** — run `bootstrap-cli.sh` to resolve the invocation token (`sf` / `npx saasfoundry-cli`). Cache for the rest of the turn.
+2. **Gather intent** — build a JSON object matching the `fields` in `reference/new-flags.json`. Only include fields the user has either stated or confirmed via a recommendation.
+3. **Materialize the plan** — pipe the intent JSON into `scripts/plan-new.sh`. It returns the full command on stdout or exits non-zero with a validation message on stderr.
+4. **Present the plan** — show the command *and* a short human summary built from the intent (structure, database, modules, post-setup apps). Never run the command yet.
+5. **Confirm and execute** — wait for explicit user approval before running. If the user tweaks a field, rebuild the intent and re-run `plan-new.sh` rather than editing the command string by hand.
+
+### Intent schema (summary)
+
+Full specification: `reference/new-flags.json`. Essentials:
+
+- **Always required:** `projectName` (kebab-case), `structure` (`monorepo` | `multirepo`)
+- **Recommended to set explicitly:** `mainBranch`, `dbSetup`, `emailService`, `analytics`
+- **Only set when user opts in:** `advancedSkills` (CSV of `context7`, `atlassian`, `notion`, `figma`) and their credential fields
+- **Secrets** (marked `"secret": true` in the manifest): never echo them back, never log them
+
+### Recommendation rules
+
+Use these defaults when the user has no strong opinion:
+
+| Dimension | Default | Condition to override |
+| --- | --- | --- |
+| `structure` | `monorepo` | Recommend `multirepo` only when backend/frontend are owned by separate teams or deploy on separate schedules |
+| `mainBranch` | `main` | Only `master` when the user's org standard says so |
+| `dbSetup` | `docker` | Recommend `credentials` for staging/prod stacks, `manual` when DB is provisioned elsewhere |
+| `emailService` | `none` | Recommend `mailersend` as soon as the product needs transactional email (password reset, invites, receipts) |
+| `analytics` | `false` | Recommend `true` only when metrics are on the roadmap from day one — otherwise `sf update --add-modules analytics` later is a one-liner |
+| `startApps` / `startServices` | `none` / `false` | Offer to start services when the user says they want to "try it immediately" |
+
+The full rationale for each recommendation is in the `recommendations` block of `reference/new-flags.json` — lean on it when the user asks "why?".
+
+### Never do these
+
+- **Don't fabricate flags.** Every flag you pass must exist in the manifest's `fields` section.
+- **Don't ask for every field in Guided mode.** Skip fields whose defaults are obvious for the user's context (e.g. don't ask about `mainBranch` for a hobby project).
+- **Don't re-serialize the plan by hand.** Always round-trip through `plan-new.sh` so the command stays consistent with the manifest.
+- **Don't stash secrets in the intent you echo back.** Collect them, pass them through to `plan-new.sh`, but redact in any user-facing summary.
+
 ## Interaction principles
 
 1. **Never bypass the CLI.** If the user asks for a file or layout that the CLI can generate, generate it via `sf`. Do not hand-write blueprints.
@@ -86,7 +139,6 @@ Guidelines:
 
 This SKILL.md is the foundation (Phase 2A, ticket #102). The following capabilities will be layered on in subsequent tickets:
 
-- **Phase 2C — Discovery for `sf new`** (#104): replaces Inquirer with a Guided / Express / Expert conversational flow.
 - **Phase 2D — Discovery for `sf update`** (#105): same treatment for module add/remove, catalogue-aware.
 - **Phase 2E — Project Awareness** (#106): read-only conversational queries over `.saasfoundry.json` and the module catalogue.
 

--- a/scaffolds/skills-templates/tool-saasfoundry/reference/new-flags.json
+++ b/scaffolds/skills-templates/tool-saasfoundry/reference/new-flags.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "description": "Source of truth for the sf new command surface used by the tool-saasfoundry skill. Each entry maps an intent JSON field to its corresponding --flag on `sf new`. Both plan-new.sh and the skill's discovery conversation read this file — keep them in sync by editing here, never by hardcoding flag names elsewhere.",
+  "command": "sf new",
+  "alwaysAppend": ["--non-interactive"],
+  "fields": {
+    "projectName": {
+      "flag": "--project-name",
+      "type": "string",
+      "required": true,
+      "description": "Project name in kebab-case"
+    },
+    "projectDescription": {
+      "flag": "--project-description",
+      "type": "string",
+      "required": false,
+      "description": "Free-text project description"
+    },
+    "structure": {
+      "flag": "--structure",
+      "type": "enum",
+      "values": ["monorepo", "multirepo"],
+      "required": true,
+      "description": "Monorepo (single repo) vs multirepo (backend + frontend split)"
+    },
+    "mainBranch": {
+      "flag": "--main-branch",
+      "type": "enum",
+      "values": ["main", "master"],
+      "required": false,
+      "default": "main"
+    },
+    "setupRepo": {
+      "flag": "--setup-repo",
+      "type": "enum",
+      "values": ["local", "existing"],
+      "required": false,
+      "default": "local"
+    },
+    "monorepoUrl": {
+      "flag": "--monorepo-url",
+      "type": "string",
+      "required": false,
+      "requiresWhen": "structure=monorepo AND setupRepo=existing"
+    },
+    "backendRepoUrl": {
+      "flag": "--backend-repo-url",
+      "type": "string",
+      "required": false,
+      "requiresWhen": "structure=multirepo AND setupRepo=existing"
+    },
+    "frontendRepoUrl": {
+      "flag": "--frontend-repo-url",
+      "type": "string",
+      "required": false,
+      "requiresWhen": "structure=multirepo AND setupRepo=existing"
+    },
+    "dbSetup": {
+      "flag": "--db-setup",
+      "type": "enum",
+      "values": ["docker", "credentials", "manual"],
+      "required": false,
+      "default": "docker"
+    },
+    "dbType": {
+      "flag": "--db-type",
+      "type": "enum",
+      "values": ["postgresql", "sql"],
+      "required": false,
+      "default": "postgresql"
+    },
+    "dbHost": { "flag": "--db-host", "type": "string", "required": false },
+    "dbPort": { "flag": "--db-port", "type": "string", "required": false },
+    "dbUser": { "flag": "--db-user", "type": "string", "required": false },
+    "dbPassword": { "flag": "--db-password", "type": "string", "required": false, "secret": true },
+    "dbName": { "flag": "--db-name", "type": "string", "required": false },
+    "emailService": {
+      "flag": "--email-service",
+      "type": "enum",
+      "values": ["none", "mailersend"],
+      "required": false,
+      "default": "none"
+    },
+    "mailersendApiKey": { "flag": "--mailersend-api-key", "type": "string", "required": false, "secret": true },
+    "mailersendSenderEmail": { "flag": "--mailersend-sender-email", "type": "string", "required": false },
+    "mailersendSenderName": { "flag": "--mailersend-sender-name", "type": "string", "required": false },
+    "s3Setup": {
+      "flag": "--s3-setup",
+      "type": "enum",
+      "values": ["docker", "credentials", "manual"],
+      "required": false
+    },
+    "s3Endpoint": { "flag": "--s3-endpoint", "type": "string", "required": false },
+    "s3AccessKey": { "flag": "--s3-access-key", "type": "string", "required": false, "secret": true },
+    "s3SecretKey": { "flag": "--s3-secret-key", "type": "string", "required": false, "secret": true },
+    "s3Bucket": { "flag": "--s3-bucket", "type": "string", "required": false },
+    "s3Region": { "flag": "--s3-region", "type": "string", "required": false },
+    "analytics": {
+      "flag": "--analytics",
+      "negationFlag": "--no-analytics",
+      "type": "boolean",
+      "required": false,
+      "default": false
+    },
+    "advancedSkills": {
+      "flag": "--advanced-skills",
+      "type": "csv",
+      "values": ["context7", "atlassian", "notion", "figma"],
+      "required": false,
+      "description": "Comma-separated list of advanced skills to install"
+    },
+    "context7ApiKey": { "flag": "--context7-api-key", "type": "string", "required": false, "secret": true },
+    "atlassianEmail": { "flag": "--atlassian-email", "type": "string", "required": false },
+    "atlassianApiToken": { "flag": "--atlassian-api-token", "type": "string", "required": false, "secret": true },
+    "atlassianSite": { "flag": "--atlassian-site", "type": "string", "required": false },
+    "atlassianCloudId": { "flag": "--atlassian-cloud-id", "type": "string", "required": false },
+    "notionApiToken": { "flag": "--notion-api-token", "type": "string", "required": false, "secret": true },
+    "notionApiVersion": { "flag": "--notion-api-version", "type": "string", "required": false },
+    "figmaApiToken": { "flag": "--figma-api-token", "type": "string", "required": false, "secret": true },
+    "workflow": {
+      "flag": "--workflow",
+      "negationFlag": "--no-workflow",
+      "type": "string",
+      "required": false,
+      "description": "Workflow preset name, or 'none' / --no-workflow to skip"
+    },
+    "startServices": {
+      "flag": "--start-services",
+      "negationFlag": "--no-start-services",
+      "type": "boolean",
+      "required": false,
+      "default": false
+    },
+    "startApps": {
+      "flag": "--start-apps",
+      "type": "enum",
+      "values": ["all", "backend", "frontend", "none"],
+      "required": false,
+      "default": "none"
+    }
+  },
+  "recommendations": {
+    "structure": {
+      "monorepo": "Default for solo devs, small teams, and projects where backend+frontend ship together. Single repo simplifies CI, versioning, and PR scope.",
+      "multirepo": "Choose when backend and frontend are owned by different teams, deploy on independent schedules, or need per-side access controls."
+    },
+    "emailService": {
+      "mailersend": "Recommend when the project needs transactional email (password reset, invites, receipts). The module ships ready-to-use templates.",
+      "none": "Default for prototypes, internal tools, or when email is already handled upstream."
+    },
+    "s3Setup": {
+      "docker": "Default for local development — spins up MinIO via docker-compose.",
+      "credentials": "Choose for staging/prod against AWS S3 or an S3-compatible provider (R2, Backblaze, DigitalOcean Spaces).",
+      "manual": "Choose when infra is provisioned outside SaaSFoundry and credentials come from an external secret manager."
+    },
+    "analytics": {
+      "true": "Recommend when tracking user activity or business metrics matters early. Installs a privacy-respecting analytics module.",
+      "false": "Default for MVPs — adding analytics later via `sf update --add-modules analytics` is a one-liner."
+    }
+  }
+}

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-new.js
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-new.js
@@ -95,7 +95,7 @@ for (const [key, spec] of Object.entries(manifest.fields)) {
 }
 
 function quote(s) {
-  if (/^[A-Za-z0-9_./@:-]+$/.test(s)) return s
+  if (/^[A-Za-z0-9_./@:,=-]+$/.test(s)) return s
   return "'" + s.replace(/'/g, "'\\''") + "'"
 }
 

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-new.js
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-new.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+'use strict'
+
+// Converts a JSON intent payload (read from stdin) into the equivalent
+// `sf new --non-interactive ...` command on stdout. The manifest at
+// ../reference/new-flags.json is the source of truth for the flag surface.
+//
+// Exit codes:
+//   0 — success
+//   1 — internal error (manifest missing)
+//   2 — invalid intent (missing required field, bad enum, malformed JSON)
+
+const fs = require('fs')
+const path = require('path')
+
+const manifestPath = path.join(__dirname, '..', 'reference', 'new-flags.json')
+
+if (!fs.existsSync(manifestPath)) {
+  process.stderr.write('plan-new: manifest not found at ' + manifestPath + '\n')
+  process.exit(1)
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+const intentRaw = fs.readFileSync(0, 'utf8')
+if (!intentRaw.trim()) {
+  process.stderr.write('plan-new: empty intent on stdin\n')
+  process.exit(2)
+}
+
+let intent
+try {
+  intent = JSON.parse(intentRaw)
+} catch (err) {
+  process.stderr.write('plan-new: invalid JSON on stdin: ' + err.message + '\n')
+  process.exit(2)
+}
+
+if (intent === null || typeof intent !== 'object' || Array.isArray(intent)) {
+  process.stderr.write('plan-new: intent must be a JSON object\n')
+  process.exit(2)
+}
+
+for (const [key, spec] of Object.entries(manifest.fields)) {
+  if (spec.required && (intent[key] === undefined || intent[key] === null || intent[key] === '')) {
+    process.stderr.write('plan-new: missing required intent field: ' + key + '\n')
+    process.exit(2)
+  }
+}
+
+for (const [key, value] of Object.entries(intent)) {
+  const spec = manifest.fields[key]
+  if (!spec) continue
+  if (spec.type === 'enum' && !spec.values.includes(value)) {
+    process.stderr.write(
+      'plan-new: invalid value "' + value + '" for ' + key +
+      '; expected one of ' + spec.values.join(', ') + '\n'
+    )
+    process.exit(2)
+  }
+  if (spec.type === 'csv' && Array.isArray(value) && spec.values) {
+    const bad = value.find((v) => !spec.values.includes(v))
+    if (bad !== undefined) {
+      process.stderr.write(
+        'plan-new: invalid value "' + bad + '" in ' + key +
+        '; expected one of ' + spec.values.join(', ') + '\n'
+      )
+      process.exit(2)
+    }
+  }
+}
+
+const parts = [...String(manifest.command).trim().split(/\s+/), ...manifest.alwaysAppend]
+
+for (const [key, spec] of Object.entries(manifest.fields)) {
+  const value = intent[key]
+  if (value === undefined || value === null) continue
+
+  if (spec.type === 'boolean') {
+    if (value === true) parts.push(spec.flag)
+    else if (value === false && spec.negationFlag) parts.push(spec.negationFlag)
+    continue
+  }
+
+  if (spec.type === 'csv') {
+    const items = Array.isArray(value)
+      ? value
+      : String(value).split(',').map((s) => s.trim()).filter(Boolean)
+    if (items.length === 0) continue
+    parts.push(spec.flag, items.join(','))
+    continue
+  }
+
+  parts.push(spec.flag, String(value))
+}
+
+function quote(s) {
+  if (/^[A-Za-z0-9_./@:-]+$/.test(s)) return s
+  return "'" + s.replace(/'/g, "'\\''") + "'"
+}
+
+process.stdout.write(parts.map(quote).join(' ') + '\n')

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-new.sh
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-new.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Thin wrapper around plan-new.js. Accepts the intent JSON on stdin,
+# emits the equivalent `sf new --non-interactive ...` command on stdout.
+# See plan-new.js for the translation logic and exit codes.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "plan-new.sh: node is required to parse JSON intent" >&2
+  exit 1
+fi
+
+exec node "${SCRIPT_DIR}/plan-new.js"

--- a/src/__tests__/unit/skill/plan-new.spec.ts
+++ b/src/__tests__/unit/skill/plan-new.spec.ts
@@ -1,0 +1,144 @@
+import { execFile } from 'child_process'
+import path from 'path'
+
+const SCRIPT = path.resolve(__dirname, '../../../../scaffolds/skills-templates/tool-saasfoundry/scripts/plan-new.sh')
+const BASH = '/bin/bash'
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+async function runWithIntent(intent: unknown): Promise<ExecResult> {
+  const child = execFile(BASH, [SCRIPT])
+  const stdoutChunks: string[] = []
+  const stderrChunks: string[] = []
+  child.stdout?.setEncoding('utf8')
+  child.stderr?.setEncoding('utf8')
+  child.stdout?.on('data', (c: string) => stdoutChunks.push(c))
+  child.stderr?.on('data', (c: string) => stderrChunks.push(c))
+  child.stdin?.write(typeof intent === 'string' ? intent : JSON.stringify(intent))
+  child.stdin?.end()
+  const code = await new Promise<number>((resolve) => child.on('close', (c) => resolve(c ?? 0)))
+  return {
+    stdout: stdoutChunks.join(''),
+    stderr: stderrChunks.join(''),
+    code
+  }
+}
+
+describe('skill/plan-new', () => {
+  describe('Guided/Express — monorepo backend-only', () => {
+    it('builds the minimal command with just projectName + structure', async () => {
+      const { stdout, code } = await runWithIntent({ projectName: 'acme', structure: 'monorepo' })
+      expect(code).toBe(0)
+      expect(stdout.trim()).toBe('sf new --non-interactive --project-name acme --structure monorepo')
+    })
+  })
+
+  describe('Express — multirepo with modules', () => {
+    it('includes db, email, analytics and advanced-skills flags in manifest order', async () => {
+      const { stdout, code } = await runWithIntent({
+        projectName: 'big-app',
+        structure: 'multirepo',
+        mainBranch: 'main',
+        dbSetup: 'docker',
+        emailService: 'mailersend',
+        mailersendApiKey: 'ms_live_xxx',
+        analytics: true,
+        advancedSkills: ['context7', 'notion']
+      })
+      expect(code).toBe(0)
+      expect(stdout.trim()).toBe(
+        [
+          'sf new',
+          '--non-interactive',
+          '--project-name big-app',
+          '--structure multirepo',
+          '--main-branch main',
+          '--db-setup docker',
+          '--email-service mailersend',
+          '--mailersend-api-key ms_live_xxx',
+          '--analytics',
+          '--advanced-skills context7,notion'
+        ].join(' ')
+      )
+    })
+  })
+
+  describe('Guided — partial intent', () => {
+    it('exits 2 when a required field is missing', async () => {
+      const { code, stderr } = await runWithIntent({ projectName: 'incomplete' })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/missing required intent field: structure/)
+    })
+  })
+
+  describe('Validation — bad enum', () => {
+    it('exits 2 with the allowed values listed', async () => {
+      const { code, stderr } = await runWithIntent({ projectName: 'x', structure: 'hybrid' })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/invalid value "hybrid" for structure; expected one of monorepo, multirepo/)
+    })
+  })
+
+  describe('Validation — malformed JSON', () => {
+    it('exits 2 on non-JSON input', async () => {
+      const { code, stderr } = await runWithIntent('not json at all')
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/invalid JSON on stdin/)
+    })
+
+    it('exits 2 on empty stdin', async () => {
+      const { code, stderr } = await runWithIntent('')
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/empty intent on stdin/)
+    })
+
+    it('exits 2 on a JSON array at top level', async () => {
+      const { code, stderr } = await runWithIntent([])
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/intent must be a JSON object/)
+    })
+  })
+
+  describe('Expert — values with spaces and special chars', () => {
+    it('shell-quotes risky values', async () => {
+      const { stdout, code } = await runWithIntent({
+        projectName: 'safe-name',
+        structure: 'monorepo',
+        projectDescription: 'Acme\'s SaaS with "quotes" & spaces'
+      })
+      expect(code).toBe(0)
+      expect(stdout).toContain('--project-name safe-name')
+      expect(stdout).toContain('--structure monorepo')
+      expect(stdout).toContain("--project-description 'Acme'\\''s SaaS with \"quotes\" & spaces'")
+    })
+  })
+
+  describe('Boolean negation', () => {
+    it('emits --no-analytics when analytics=false and a negationFlag exists', async () => {
+      const { stdout, code } = await runWithIntent({
+        projectName: 'x',
+        structure: 'monorepo',
+        analytics: false
+      })
+      expect(code).toBe(0)
+      expect(stdout).toContain('--no-analytics')
+      expect(stdout).not.toContain(' --analytics ')
+    })
+  })
+
+  describe('CSV validation', () => {
+    it('rejects unknown advanced skill values', async () => {
+      const { code, stderr } = await runWithIntent({
+        projectName: 'x',
+        structure: 'monorepo',
+        advancedSkills: ['context7', 'badvalue']
+      })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/invalid value "badvalue" in advancedSkills/)
+    })
+  })
+})


### PR DESCRIPTION
Closes #104

## Summary
- New **`reference/new-flags.json`** manifest: single source of truth for the full `sf new` surface (38 fields with type, required, default, enum values, secret flag, negation flag)
- New **`scripts/plan-new.sh` + `plan-new.js`**: read a JSON intent on stdin, validate against the manifest, emit the equivalent `sf new --non-interactive …` command on stdout. POSIX-safe shell quoting, explicit exit codes (0 / 1 / 2)
- New **Discovery section in `SKILL.md`**: three-mode discovery flow (Guided / Express / Expert), 5-step workflow, recommendation rules table, "never do" guardrails

## Test plan
- [x] `npm run test:pre-commit` → 499/499 Jest tests pass (43 suites)
- [x] `npm run test:pre-push` → 2/2 Docker scenarios pass (multirepo-minimal, monorepo-minimal)
- [x] 10 new Jest tests in `src/__tests__/unit/skill/plan-new.spec.ts` cover:
  - Minimal monorepo command building
  - Full multirepo with modules (manifest-order flags, CSV unquoted)
  - Missing required field → exit 2
  - Bad enum value → exit 2 with allowed values listed
  - Malformed JSON / empty stdin / top-level array → exit 2
  - Shell-quoting of values with quotes/spaces/ampersand
  - Boolean negation (`analytics: false` → `--no-analytics`)
  - CSV value validation (`advancedSkills`)

## Non-regression
- 489 pre-existing tests unchanged
- No touch to `src/commands/new.ts`, prompts, or builders — skill-side only

🤖 Generated with [Claude Code](https://claude.com/claude-code)