### PR TITLE
feat(#106): Project Awareness (read-only queries sur .saasfoundry.json)

### DIFF
--- a/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
+++ b/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
@@ -178,6 +178,49 @@ Full specification: `reference/update-flags.json`. Essentials:
 - **Don't fabricate module names.** Every value in `addModules` must exist in `sf modules list --json`.
 - **Don't echo credentials.** Collect them, pass to `plan-update.sh`, redact in any user-facing summary.
 
+## Project Awareness
+
+Project Awareness is the read-only surface of the skill. When the user asks a question about the *current* state of their SaaSFoundry project, the skill answers from a consolidated snapshot — it never writes, never installs, never mutates anything.
+
+### Supported questions
+
+| User asks | How the skill answers |
+| --- | --- |
+| "What's my SaaSFoundry version? Am I up to date?" | `report.project.cliVersion` + `report.upToDate`. If `false`, list `report.modules.obsolete` with their `minCliVersion` and recommend `sf skill update` + `sf update`. |
+| "What modules do I have?" | `report.modules.installed` — read verbatim. If the user wants details on a specific one, run `sf modules info <slug> --json`. |
+| "What would `sf update` do right now?" | Do **not** answer from the snapshot alone. Run `sf update --dry-run --non-interactive` and show the plan (this is a CLI call, not a mutation). |
+| "Are there new modules since my install?" | `report.modules.newlyAvailable` — list with one-line descriptions from the catalogue (`sf modules info <name> --json` for the `description` field). |
+| "Where was this project generated / when?" | `report.project.generatedAt` + `report.project.structure` + `report.project.name`. |
+
+### Workflow
+
+1. **Bootstrap** — run `bootstrap-cli.sh` to resolve the invocation token (`sf` / `npx saasfoundry-cli`).
+2. **Gather snapshot** — run `scripts/read-project.sh` from the project root. It reads `.saasfoundry.json`, calls `sf modules list --json`, and emits a consolidated JSON report on stdout.
+3. **Answer from the report** — never invent facts about the project; if a field is missing in the report, tell the user you don't know rather than guessing.
+4. **Stay read-only** — if the user's follow-up becomes "add X", "remove Y", "upgrade Z", route through Phase 2D's `plan-update.sh`. Never let a "tell me about…" thread slip into a mutation without explicit intent.
+
+### Report shape (from `read-project.sh`)
+
+```json
+{
+  "project": { "name": "…", "structure": "monorepo", "cliVersion": "1.0.0-beta", "generatedAt": "…" },
+  "modules": {
+    "installed": ["email", "storage", "sf-skill-context7"],
+    "available": ["email", "storage", "analytics", …],
+    "newlyAvailable": ["analytics"],
+    "obsolete": [{ "name": "email", "minCliVersion": "1.1.0" }]
+  },
+  "upToDate": true
+}
+```
+
+### Never do these
+
+- **Don't write anything.** Project Awareness is read-only by design; mutations live in Phase 2C (`sf new`) and Phase 2D (`sf update`).
+- **Don't trust a stale snapshot across turns.** Re-run `read-project.sh` when the user signals they've made changes (commits, CLI runs, etc.).
+- **Don't fabricate module descriptions.** If the user wants "what does module X do?", call `sf modules info X --json` and read from the catalogue.
+- **Don't answer "am I up to date?" from cached intuition.** Always use `report.upToDate` — it's the only field that cross-checks installed modules against `catalogue.minCliVersion`.
+
 ## Interaction principles
 
 1. **Never bypass the CLI.** If the user asks for a file or layout that the CLI can generate, generate it via `sf`. Do not hand-write blueprints.

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+'use strict'
+
+// Consolidates .saasfoundry.json and `sf modules list --json` output into a
+// single read-only report the skill can answer project-awareness questions
+// from. This script performs NO mutations — for any add/remove flow, route
+// through plan-update.sh.
+//
+// Input (stdin, JSON object):
+//   {
+//     "manifest": <contents of .saasfoundry.json>,
+//     "catalogue": [<sf modules list --json entries>]
+//   }
+//
+// Output (stdout, JSON object):
+//   {
+//     project: { name, structure, cliVersion, generatedAt },
+//     modules: {
+//       installed: [string],         // derived from manifest.modules
+//       available: [string],         // every catalogue entry name
+//       newlyAvailable: [string],    // in catalogue, not installed
+//       obsolete: [{name, minCliVersion}]   // catalogue minCliVersion > manifest.version
+//     },
+//     upToDate: boolean              // false when any installed module has minCliVersion > manifest.version
+//   }
+//
+// Exit codes:
+//   0 — success
+//   2 — invalid input (missing/empty stdin, malformed JSON, missing manifest or catalogue)
+
+const fs = require('fs')
+
+const raw = fs.readFileSync(0, 'utf8')
+if (!raw.trim()) {
+  process.stderr.write('read-project: empty input on stdin\n')
+  process.exit(2)
+}
+
+let input
+try {
+  input = JSON.parse(raw)
+} catch (err) {
+  process.stderr.write('read-project: invalid JSON on stdin: ' + err.message + '\n')
+  process.exit(2)
+}
+
+if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+  process.stderr.write('read-project: input must be a JSON object with "manifest" and "catalogue" keys\n')
+  process.exit(2)
+}
+
+const manifest = input.manifest
+const catalogue = input.catalogue
+
+if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+  process.stderr.write('read-project: input.manifest must be the .saasfoundry.json object\n')
+  process.exit(2)
+}
+
+if (!Array.isArray(catalogue)) {
+  process.stderr.write('read-project: input.catalogue must be an array (output of `sf modules list --json`)\n')
+  process.exit(2)
+}
+
+function deriveInstalled(m) {
+  const installed = []
+  const mods = m.modules || {}
+  if (mods.emailService && mods.emailService !== 'none') installed.push('email')
+  if (mods.s3Setup) installed.push('storage')
+  if (mods.includeAnalytics === true) installed.push('analytics')
+  if (Array.isArray(mods.advancedSkills)) {
+    for (const s of mods.advancedSkills) installed.push('sf-skill-' + s)
+  }
+  return installed
+}
+
+function compareSemver(a, b) {
+  const toParts = (v) =>
+    String(v)
+      .split('-')[0]
+      .split('.')
+      .map((n) => parseInt(n, 10) || 0)
+  const [aMaj, aMin, aPatch] = toParts(a)
+  const [bMaj, bMin, bPatch] = toParts(b)
+  if (aMaj !== bMaj) return aMaj - bMaj
+  if (aMin !== bMin) return aMin - bMin
+  return aPatch - bPatch
+}
+
+const installed = deriveInstalled(manifest)
+const installedSet = new Set(installed)
+const available = catalogue.map((c) => c.name)
+const newlyAvailable = available.filter((n) => !installedSet.has(n))
+
+const cliVersion = manifest.version || 'unknown'
+const obsolete = []
+for (const entry of catalogue) {
+  if (!installedSet.has(entry.name)) continue
+  if (!entry.minCliVersion) continue
+  if (compareSemver(entry.minCliVersion, cliVersion) > 0) {
+    obsolete.push({ name: entry.name, minCliVersion: entry.minCliVersion })
+  }
+}
+
+const report = {
+  project: {
+    name: manifest.projectName || 'unknown',
+    structure: manifest.structure || 'unknown',
+    cliVersion,
+    generatedAt: manifest.generatedAt || null
+  },
+  modules: {
+    installed,
+    available,
+    newlyAvailable,
+    obsolete
+  },
+  upToDate: obsolete.length === 0
+}
+
+process.stdout.write(JSON.stringify(report, null, 2) + '\n')

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.sh
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reads .saasfoundry.json from the current directory and `sf modules list --json`
+# from the resolved CLI invocation, then emits a consolidated read-only report
+# via read-project.js.
+#
+# Env overrides (useful for skill orchestration and tests):
+#   SF_MANIFEST_PATH — path to .saasfoundry.json (default: ./.saasfoundry.json)
+#   SF_CLI           — command token for the saasfoundry CLI (default: sf)
+#                      e.g. "sf", "saasfoundry-cli", or "npx saasfoundry-cli"
+#
+# Exit codes:
+#   0 — success
+#   1 — internal error (CLI invocation failed)
+#   2 — invalid input (manifest missing / invalid)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST_PATH="${SF_MANIFEST_PATH:-./.saasfoundry.json}"
+SF_CLI_CMD="${SF_CLI:-sf}"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "read-project.sh: node is required" >&2
+  exit 1
+fi
+
+if [ ! -f "${MANIFEST_PATH}" ]; then
+  echo "read-project.sh: manifest not found at ${MANIFEST_PATH} — is this a SaaSFoundry project?" >&2
+  exit 2
+fi
+
+manifest_json=$(cat "${MANIFEST_PATH}")
+
+# Resolve the catalogue: run `<sf> modules list --json`. Fall back to an empty
+# array with a visible warning on stderr so the script still emits a useful
+# report (installed modules + upToDate based on version only).
+catalogue_json="[]"
+if ! catalogue_json=$(${SF_CLI_CMD} modules list --json 2>/dev/null); then
+  echo "read-project.sh: '${SF_CLI_CMD} modules list --json' failed — reporting with empty catalogue" >&2
+  catalogue_json="[]"
+fi
+
+node "${SCRIPT_DIR}/read-project.js" <<EOF
+{
+  "manifest": ${manifest_json},
+  "catalogue": ${catalogue_json}
+}
+EOF

