### PR TITLE
Phase 2D: Discovery conversationnelle pour sf update (#105)

### DIFF
--- a/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
+++ b/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
@@ -127,6 +127,57 @@ The full rationale for each recommendation is in the `recommendations` block of 
 - **Don't re-serialize the plan by hand.** Always round-trip through `plan-new.sh` so the command stays consistent with the manifest.
 - **Don't stash secrets in the intent you echo back.** Collect them, pass them through to `plan-new.sh`, but redact in any user-facing summary.
 
+## Discovery: `sf update`
+
+When the user wants to evolve an existing SaaSFoundry project (add a module, apply template updates), the skill replaces the CLI's Inquirer prompts with the same conversational flow pattern as `sf new`. The intent is produced as a JSON object, materialized into a single `sf update --non-interactive …` command via `plan-update.sh`. The intent schema is documented in `reference/update-flags.json`.
+
+> **Scope note** — `sf update` is **add-only** today. Module removal is not yet supported by the CLI; if the user asks to remove a module, point them at `sf feedback request` to track the request and keep the conversation unblocked.
+
+### Three discovery modes
+
+Same triage as `sf new`:
+
+| Mode | When it fits | Flow |
+| --- | --- | --- |
+| **Guided** *(default)* | User says "I want to add email" or "what's missing from my project?" | Read `.saasfoundry.json` + catalogue, recommend 1–2 modules with rationale, ask one question at a time |
+| **Express** | User says exactly what they want: "add email and analytics" | Build intent, echo back as a plan, single-shot confirmation |
+| **Expert** | User pastes a full or partial `sf update --non-interactive …` command | Pass through after sanity-checking flag names + module values against the manifest |
+
+### Discovery workflow
+
+1. **Bootstrap** — run `bootstrap-cli.sh` to resolve the invocation token. Cache for the rest of the turn.
+2. **Read project state** — parse `.saasfoundry.json` to know what modules are already installed. Pass that list in the intent as `alreadyInstalled` so `plan-update.sh` can reject silent no-ops.
+3. **Consult the catalogue** — `sf modules list --json` for the full list, `sf modules info <slug> --json` for drill-down. Never invent module names.
+4. **Gather intent** — build a JSON object matching `fields` in `reference/update-flags.json`. Only include fields the user has confirmed.
+5. **Dry-run first** — set `dryRun: true` in the intent and show the output to the user. Only rebuild the intent with `dryRun: false` after explicit approval.
+6. **Materialize the plan** — pipe the intent JSON into `scripts/plan-update.sh`. It emits the command on stdout or exits non-zero with a validation message on stderr.
+7. **Present and confirm** — show the command + a human summary of what will be added + which credentials were captured (redact secret values). Wait for approval before running.
+
+### Intent schema (summary)
+
+Full specification: `reference/update-flags.json`. Essentials:
+
+- **`addModules`** (CSV) — values must match `sf modules list --json`; collision with `alreadyInstalled` is an error, not a warning
+- **`dryRun`** (boolean) — recommend `true` for the first round; flip to `false` only after user approves the plan
+- **`conflictStrategy`** (enum: `keep` | `replace` | `save-new`) — default `save-new`; only change if the user has strong preferences about their local edits
+- **Credential pass-throughs** — only collect the ones required by the modules being added (`mailersend*` when adding email, `s3*` when adding storage, `*ApiToken` when adding advanced skills). All `secret: true` fields must be redacted in any echo-back
+
+### Recommendation rules
+
+| Dimension | Default | Condition to override |
+| --- | --- | --- |
+| `dryRun` | `true` on first run | Skip only when the user explicitly says "just do it" and the change is small |
+| `conflictStrategy` | `save-new` | Recommend `keep` when the user has significant local edits they don't want touched; `replace` only when they ask for "latest upstream, overwrite mine" |
+| Which modules to propose | None unless user asks | If the user asks "what should I add next?", consult `recommendations.modules` in the manifest for guidance anchored to product needs |
+
+### Never do these
+
+- **Don't propose a module already in `.saasfoundry.json`.** Check `alreadyInstalled` before building the intent; suggesting a silent no-op erodes user trust.
+- **Don't skip the dry-run round** unless the user explicitly waives it.
+- **Don't suggest module removal as if it were supported.** Redirect to `sf feedback request` and note the limitation.
+- **Don't fabricate module names.** Every value in `addModules` must exist in `sf modules list --json`.
+- **Don't echo credentials.** Collect them, pass to `plan-update.sh`, redact in any user-facing summary.
+
 ## Interaction principles
 
 1. **Never bypass the CLI.** If the user asks for a file or layout that the CLI can generate, generate it via `sf`. Do not hand-write blueprints.
@@ -139,7 +190,6 @@ The full rationale for each recommendation is in the `recommendations` block of 
 
 This SKILL.md is the foundation (Phase 2A, ticket #102). The following capabilities will be layered on in subsequent tickets:
 
-- **Phase 2D — Discovery for `sf update`** (#105): same treatment for module add/remove, catalogue-aware.
 - **Phase 2E — Project Awareness** (#106): read-only conversational queries over `.saasfoundry.json` and the module catalogue.
 
 Phases 3+ (Anti-reinvention guardrail, Community voting polish, Event handling) are tracked under epic #18.

--- a/scaffolds/skills-templates/tool-saasfoundry/reference/update-flags.json
+++ b/scaffolds/skills-templates/tool-saasfoundry/reference/update-flags.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "description": "Source of truth for the sf update command surface used by the tool-saasfoundry skill. Each entry maps an intent JSON field to its corresponding --flag on `sf update`. Both plan-update.sh and the skill's discovery conversation read this file — keep them in sync by editing here, never by hardcoding flag names elsewhere. sf update is ADD-ONLY today; module removal is not yet supported by the CLI.",
+  "command": "sf update",
+  "alwaysAppend": ["--non-interactive"],
+  "fields": {
+    "addModules": {
+      "flag": "--add-modules",
+      "type": "csv",
+      "values": [
+        "email",
+        "storage",
+        "analytics",
+        "sf-skill-context7",
+        "sf-skill-atlassian",
+        "sf-skill-notion",
+        "sf-skill-figma"
+      ],
+      "required": false,
+      "description": "Comma-separated list of modules to add. Values must come from `sf modules list --json` and must not already appear in .saasfoundry.json."
+    },
+    "dryRun": {
+      "flag": "--dry-run",
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "description": "Emit a JSON plan on stdout without mutating files. Always recommend this first."
+    },
+    "acceptTemplateUpdates": {
+      "flag": "--accept-template-updates",
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "description": "Auto-apply non-conflicting template updates without prompting."
+    },
+    "conflictStrategy": {
+      "flag": "--conflict-strategy",
+      "type": "enum",
+      "values": ["keep", "replace", "save-new"],
+      "required": false,
+      "default": "save-new",
+      "description": "How three-way merge conflicts are handled. save-new preserves both sides, keep ignores upstream changes, replace overwrites local edits."
+    },
+    "mailersendApiKey": {
+      "flag": "--mailersend-api-key",
+      "type": "string",
+      "required": false,
+      "secret": true,
+      "requiresWhen": "addModules includes email"
+    },
+    "mailersendSenderEmail": {
+      "flag": "--mailersend-sender-email",
+      "type": "string",
+      "required": false,
+      "requiresWhen": "addModules includes email"
+    },
+    "mailersendSenderName": {
+      "flag": "--mailersend-sender-name",
+      "type": "string",
+      "required": false,
+      "requiresWhen": "addModules includes email"
+    },
+    "s3Setup": {
+      "flag": "--s3-setup",
+      "type": "enum",
+      "values": ["docker", "credentials"],
+      "required": false,
+      "requiresWhen": "addModules includes storage"
+    },
+    "s3Endpoint": { "flag": "--s3-endpoint", "type": "string", "required": false },
+    "s3AccessKey": { "flag": "--s3-access-key", "type": "string", "required": false, "secret": true },
+    "s3SecretKey": { "flag": "--s3-secret-key", "type": "string", "required": false, "secret": true },
+    "s3Bucket": { "flag": "--s3-bucket", "type": "string", "required": false },
+    "s3Region": { "flag": "--s3-region", "type": "string", "required": false },
+    "context7ApiKey": { "flag": "--context7-api-key", "type": "string", "required": false, "secret": true },
+    "atlassianEmail": { "flag": "--atlassian-email", "type": "string", "required": false },
+    "atlassianApiToken": { "flag": "--atlassian-api-token", "type": "string", "required": false, "secret": true },
+    "atlassianSite": { "flag": "--atlassian-site", "type": "string", "required": false },
+    "atlassianCloudId": { "flag": "--atlassian-cloud-id", "type": "string", "required": false },
+    "notionApiToken": { "flag": "--notion-api-token", "type": "string", "required": false, "secret": true },
+    "notionApiVersion": { "flag": "--notion-api-version", "type": "string", "required": false },
+    "figmaApiToken": { "flag": "--figma-api-token", "type": "string", "required": false, "secret": true }
+  },
+  "recommendations": {
+    "dryRun": {
+      "true": "Always recommend `--dry-run` first so the user sees the template-merge plan before files are mutated. Run the real command only after explicit approval.",
+      "false": "Only skip dry-run if the user explicitly says 'just do it' and the addition is one small module with no template merge risk."
+    },
+    "conflictStrategy": {
+      "save-new": "Default — the safest option: conflicting files are written as `.saasfoundry.new` next to the originals so the user can diff and reconcile.",
+      "keep": "Choose when the user has significant local edits they do not want touched by a template update.",
+      "replace": "Choose only when the user wants the latest upstream version and is okay losing local edits to conflicting files."
+    },
+    "modules": {
+      "email": "Recommend adding when the app now needs transactional email (password reset, invites, receipts). Requires a mailersend API key.",
+      "storage": "Recommend adding when the app needs file uploads (logos, user docs). Docker setup for local dev, credentials for staging/prod.",
+      "analytics": "Recommend adding when tracking user activity or business metrics becomes relevant. Self-hosted Umami, production-only.",
+      "sf-skill-context7": "Recommend adding when the project relies on third-party libs and needs up-to-date doc retrieval for the AI agent.",
+      "sf-skill-atlassian": "Recommend adding when issues/pages live in Jira or Confluence and the AI agent should read/write them.",
+      "sf-skill-notion": "Recommend adding when product specs or knowledge base live in Notion.",
+      "sf-skill-figma": "Recommend adding when design hand-off goes through Figma files."
+    }
+  }
+}

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-update.js
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-update.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+'use strict'
+
+// Converts a JSON intent payload (read from stdin) into the equivalent
+// `sf update --non-interactive ...` command on stdout. The manifest at
+// ../reference/update-flags.json is the source of truth for the flag surface.
+//
+// Intent may carry an `alreadyInstalled` array (modules currently present
+// in .saasfoundry.json). Any `addModules` entry colliding with that list
+// is rejected — the CLI would silently no-op, which is a bad UX for the
+// skill's conversational plan.
+//
+// Exit codes:
+//   0 — success
+//   1 — internal error (manifest missing)
+//   2 — invalid intent (missing required field, bad enum, malformed JSON,
+//       module already installed)
+
+const fs = require('fs')
+const path = require('path')
+
+const manifestPath = path.join(__dirname, '..', 'reference', 'update-flags.json')
+
+if (!fs.existsSync(manifestPath)) {
+  process.stderr.write('plan-update: manifest not found at ' + manifestPath + '\n')
+  process.exit(1)
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+const intentRaw = fs.readFileSync(0, 'utf8')
+if (!intentRaw.trim()) {
+  process.stderr.write('plan-update: empty intent on stdin\n')
+  process.exit(2)
+}
+
+let intent
+try {
+  intent = JSON.parse(intentRaw)
+} catch (err) {
+  process.stderr.write('plan-update: invalid JSON on stdin: ' + err.message + '\n')
+  process.exit(2)
+}
+
+if (intent === null || typeof intent !== 'object' || Array.isArray(intent)) {
+  process.stderr.write('plan-update: intent must be a JSON object\n')
+  process.exit(2)
+}
+
+for (const [key, spec] of Object.entries(manifest.fields)) {
+  if (spec.required && (intent[key] === undefined || intent[key] === null || intent[key] === '')) {
+    process.stderr.write('plan-update: missing required intent field: ' + key + '\n')
+    process.exit(2)
+  }
+}
+
+for (const [key, value] of Object.entries(intent)) {
+  if (key === 'alreadyInstalled') continue
+  const spec = manifest.fields[key]
+  if (!spec) continue
+  if (spec.type === 'enum' && !spec.values.includes(value)) {
+    process.stderr.write(
+      'plan-update: invalid value "' +
+        value +
+        '" for ' +
+        key +
+        '; expected one of ' +
+        spec.values.join(', ') +
+        '\n'
+    )
+    process.exit(2)
+  }
+  if (spec.type === 'csv' && Array.isArray(value) && spec.values) {
+    const bad = value.find((v) => !spec.values.includes(v))
+    if (bad !== undefined) {
+      process.stderr.write(
+        'plan-update: invalid value "' +
+          bad +
+          '" in ' +
+          key +
+          '; expected one of ' +
+          spec.values.join(', ') +
+          '\n'
+      )
+      process.exit(2)
+    }
+  }
+}
+
+if (Array.isArray(intent.alreadyInstalled) && Array.isArray(intent.addModules)) {
+  const collision = intent.addModules.find((m) => intent.alreadyInstalled.includes(m))
+  if (collision !== undefined) {
+    process.stderr.write(
+      'plan-update: module "' + collision + '" is already installed; drop it from addModules\n'
+    )
+    process.exit(2)
+  }
+}
+
+const parts = [...String(manifest.command).trim().split(/\s+/), ...manifest.alwaysAppend]
+
+for (const [key, spec] of Object.entries(manifest.fields)) {
+  const value = intent[key]
+  if (value === undefined || value === null) continue
+
+  if (spec.type === 'boolean') {
+    if (value === true) parts.push(spec.flag)
+    else if (value === false && spec.negationFlag) parts.push(spec.negationFlag)
+    continue
+  }
+
+  if (spec.type === 'csv') {
+    const items = Array.isArray(value)
+      ? value
+      : String(value)
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+    if (items.length === 0) continue
+    parts.push(spec.flag, items.join(','))
+    continue
+  }
+
+  parts.push(spec.flag, String(value))
+}
+
+function quote(s) {
+  if (/^[A-Za-z0-9_./@:,=-]+$/.test(s)) return s
+  return "'" + s.replace(/'/g, "'\\''") + "'"
+}
+
+process.stdout.write(parts.map(quote).join(' ') + '\n')

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-update.sh
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-update.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Thin wrapper around plan-update.js. Accepts the intent JSON on stdin,
+# emits the equivalent `sf update --non-interactive ...` command on stdout.
+# See plan-update.js for the translation logic and exit codes.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "plan-update.sh: node is required to parse JSON intent" >&2
+  exit 1
+fi
+
+exec node "${SCRIPT_DIR}/plan-update.js"

--- a/src/__tests__/unit/skill/plan-update.spec.ts
+++ b/src/__tests__/unit/skill/plan-update.spec.ts
@@ -1,0 +1,152 @@
+import { execFile } from 'child_process'
+import path from 'path'
+
+const SCRIPT = path.resolve(__dirname, '../../../../scaffolds/skills-templates/tool-saasfoundry/scripts/plan-update.sh')
+const BASH = '/bin/bash'
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+async function runWithIntent(intent: unknown): Promise<ExecResult> {
+  const child = execFile(BASH, [SCRIPT])
+  const stdoutChunks: string[] = []
+  const stderrChunks: string[] = []
+  child.stdout?.setEncoding('utf8')
+  child.stderr?.setEncoding('utf8')
+  child.stdout?.on('data', (c: string) => stdoutChunks.push(c))
+  child.stderr?.on('data', (c: string) => stderrChunks.push(c))
+  child.stdin?.write(typeof intent === 'string' ? intent : JSON.stringify(intent))
+  child.stdin?.end()
+  const code = await new Promise<number>((resolve) => child.on('close', (c) => resolve(c ?? 0)))
+  return {
+    stdout: stdoutChunks.join(''),
+    stderr: stderrChunks.join(''),
+    code
+  }
+}
+
+describe('skill/plan-update', () => {
+  describe('Guided/Express — minimal add', () => {
+    it('builds the minimal command with just a single module addition', async () => {
+      const { stdout, code } = await runWithIntent({ addModules: ['email'] })
+      expect(code).toBe(0)
+      expect(stdout.trim()).toBe('sf update --non-interactive --add-modules email')
+    })
+  })
+
+  describe('Express — full plan with credentials and dry-run', () => {
+    it('emits flags in manifest order with CSV unquoted and dry-run set', async () => {
+      const { stdout, code } = await runWithIntent({
+        addModules: ['email', 'storage'],
+        dryRun: true,
+        conflictStrategy: 'save-new',
+        mailersendApiKey: 'ms_live_abc',
+        mailersendSenderEmail: 'noreply@example.com',
+        s3Setup: 'docker'
+      })
+      expect(code).toBe(0)
+      expect(stdout.trim()).toBe(
+        [
+          'sf update',
+          '--non-interactive',
+          '--add-modules email,storage',
+          '--dry-run',
+          '--conflict-strategy save-new',
+          '--mailersend-api-key ms_live_abc',
+          '--mailersend-sender-email noreply@example.com',
+          '--s3-setup docker'
+        ].join(' ')
+      )
+    })
+  })
+
+  describe('Catalogue-awareness — already installed collision', () => {
+    it('rejects a module that is already in alreadyInstalled', async () => {
+      const { code, stderr } = await runWithIntent({
+        addModules: ['email', 'storage'],
+        alreadyInstalled: ['email']
+      })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/module "email" is already installed; drop it from addModules/)
+    })
+
+    it('accepts additions when alreadyInstalled is disjoint', async () => {
+      const { stdout, code } = await runWithIntent({
+        addModules: ['storage'],
+        alreadyInstalled: ['email', 'analytics']
+      })
+      expect(code).toBe(0)
+      expect(stdout.trim()).toBe('sf update --non-interactive --add-modules storage')
+    })
+  })
+
+  describe('Validation — bad enum', () => {
+    it('exits 2 when conflictStrategy is not in the allowed set', async () => {
+      const { code, stderr } = await runWithIntent({
+        addModules: ['email'],
+        conflictStrategy: 'overwrite-everything'
+      })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(
+        /invalid value "overwrite-everything" for conflictStrategy; expected one of keep, replace, save-new/
+      )
+    })
+  })
+
+  describe('Validation — unknown module', () => {
+    it('rejects addModules values not listed in the manifest', async () => {
+      const { code, stderr } = await runWithIntent({
+        addModules: ['email', 'not-a-real-module']
+      })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/invalid value "not-a-real-module" in addModules/)
+    })
+  })
+
+  describe('Validation — malformed JSON', () => {
+    it('exits 2 on non-JSON input', async () => {
+      const { code, stderr } = await runWithIntent('not json at all')
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/invalid JSON on stdin/)
+    })
+
+    it('exits 2 on empty stdin', async () => {
+      const { code, stderr } = await runWithIntent('')
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/empty intent on stdin/)
+    })
+
+    it('exits 2 on a JSON array at top level', async () => {
+      const { code, stderr } = await runWithIntent([])
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/intent must be a JSON object/)
+    })
+  })
+
+  describe('Expert — credentials with risky characters', () => {
+    it('shell-quotes values containing spaces and quotes', async () => {
+      const { stdout, code } = await runWithIntent({
+        addModules: ['email'],
+        mailersendSenderName: "Acme's Support Team"
+      })
+      expect(code).toBe(0)
+      expect(stdout).toContain('--add-modules email')
+      expect(stdout).toContain("--mailersend-sender-name 'Acme'\\''s Support Team'")
+    })
+  })
+
+  describe('Boolean emission', () => {
+    it('omits dry-run flag when dryRun is false', async () => {
+      const { stdout, code } = await runWithIntent({
+        addModules: ['analytics'],
+        dryRun: false
+      })
+      expect(code).toBe(0)
+      expect(stdout).not.toContain('--dry-run')
+      expect(stdout.trim()).toBe('sf update --non-interactive --add-modules analytics')
+    })
+  })
+})