--- a/src/__tests__/unit/skill/read-project.spec.ts
+++ b/src/__tests__/unit/skill/read-project.spec.ts
@@ -1,10 +1,7 @@
 import { execFile } from 'child_process'
 import path from 'path'
 
-const SCRIPT = path.resolve(
-  __dirname,
-  '../../../../scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js'
-)
+const SCRIPT = path.resolve(__dirname, '../../../../scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js')
 const NODE = process.execPath
 
 interface ExecResult {
@@ -78,12 +75,7 @@ describe('skill/read-project', () => {
         generatedAt: '2026-04-01T10:00:00Z'
       })
       expect(report.modules.installed).toEqual(['email'])
-      expect(report.modules.newlyAvailable).toEqual([
-        'storage',
-        'analytics',
-        'sf-skill-context7',
-        'sf-skill-notion'
-      ])
+      expect(report.modules.newlyAvailable).toEqual(['storage', 'analytics', 'sf-skill-context7', 'sf-skill-notion'])
       expect(report.modules.obsolete).toEqual([])
       expect(report.upToDate).toBe(true)
     })
@@ -105,13 +97,7 @@ describe('skill/read-project', () => {
         },
         catalogue: fullCatalogue
       })
-      expect(report.modules.installed).toEqual([
-        'email',
-        'storage',
-        'analytics',
-        'sf-skill-context7',
-        'sf-skill-notion'
-      ])
+      expect(report.modules.installed).toEqual(['email', 'storage', 'analytics', 'sf-skill-context7', 'sf-skill-notion'])
       expect(report.modules.newlyAvailable).toEqual([])
       expect(report.upToDate).toBe(true)
     })

--- a/src/__tests__/unit/skill/read-project.spec.ts
+++ b/src/__tests__/unit/skill/read-project.spec.ts
@@ -1,0 +1,250 @@
+import { execFile } from 'child_process'
+import path from 'path'
+
+const SCRIPT = path.resolve(
+  __dirname,
+  '../../../../scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js'
+)
+const NODE = process.execPath
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+async function runWithInput(input: unknown): Promise<ExecResult> {
+  const child = execFile(NODE, [SCRIPT])
+  const stdoutChunks: string[] = []
+  const stderrChunks: string[] = []
+  child.stdout?.setEncoding('utf8')
+  child.stderr?.setEncoding('utf8')
+  child.stdout?.on('data', (c: string) => stdoutChunks.push(c))
+  child.stderr?.on('data', (c: string) => stderrChunks.push(c))
+  child.stdin?.write(typeof input === 'string' ? input : JSON.stringify(input))
+  child.stdin?.end()
+  const code = await new Promise<number>((resolve) => child.on('close', (c) => resolve(c ?? 0)))
+  return {
+    stdout: stdoutChunks.join(''),
+    stderr: stderrChunks.join(''),
+    code
+  }
+}
+
+interface Report {
+  project: { name: string; structure: string; cliVersion: string; generatedAt: string | null }
+  modules: {
+    installed: string[]
+    available: string[]
+    newlyAvailable: string[]
+    obsolete: Array<{ name: string; minCliVersion: string }>
+  }
+  upToDate: boolean
+}
+
+async function runAndParse(input: unknown): Promise<Report & ExecResult> {
+  const res = await runWithInput(input)
+  if (res.code !== 0) {
+    throw new Error(`Expected success, got code=${res.code}, stderr=${res.stderr}`)
+  }
+  return { ...res, ...(JSON.parse(res.stdout) as Report) }
+}
+
+const fullCatalogue = [
+  { name: 'email', minCliVersion: '1.0.0-beta', description: 'Transactional email' },
+  { name: 'storage', minCliVersion: '1.0.0-beta', description: 'S3-compatible storage' },
+  { name: 'analytics', minCliVersion: '1.0.0-beta', description: 'Usage analytics' },
+  { name: 'sf-skill-context7', minCliVersion: '1.0.0-beta', description: 'Context7 MCP' },
+  { name: 'sf-skill-notion', minCliVersion: '1.0.0-beta', description: 'Notion MCP' }
+]
+
+describe('skill/read-project', () => {
+  describe('Fresh install — only email', () => {
+    it('reports email installed and other modules as newlyAvailable', async () => {
+      const report = await runAndParse({
+        manifest: {
+          projectName: 'demo-app',
+          structure: 'monorepo',
+          version: '1.0.0-beta',
+          generatedAt: '2026-04-01T10:00:00Z',
+          modules: { emailService: 'mailersend' }
+        },
+        catalogue: fullCatalogue
+      })
+      expect(report.project).toEqual({
+        name: 'demo-app',
+        structure: 'monorepo',
+        cliVersion: '1.0.0-beta',
+        generatedAt: '2026-04-01T10:00:00Z'
+      })
+      expect(report.modules.installed).toEqual(['email'])
+      expect(report.modules.newlyAvailable).toEqual([
+        'storage',
+        'analytics',
+        'sf-skill-context7',
+        'sf-skill-notion'
+      ])
+      expect(report.modules.obsolete).toEqual([])
+      expect(report.upToDate).toBe(true)
+    })
+  })
+
+  describe('Every module installed', () => {
+    it('lists all modules, nothing newly available, up to date', async () => {
+      const report = await runAndParse({
+        manifest: {
+          projectName: 'kitchen-sink',
+          structure: 'multirepo',
+          version: '1.0.0-beta',
+          modules: {
+            emailService: 'mailersend',
+            s3Setup: 'docker',
+            includeAnalytics: true,
+            advancedSkills: ['context7', 'notion']
+          }
+        },
+        catalogue: fullCatalogue
+      })
+      expect(report.modules.installed).toEqual([
+        'email',
+        'storage',
+        'analytics',
+        'sf-skill-context7',
+        'sf-skill-notion'
+      ])
+      expect(report.modules.newlyAvailable).toEqual([])
+      expect(report.upToDate).toBe(true)
+    })
+  })
+
+  describe('Advanced skills subset', () => {
+    it('only lists installed skills and marks the rest newly available', async () => {
+      const report = await runAndParse({
+        manifest: {
+          projectName: 'partial',
+          structure: 'monorepo',
+          version: '1.0.0-beta',
+          modules: { advancedSkills: ['context7'] }
+        },
+        catalogue: fullCatalogue
+      })
+      expect(report.modules.installed).toEqual(['sf-skill-context7'])
+      expect(report.modules.newlyAvailable).toContain('sf-skill-notion')
+      expect(report.modules.newlyAvailable).not.toContain('sf-skill-context7')
+    })
+  })
+
+  describe('Obsolete CLI version', () => {
+    it('flags installed modules whose minCliVersion exceeds cliVersion', async () => {
+      const report = await runAndParse({
+        manifest: {
+          projectName: 'stale',
+          structure: 'monorepo',
+          version: '1.0.0-beta',
+          modules: { emailService: 'mailersend', s3Setup: 'docker' }
+        },
+        catalogue: [
+          { name: 'email', minCliVersion: '1.1.0' },
+          { name: 'storage', minCliVersion: '1.0.0-beta' }
+        ]
+      })
+      expect(report.modules.obsolete).toEqual([{ name: 'email', minCliVersion: '1.1.0' }])
+      expect(report.upToDate).toBe(false)
+    })
+
+    it('ignores obsolete entries for modules the project does not have', async () => {
+      const report = await runAndParse({
+        manifest: {
+          projectName: 'lean',
+          structure: 'monorepo',
+          version: '1.0.0-beta',
+          modules: { emailService: 'mailersend' }
+        },
+        catalogue: [
+          { name: 'email', minCliVersion: '1.0.0-beta' },
+          { name: 'analytics', minCliVersion: '9.9.9' }
+        ]
+      })
+      expect(report.modules.obsolete).toEqual([])
+      expect(report.upToDate).toBe(true)
+    })
+  })
+
+  describe('Empty catalogue', () => {
+    it('emits a report with available=[] and upToDate=true', async () => {
+      const report = await runAndParse({
+        manifest: {
+          projectName: 'offline',
+          structure: 'monorepo',
+          version: '1.0.0-beta',
+          modules: { emailService: 'mailersend' }
+        },
+        catalogue: []
+      })
+      expect(report.modules.available).toEqual([])
+      expect(report.modules.newlyAvailable).toEqual([])
+      expect(report.modules.installed).toEqual(['email'])
+      expect(report.upToDate).toBe(true)
+    })
+  })
+
+  describe('Manifest defaults', () => {
+    it('falls back to unknown/null when optional fields are absent', async () => {
+      const report = await runAndParse({
+        manifest: { modules: {} },
+        catalogue: []
+      })
+      expect(report.project).toEqual({
+        name: 'unknown',
+        structure: 'unknown',
+        cliVersion: 'unknown',
+        generatedAt: null
+      })
+      expect(report.modules.installed).toEqual([])
+    })
+
+    it('treats emailService="none" as not installed', async () => {
+      const report = await runAndParse({
+        manifest: {
+          projectName: 'no-email',
+          version: '1.0.0-beta',
+          modules: { emailService: 'none', includeAnalytics: true }
+        },
+        catalogue: fullCatalogue
+      })
+      expect(report.modules.installed).toEqual(['analytics'])
+    })
+  })
+
+  describe('Validation — malformed input', () => {
+    it('exits 2 on empty stdin', async () => {
+      const { code, stderr } = await runWithInput('')
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/empty input on stdin/)
+    })
+
+    it('exits 2 on invalid JSON', async () => {
+      const { code, stderr } = await runWithInput('{not json')
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/invalid JSON on stdin/)
+    })
+
+    it('exits 2 on a top-level array', async () => {
+      const { code, stderr } = await runWithInput([])
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input must be a JSON object/)
+    })
+
+    it('exits 2 when manifest is missing', async () => {
+      const { code, stderr } = await runWithInput({ catalogue: [] })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input.manifest must be the .saasfoundry.json object/)
+    })
+
+    it('exits 2 when catalogue is not an array', async () => {
+      const { code, stderr } = await runWithInput({ manifest: { modules: {} }, catalogue: 'oops' })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input.catalogue must be an array/)
+    })
+  })
+})