--- a/src/__tests__/unit/skill/plan-update.spec.ts
+++ b/src/__tests__/unit/skill/plan-update.spec.ts
@@ -90,9 +90,7 @@ describe('skill/plan-update', () => {
         conflictStrategy: 'overwrite-everything'
       })
       expect(code).toBe(2)
-      expect(stderr).toMatch(
-        /invalid value "overwrite-everything" for conflictStrategy; expected one of keep, replace, save-new/
-      )
+      expect(stderr).toMatch(/invalid value "overwrite-everything" for conflictStrategy; expected one of keep, replace, save-new/)
     })
   })
 


### PR DESCRIPTION
Closes #105

## Summary
- New **`reference/update-flags.json`** manifest: single source of truth for the `sf update` surface — 7 add-module values, `--dry-run`, `--conflict-strategy` enum, `--accept-template-updates`, plus all credential pass-throughs
- New **`scripts/plan-update.sh` + `plan-update.js`**: intent JSON on stdin → `sf update --non-interactive …` on stdout. Catalogue-aware: rejects `addModules` entries already present in `alreadyInstalled`
- New **Discovery section in `SKILL.md`**: 3-mode flow (Guided / Express / Expert), 7-step workflow anchored on a mandatory dry-run round, explicit scope note that module removal is not yet supported (redirect to `sf feedback request`)

## Test plan
- [x] `npm run test:pre-commit` → **510/510 tests pass** (44 suites, 499 pre-existing + 11 new)
- [x] `npm run test:pre-push` → 2/2 Docker scenarios pass
- [x] 11 new Jest tests in `src/__tests__/unit/skill/plan-update.spec.ts`:
  - Minimal add-modules command
  - Full plan with credentials + dry-run + conflict-strategy
  - Collision with `alreadyInstalled` → exit 2
  - Disjoint `alreadyInstalled` → accepted
  - Bad `conflictStrategy` enum → exit 2 with allowed values listed
  - Unknown module in CSV → exit 2
  - Malformed / empty / array JSON → exit 2
  - Credentials with quotes/spaces → POSIX-escaped
  - `dryRun: false` → `--dry-run` omitted

## Non-regression
- 499 pre-existing tests unchanged
- No touch to `src/commands/update.ts`, prompts, or installers — skill-side only
- `new-flags.json` + `plan-new.sh` from #104 untouched

## Out of scope
- Live `sf update` execution (plan-update materializes the command only)
- Module removal (not yet supported by the CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)