### PR DESCRIPTION
## Ticket
Closes #106 — Phase 2E: Project Awareness (read-only queries sur `.saasfoundry.json`).

## Summary

- **`scripts/read-project.sh` + `read-project.js`** — consolidated read-only report consumed by the skill to answer "what's my version / what modules / what's newly available" without any mutation.
  - Reads `.saasfoundry.json` (path overridable via `SF_MANIFEST_PATH`).
  - Calls `${SF_CLI:-sf} modules list --json`, falls back to an empty catalogue with a stderr warning if the CLI invocation fails.
  - Emits `{ project, modules.{installed, available, newlyAvailable, obsolete}, upToDate }`.
- **SKILL.md — new "Project Awareness" section** — lists the 5 supported questions, the 4-step workflow (bootstrap → snapshot → answer → stay read-only), the report shape, and the "never-do" rules (no mutations, don't trust stale snapshots, always use `upToDate`).
- **13 new Jest tests** covering fresh install, kitchen-sink, advanced-skills subset, obsolete CLI version, catalogue edge cases, manifest defaults, and 5 malformed-input validations.

## Test plan

See [the AI Testing comment on #106](https://github.com/DiamondForgeFr/SaaSFoundry/issues/106#issuecomment-4271754375) for the full 10-scenario plan. All scenarios validated in [the AI Testing report](https://github.com/DiamondForgeFr/SaaSFoundry/issues/106#issuecomment-4271757335).

- [x] Unit — `src/__tests__/unit/skill/read-project.spec.ts` (13 tests)
- [x] Lint + build + full Jest (523/523)
- [x] Pre-push Docker smoke (`monorepo-minimal`, `multirepo-minimal`)
- [x] Live smoke in a temp project (script end-to-end)
- [x] Human Testing validated

## Commits

- `feat(#106)` — `read-project.sh` + `read-project.js`
- `docs(#106)` — Project Awareness section in SKILL.md
- `test(#106)` — 13 Jest fixtures
- `style(#106)` — prettier reformat

🤖 Generated with [Claude Code](https://claude.com/claude-code)