### PR TITLE
feat(#124): Phase 3B — Feedback Request flow (scorecard + dedup)

### DIFF
--- a/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
+++ b/scaffolds/skills-templates/tool-saasfoundry/SKILL.md
@@ -26,6 +26,7 @@ Activate on explicit SaaSFoundry intent:
 - "what modules do I have?" / "am I up to date?" / "what's in `.saasfoundry.json`?"
 - "file a module request" / "report a SaaSFoundry bug" / "vote on roadmap"
 - **Add/build/implement verbs inside a SaaSFoundry project** — "I want to add file uploads", "let's build an email flow", "I need to track usage" → the skill runs the anti-reinvention guardrail (see below) *before* letting the user custom-code.
+- **Explicit feedback intent** — "file a module request for X", "I want to request Y", "this should be a first-party module" → the skill runs the Feedback — Module Request scorecard (see below) *before* calling `sf feedback request`.
 
 Do NOT activate on:
 
@@ -239,7 +240,7 @@ When the user expresses intent to build, add, or implement a capability **inside
 3. **Read the `tier` field** and act accordingly:
    - `HIGH` (score ≥ 6) → Propose `sf update --add-modules <name>` **before** writing a single line of custom code. Present the tradeoff: what the module ships (routes, adapters, docs, tests, CI) vs what a hand-rolled impl costs the user (maintenance, drift from blueprint, no upstream updates).
    - `MEDIUM` (score 3–5) → Surface the candidate, ask the user to confirm it matches their intent (use `AskUserQuestion`), and only then propose `sf update`.
-   - `LOW` (score 1–2) or `NONE` (no results) → Route to Phase 3B: offer `sf feedback request` so the user can push for catalogue inclusion, then fall back to custom dev with eyes open.
+   - `LOW` (score 1–2) or `NONE` (no results) → Route to **Feedback — Module Request** below: run the scorecard before offering `sf feedback request`, then fall back to custom dev with eyes open.
 4. **Stay honest** — if the user insists on custom code even with a HIGH match, do it. But log the decision explicitly ("we're building X custom despite a HIGH catalogue match for module Y"), so future-you doesn't re-propose it every turn.
 
 ### Recommendation shape (from `check-catalogue.sh`)
@@ -264,6 +265,72 @@ When the user expresses intent to build, add, or implement a capability **inside
 - **Don't force a HIGH-tier proposal.** If the user confirms they want custom dev, move on. The guardrail informs, it doesn't block.
 - **Don't conflate `LOW` with `NONE`.** A LOW-tier match is still a signal — surface it as "closest neighbor" when routing to `sf feedback request`, so the user's request can reference existing work.
 
+## Feedback — Module Request
+
+When the user wants to file a module request — either because the anti-reinvention guardrail routed them here (LOW/NONE tier), or because they explicitly asked to — the skill MUST run a 5-criterion scorecard **before** calling `sf feedback request`. The scorecard exists because a catalogue slot is a long-term maintenance commitment: the skill can and should **refuse** requests that don't fit, with clear reasoning, rather than filing noise.
+
+### When this flow triggers
+
+- Anti-reinvention guardrail returned `LOW` or `NONE` tier and the user wants to push for catalogue inclusion.
+- User says explicitly: "file a module request", "request this as a module", "submit this to SaaSFoundry", etc.
+- **Does NOT trigger** on bug reports (that's Phase 3C) or voting (Pillar 6 — `sf feedback vote --list`).
+
+### The 5-criterion scorecard
+
+Ask each criterion as a natural question during the conversation — don't hand the user a dry form. Each criterion answers `yes` / `no` / `unclear`. **One `no` or one `unclear` refuses the filing.**
+
+| Criterion | The question behind it | What `yes` looks like |
+| --- | --- | --- |
+| `scopeFit` | "Is this something every SaaS eventually wants?" | The feature belongs to the SaaS baseline (auth, billing, email, storage, observability, comms, admin tooling). |
+| `reusability` | "Would 3+ unrelated projects plausibly want this?" | Broad SaaS relevance, not specific to one product or industry. |
+| `notAlreadySolvable` | "Can't this already be done cleanly with existing modules or a small custom impl?" | Existing modules don't cover it, and a hand-rolled version would be non-trivial (>2 days work). |
+| `opinionOwnership` | "Is there a clear opinionated 'right way' to do this in SaaSFoundry?" | You can name the stack, the vendor(s), the integration surface without hedging. |
+| `maintenanceRealism` | "Can this be maintained long-term?" | Stable deps, non-fragile upstream, vendor is unlikely to pivot/shutter within 2 years. |
+
+If any criterion is `no` or `unclear`, the skill **refuses** the filing and explains which criteria blocked it. The refusal is not a snub — it's the skill protecting the catalogue from scope creep. Explain the red flag, and suggest alternatives (custom code, existing module, wait-and-see).
+
+### Workflow
+
+1. **Bootstrap** — run `bootstrap-cli.sh` to resolve the invocation token and `bootstrap-gh.sh` to confirm GitHub auth (filing requires it).
+2. **Gather the scorecard** — walk through the 5 criteria conversationally. Ask each one in plain language; translate the answer into `yes` / `no` / `unclear` yourself. Use `AskUserQuestion` for the user-facing choices when possible.
+3. **Propose a module name** — infer a kebab-case slug from the intent (e.g. "real-time chat" → `chat`). Confirm with the user before finalizing.
+4. **Classify** — pipe the intent + name + scorecard + optional description into `scripts/plan-feedback-request.sh`. The script fetches open module-request issues via `sf feedback list --status open --json`, detects duplicates, and emits a decision.
+5. **Act on the `decision` field**:
+   - `file-request` → Present the emitted `sf feedback request …` command, get explicit approval, then run it. Quote the scorecard answers in the issue description so future reviewers can see the rationale.
+   - `route-to-existing` → Point the user at the duplicate issue (number + title + url). Offer `sf feedback vote <n> up` or `sf feedback vote <n> comment --comment "…"` so the existing issue gathers traction instead of a parallel noise thread.
+   - `refuse` → List the `redFlags` array verbatim. Don't soft-pedal — the criteria are in place for a reason. If the user pushes back with new info, rebuild the scorecard (they may have just unblocked a criterion) and re-classify.
+
+### Recommendation shape (from `plan-feedback-request.sh`)
+
+```json
+{
+  "intent": "real-time chat between project members",
+  "name": "chat",
+  "decision": "refuse",
+  "redFlags": [
+    {
+      "criterion": "reusability",
+      "answer": "no",
+      "reason": "Low reusability — at least 3 unrelated projects should plausibly want this before it earns a slot in the catalogue."
+    }
+  ],
+  "duplicate": null,
+  "recommendation": {
+    "action": "refuse",
+    "command": null,
+    "message": "Refused: the scorecard has 1 red flag (reusability=no). Explain the red flags to the user before filing anything."
+  }
+}
+```
+
+### Never do these
+
+- **Don't skip the scorecard.** Even when routed here from anti-reinvention, run all 5 criteria — the guardrail's LOW tier is not a green light to file, it's a "worth evaluating" signal.
+- **Don't soft-pass an `unclear` answer.** `unclear` is a refusal, just like `no`. Treat it as "come back when you know" rather than "probably fine".
+- **Don't echo the scorecard without the decision.** The user should always hear the outcome (file / route / refuse) plus the reasoning, never a raw JSON dump.
+- **Don't skip dedup.** Always let `plan-feedback-request.sh` enrich the payload with `sf feedback list` — catching a duplicate before filing is the entire point of the orchestration.
+- **Don't file without `bootstrap-gh.sh`.** A filing attempt against an unauthenticated `gh` produces a confusing failure; surface the install/login guidance from `bootstrap-gh.sh` first.
+
 ## Interaction principles
 
 1. **Never bypass the CLI.** If the user asks for a file or layout that the CLI can generate, generate it via `sf`. Do not hand-write blueprints.
@@ -276,7 +343,6 @@ When the user expresses intent to build, add, or implement a capability **inside
 
 This SKILL.md is the foundation (Phase 2A, ticket #102). The following capabilities will be layered on in subsequent tickets:
 
-- **Phase 3B — Feedback Request flow** (#124): scorecard-gated module request orchestration on top of `sf feedback request`.
 - **Phase 3C — Feedback Bug Report flow** (#125): passive detection + auto-repro on top of `sf feedback bug`.
 - **Phase 4 — Community voting polish** (Pillar 6): skill-side UX for ranking and voting on open module requests.
 - **Phase 5 — Event handling** (Pillar 7): cmux/IDE/terminal adaptation for browser flows and multi-server launches.

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-feedback-request.js
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-feedback-request.js
@@ -164,17 +164,19 @@ if (redFlags.length > 0) {
   }
 }
 
+const reportedDuplicate = decision === 'route-to-existing' && duplicate ? duplicate : null
+
 const output = {
   intent: input.intent,
   name: input.name,
   decision,
   redFlags,
-  duplicate: duplicate
+  duplicate: reportedDuplicate
     ? {
-        number: duplicate.number,
-        title: duplicate.title,
-        url: typeof duplicate.url === 'string' ? duplicate.url : null,
-        state: typeof duplicate.state === 'string' ? duplicate.state : null
+        number: reportedDuplicate.number,
+        title: reportedDuplicate.title,
+        url: typeof reportedDuplicate.url === 'string' ? reportedDuplicate.url : null,
+        state: typeof reportedDuplicate.state === 'string' ? reportedDuplicate.state : null
       }
     : null,
   recommendation

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-feedback-request.js
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-feedback-request.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+'use strict'
+
+// Evaluates a 5-criterion scorecard for a proposed module-request feedback
+// issue and emits a structured decision the skill can speak from. Performs
+// NO mutations and NO network calls — just scorecard + dedup analysis.
+//
+// Input (stdin, JSON object):
+//   {
+//     "intent": "real-time chat between project members",
+//     "name": "chat",
+//     "scorecard": {
+//       "scopeFit":            "yes" | "no" | "unclear",
+//       "reusability":         "yes" | "no" | "unclear",
+//       "notAlreadySolvable":  "yes" | "no" | "unclear",
+//       "opinionOwnership":    "yes" | "no" | "unclear",
+//       "maintenanceRealism":  "yes" | "no" | "unclear"
+//     },
+//     "description": "optional longer pitch the skill drafted with the user",
+//     "existingIssues": [
+//       { "number": 42, "title": "[request] chat", "state": "open",
+//         "url": "https://github.com/.../42", "labels": ["module-request"] }
+//     ]
+//   }
+//
+// Output (stdout, JSON object):
+//   {
+//     intent: string,
+//     name: string,
+//     decision: "file-request" | "route-to-existing" | "refuse",
+//     redFlags: [{ criterion, answer, reason }],   // empty unless refuse
+//     duplicate: { number, title, url, state } | null,
+//     recommendation: {
+//       action: "run-command" | "route-to-existing" | "refuse",
+//       command: string | null,
+//       message: string
+//     }
+//   }
+//
+// Decision rules:
+//   - Any criterion answered "no"        → refuse, list red flags
+//   - Any criterion answered "unclear"   → refuse (ask user to resolve first)
+//   - All five "yes" AND duplicate found → route-to-existing
+//   - All five "yes" AND no duplicate    → file-request (emit sf command)
+//
+// Exit codes:
+//   0 — success
+//   2 — invalid input (empty stdin, malformed JSON, missing required keys)
+
+const fs = require('fs')
+
+const CRITERIA = ['scopeFit', 'reusability', 'notAlreadySolvable', 'opinionOwnership', 'maintenanceRealism']
+const ANSWERS = new Set(['yes', 'no', 'unclear'])
+
+const REFUSAL_REASONS = {
+  scopeFit: 'Out of SaaSFoundry scope — the skill should not file a request for a feature that does not belong in the SaaS baseline.',
+  reusability: 'Low reusability — at least 3 unrelated projects should plausibly want this before it earns a slot in the catalogue.',
+  notAlreadySolvable: 'Already solvable — an existing module or a small custom implementation covers this cleanly; no new module warranted.',
+  opinionOwnership: 'No strong opinion — SaaSFoundry modules are opinionated; without a clear "right way" the module would drift.',
+  maintenanceRealism: 'Maintenance risk — vendor churn, heavy deps, or fragile upstream makes long-term ownership unrealistic.'
+}
+
+const raw = fs.readFileSync(0, 'utf8')
+if (!raw.trim()) {
+  process.stderr.write('plan-feedback-request: empty input on stdin\n')
+  process.exit(2)
+}
+
+let input
+try {
+  input = JSON.parse(raw)
+} catch (err) {
+  process.stderr.write('plan-feedback-request: invalid JSON on stdin: ' + err.message + '\n')
+  process.exit(2)
+}
+
+if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+  process.stderr.write('plan-feedback-request: input must be a JSON object\n')
+  process.exit(2)
+}
+
+if (typeof input.intent !== 'string' || !input.intent.trim()) {
+  process.stderr.write('plan-feedback-request: input.intent must be a non-empty string\n')
+  process.exit(2)
+}
+
+if (typeof input.name !== 'string' || !input.name.trim()) {
+  process.stderr.write('plan-feedback-request: input.name must be a non-empty string (proposed module slug)\n')
+  process.exit(2)
+}
+
+if (!input.scorecard || typeof input.scorecard !== 'object' || Array.isArray(input.scorecard)) {
+  process.stderr.write('plan-feedback-request: input.scorecard must be an object with 5 criteria\n')
+  process.exit(2)
+}
+
+for (const criterion of CRITERIA) {
+  const answer = input.scorecard[criterion]
+  if (typeof answer !== 'string' || !ANSWERS.has(answer)) {
+    process.stderr.write('plan-feedback-request: input.scorecard.' + criterion + ' must be one of "yes" | "no" | "unclear"\n')
+    process.exit(2)
+  }
+}
+
+const existingIssues = Array.isArray(input.existingIssues) ? input.existingIssues : []
+
+const redFlags = []
+for (const criterion of CRITERIA) {
+  const answer = input.scorecard[criterion]
+  if (answer === 'no' || answer === 'unclear') {
+    redFlags.push({
+      criterion,
+      answer,
+      reason: REFUSAL_REASONS[criterion]
+    })
+  }
+}
+
+const nameLc = input.name.toLowerCase()
+const intentLc = input.intent.toLowerCase()
+const duplicate =
+  existingIssues.find((issue) => {
+    if (!issue || typeof issue.title !== 'string') return false
+    const title = issue.title.toLowerCase()
+    if (title.includes(nameLc)) return true
+    const nameTokens = nameLc.split(/[\s-_]+/).filter((t) => t.length >= 4)
+    const intentTokens = intentLc.split(/[\s-_]+/).filter((t) => t.length >= 4)
+    const tokens = new Set([...nameTokens, ...intentTokens])
+    for (const token of tokens) {
+      if (title.includes(token)) return true
+    }
+    return false
+  }) || null
+
+let decision
+let recommendation
+
+if (redFlags.length > 0) {
+  decision = 'refuse'
+  const criteriaList = redFlags.map((f) => f.criterion + '=' + f.answer).join(', ')
+  recommendation = {
+    action: 'refuse',
+    command: null,
+    message: 'Refused: the scorecard has ' + redFlags.length + ' red flag' + (redFlags.length === 1 ? '' : 's') + ' (' + criteriaList + '). Explain the red flags to the user before filing anything.'
+  }
+} else if (duplicate) {
+  decision = 'route-to-existing'
+  recommendation = {
+    action: 'route-to-existing',
+    command: null,
+    message: 'Duplicate found: issue #' + duplicate.number + ' — "' + duplicate.title + '". Route the user there (sf feedback vote ' + duplicate.number + ' up) instead of filing a new request.'
+  }
+} else {
+  decision = 'file-request'
+  let command = 'sf feedback request ' + input.name
+  if (typeof input.description === 'string' && input.description.trim()) {
+    const safe = input.description.replace(/"/g, '\\"')
+    command += ' --description "' + safe + '"'
+  }
+  recommendation = {
+    action: 'run-command',
+    command,
+    message: 'Scorecard all green and no duplicate found. File the request with: ' + command
+  }
+}
+
+const output = {
+  intent: input.intent,
+  name: input.name,
+  decision,
+  redFlags,
+  duplicate: duplicate
+    ? {
+        number: duplicate.number,
+        title: duplicate.title,
+        url: typeof duplicate.url === 'string' ? duplicate.url : null,
+        state: typeof duplicate.state === 'string' ? duplicate.state : null
+      }
+    : null,
+  recommendation
+}
+
+process.stdout.write(JSON.stringify(output, null, 2) + '\n')

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-feedback-request.sh
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/plan-feedback-request.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reads a feedback-request scorecard from stdin, enriches it with the list
+# of open module-request issues (via `sf feedback list`), and pipes the
+# consolidated payload to plan-feedback-request.js which classifies the
+# decision (file-request / route-to-existing / refuse) the skill speaks from.
+#
+# Usage:
+#   cat <<EOF | scripts/plan-feedback-request.sh
+#   {
+#     "intent": "real-time chat between project members",
+#     "name": "chat",
+#     "description": "first-party chat module with presence and history",
+#     "scorecard": {
+#       "scopeFit": "yes",
+#       "reusability": "yes",
+#       "notAlreadySolvable": "yes",
+#       "opinionOwnership": "yes",
+#       "maintenanceRealism": "yes"
+#     }
+#   }
+#   EOF
+#
+# Env overrides (useful for skill orchestration and tests):
+#   SF_CLI — command token for the saasfoundry CLI (default: sf)
+#            e.g. "sf", "saasfoundry-cli", or "npx saasfoundry-cli"
+#
+# Exit codes:
+#   0 — success
+#   1 — internal error (node missing, CLI invocation failed hard)
+#   2 — invalid input (empty/malformed scorecard)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SF_CLI_CMD="${SF_CLI:-sf}"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "plan-feedback-request.sh: node is required" >&2
+  exit 1
+fi
+
+if [ -t 0 ]; then
+  echo "plan-feedback-request.sh: scorecard must be piped on stdin" >&2
+  exit 2
+fi
+
+stdin_payload=$(cat)
+if [ -z "${stdin_payload}" ]; then
+  echo "plan-feedback-request.sh: empty input on stdin" >&2
+  exit 2
+fi
+
+# Fetch open module-request issues for dedup. If the CLI fails, fall back to
+# an empty list so the classifier still emits a decision rather than crashing.
+existing_json='[]'
+if raw_list=$(${SF_CLI_CMD} feedback list --status open --json --limit 100 2>/dev/null); then
+  existing_json=$(printf '%s' "${raw_list}" | node -e "
+    let r='';
+    process.stdin.on('data', c => r += c);
+    process.stdin.on('end', () => {
+      try {
+        const arr = JSON.parse(r);
+        const filtered = Array.isArray(arr)
+          ? arr.filter(i => i && i.kind === 'module-request')
+          : [];
+        process.stdout.write(JSON.stringify(filtered));
+      } catch {
+        process.stdout.write('[]');
+      }
+    });
+  ")
+else
+  echo "plan-feedback-request.sh: '${SF_CLI_CMD} feedback list' failed — skipping dedup" >&2
+fi
+
+# Merge the user scorecard with existingIssues and pipe to the classifier.
+export SF_EXISTING_ISSUES="${existing_json}"
+printf '%s' "${stdin_payload}" | node -e "
+  let r='';
+  process.stdin.on('data', c => r += c);
+  process.stdin.on('end', () => {
+    let input;
+    try { input = JSON.parse(r); }
+    catch (err) {
+      process.stderr.write('plan-feedback-request.sh: invalid JSON on stdin: ' + err.message + '\n');
+      process.exit(2);
+    }
+    if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+      process.stderr.write('plan-feedback-request.sh: input must be a JSON object\n');
+      process.exit(2);
+    }
+    const existing = JSON.parse(process.env.SF_EXISTING_ISSUES || '[]');
+    input.existingIssues = Array.isArray(input.existingIssues) && input.existingIssues.length > 0
+      ? input.existingIssues
+      : existing;
+    process.stdout.write(JSON.stringify(input));
+  });
+" | node "${SCRIPT_DIR}/plan-feedback-request.js"

--- a/src/__tests__/unit/skill/plan-feedback-request.spec.ts
+++ b/src/__tests__/unit/skill/plan-feedback-request.spec.ts
@@ -1,0 +1,280 @@
+import { execFile } from 'child_process'
+import path from 'path'
+
+const SCRIPT = path.resolve(__dirname, '../../../../scaffolds/skills-templates/tool-saasfoundry/scripts/plan-feedback-request.js')
+const NODE = process.execPath
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+async function runWithInput(input: unknown): Promise<ExecResult> {
+  const child = execFile(NODE, [SCRIPT])
+  const stdoutChunks: string[] = []
+  const stderrChunks: string[] = []
+  child.stdout?.setEncoding('utf8')
+  child.stderr?.setEncoding('utf8')
+  child.stdout?.on('data', (c: string) => stdoutChunks.push(c))
+  child.stderr?.on('data', (c: string) => stderrChunks.push(c))
+  child.stdin?.write(typeof input === 'string' ? input : JSON.stringify(input))
+  child.stdin?.end()
+  const code = await new Promise<number>((resolve) => child.on('close', (c) => resolve(c ?? 0)))
+  return { stdout: stdoutChunks.join(''), stderr: stderrChunks.join(''), code }
+}
+
+type Answer = 'yes' | 'no' | 'unclear'
+
+interface Scorecard {
+  scopeFit: Answer
+  reusability: Answer
+  notAlreadySolvable: Answer
+  opinionOwnership: Answer
+  maintenanceRealism: Answer
+}
+
+interface ExistingIssue {
+  number: number
+  title: string
+  state?: string
+  url?: string
+}
+
+interface Decision {
+  intent: string
+  name: string
+  decision: 'file-request' | 'route-to-existing' | 'refuse'
+  redFlags: Array<{ criterion: string; answer: Answer; reason: string }>
+  duplicate: { number: number; title: string; url: string | null; state: string | null } | null
+  recommendation: {
+    action: 'run-command' | 'route-to-existing' | 'refuse'
+    command: string | null
+    message: string
+  }
+}
+
+function allGreen(): Scorecard {
+  return {
+    scopeFit: 'yes',
+    reusability: 'yes',
+    notAlreadySolvable: 'yes',
+    opinionOwnership: 'yes',
+    maintenanceRealism: 'yes'
+  }
+}
+
+async function runAndParse(input: unknown): Promise<Decision & ExecResult> {
+  const res = await runWithInput(input)
+  if (res.code !== 0) {
+    throw new Error(`Expected success, got code=${res.code}, stderr=${res.stderr}`)
+  }
+  return { ...res, ...(JSON.parse(res.stdout) as Decision) }
+}
+
+describe('skill/plan-feedback-request', () => {
+  describe('Decision: file-request (all-green, no duplicate)', () => {
+    it('emits the sf feedback request command when scorecard is fully green', async () => {
+      const out = await runAndParse({
+        intent: 'real-time chat between project members',
+        name: 'chat',
+        scorecard: allGreen(),
+        existingIssues: []
+      })
+      expect(out.decision).toBe('file-request')
+      expect(out.redFlags).toEqual([])
+      expect(out.duplicate).toBeNull()
+      expect(out.recommendation.action).toBe('run-command')
+      expect(out.recommendation.command).toBe('sf feedback request chat')
+      expect(out.recommendation.message).toMatch(/Scorecard all green/)
+    })
+
+    it('appends --description when provided and escapes inner double quotes', async () => {
+      const out = await runAndParse({
+        intent: 'invoicing',
+        name: 'billing',
+        description: 'first-party "billing" with Stripe adapter',
+        scorecard: allGreen(),
+        existingIssues: []
+      })
+      expect(out.recommendation.command).toBe('sf feedback request billing --description "first-party \\"billing\\" with Stripe adapter"')
+    })
+  })
+
+  describe('Decision: route-to-existing (duplicate found)', () => {
+    it('routes to a duplicate when the name appears in an existing title', async () => {
+      const out = await runAndParse({
+        intent: 'real-time chat',
+        name: 'chat',
+        scorecard: allGreen(),
+        existingIssues: [{ number: 42, title: '[request] chat module', state: 'OPEN', url: 'https://example/42' }]
+      })
+      expect(out.decision).toBe('route-to-existing')
+      expect(out.recommendation.action).toBe('route-to-existing')
+      expect(out.recommendation.command).toBeNull()
+      expect(out.duplicate).toEqual({ number: 42, title: '[request] chat module', state: 'OPEN', url: 'https://example/42' })
+      expect(out.recommendation.message).toMatch(/Duplicate found/)
+      expect(out.recommendation.message).toMatch(/#42/)
+    })
+
+    it('matches on intent tokens (≥4 chars) when the title does not contain the name', async () => {
+      const out = await runAndParse({
+        intent: 'billing and invoicing with Stripe',
+        name: 'stripe',
+        scorecard: allGreen(),
+        existingIssues: [{ number: 7, title: '[request] invoicing workflow', state: 'OPEN' }]
+      })
+      expect(out.decision).toBe('route-to-existing')
+      expect(out.duplicate?.number).toBe(7)
+    })
+
+    it('ignores existing issues whose titles do not match name or intent tokens', async () => {
+      const out = await runAndParse({
+        intent: 'presence indicators',
+        name: 'presence',
+        scorecard: allGreen(),
+        existingIssues: [{ number: 99, title: '[request] dark-mode preset', state: 'OPEN' }]
+      })
+      expect(out.decision).toBe('file-request')
+      expect(out.duplicate).toBeNull()
+    })
+  })
+
+  describe('Decision: refuse (red flags)', () => {
+    it('refuses when one criterion is "no" and lists the red flag', async () => {
+      const out = await runAndParse({
+        intent: 'send emails',
+        name: 'smtp',
+        scorecard: { ...allGreen(), notAlreadySolvable: 'no' },
+        existingIssues: []
+      })
+      expect(out.decision).toBe('refuse')
+      expect(out.redFlags).toHaveLength(1)
+      expect(out.redFlags[0].criterion).toBe('notAlreadySolvable')
+      expect(out.redFlags[0].answer).toBe('no')
+      expect(out.redFlags[0].reason).toMatch(/Already solvable/)
+      expect(out.recommendation.action).toBe('refuse')
+      expect(out.recommendation.command).toBeNull()
+      expect(out.recommendation.message).toMatch(/1 red flag/)
+    })
+
+    it('refuses on "unclear" — treats it as an open question, not a soft-pass', async () => {
+      const out = await runAndParse({
+        intent: 'multiplayer whiteboard',
+        name: 'whiteboard',
+        scorecard: { ...allGreen(), maintenanceRealism: 'unclear' },
+        existingIssues: []
+      })
+      expect(out.decision).toBe('refuse')
+      expect(out.redFlags[0]).toMatchObject({ criterion: 'maintenanceRealism', answer: 'unclear' })
+      expect(out.redFlags[0].reason).toMatch(/Maintenance risk/)
+    })
+
+    it('accumulates multiple red flags when several criteria fail', async () => {
+      const out = await runAndParse({
+        intent: 'bespoke crypto wallet',
+        name: 'wallet',
+        scorecard: {
+          scopeFit: 'no',
+          reusability: 'no',
+          notAlreadySolvable: 'yes',
+          opinionOwnership: 'unclear',
+          maintenanceRealism: 'yes'
+        },
+        existingIssues: []
+      })
+      expect(out.decision).toBe('refuse')
+      expect(out.redFlags.map((f) => f.criterion)).toEqual(['scopeFit', 'reusability', 'opinionOwnership'])
+      expect(out.recommendation.message).toMatch(/3 red flags/)
+    })
+
+    it('prefers refusal over dedup when both would apply', async () => {
+      const out = await runAndParse({
+        intent: 'chat',
+        name: 'chat',
+        scorecard: { ...allGreen(), scopeFit: 'no' },
+        existingIssues: [{ number: 42, title: '[request] chat' } as ExistingIssue]
+      })
+      expect(out.decision).toBe('refuse')
+      expect(out.duplicate).toBeNull()
+    })
+  })
+
+  describe('Validation — malformed input', () => {
+    it('exits 2 on empty stdin', async () => {
+      const { code, stderr } = await runWithInput('')
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/empty input on stdin/)
+    })
+
+    it('exits 2 on invalid JSON', async () => {
+      const { code, stderr } = await runWithInput('{not json')
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/invalid JSON on stdin/)
+    })
+
+    it('exits 2 on a top-level array', async () => {
+      const { code, stderr } = await runWithInput([])
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input must be a JSON object/)
+    })
+
+    it('exits 2 when intent is missing or empty', async () => {
+      const { code, stderr } = await runWithInput({ intent: '', name: 'x', scorecard: allGreen() })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input.intent must be a non-empty string/)
+    })
+
+    it('exits 2 when name is missing', async () => {
+      const { code, stderr } = await runWithInput({ intent: 'foo', scorecard: allGreen() })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input.name must be a non-empty string/)
+    })
+
+    it('exits 2 when scorecard is missing', async () => {
+      const { code, stderr } = await runWithInput({ intent: 'foo', name: 'bar' })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input.scorecard must be an object with 5 criteria/)
+    })
+
+    it('exits 2 when a scorecard criterion is absent', async () => {
+      const partial = { ...allGreen() } as Partial<Scorecard>
+      delete partial.reusability
+      const { code, stderr } = await runWithInput({ intent: 'foo', name: 'bar', scorecard: partial })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input.scorecard.reusability must be one of/)
+    })
+
+    it('exits 2 when a scorecard criterion has an unexpected value', async () => {
+      const { code, stderr } = await runWithInput({
+        intent: 'foo',
+        name: 'bar',
+        scorecard: { ...allGreen(), opinionOwnership: 'maybe' }
+      })
+      expect(code).toBe(2)
+      expect(stderr).toMatch(/input.scorecard.opinionOwnership must be one of/)
+    })
+  })
+
+  describe('Output payload shape', () => {
+    it('passes through the full duplicate fields when the issue carries them', async () => {
+      const out = await runAndParse({
+        intent: 'chat',
+        name: 'chat',
+        scorecard: allGreen(),
+        existingIssues: [{ number: 42, title: '[request] chat', state: 'OPEN', url: 'https://gh/42' }]
+      })
+      expect(out.duplicate).toEqual({ number: 42, title: '[request] chat', state: 'OPEN', url: 'https://gh/42' })
+    })
+
+    it('defaults duplicate.url and duplicate.state to null when not provided', async () => {
+      const out = await runAndParse({
+        intent: 'chat',
+        name: 'chat',
+        scorecard: allGreen(),
+        existingIssues: [{ number: 7, title: '[request] chat' }]
+      })
+      expect(out.duplicate).toEqual({ number: 7, title: '[request] chat', url: null, state: null })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds the **Feedback — Module Request** skill orchestration (Pillar 5, half 1): a 5-criterion scorecard that gates any call to `sf feedback request`, with built-in dedup against open module-request issues.
- New scripts under `scaffolds/skills-templates/tool-saasfoundry/scripts/`: `plan-feedback-request.js` (pure classifier) + `plan-feedback-request.sh` (bash orchestrator that enriches the payload with `sf feedback list --json`).
- SKILL.md gains a `Feedback — Module Request` section covering trigger conditions, the 5 criteria with rubric, the 3-decision workflow (`file-request` / `route-to-existing` / `refuse`), the recommendation shape, and never-do rules. Anti-Reinvention LOW/NONE routing now targets this section by name instead of a bare "Phase 3B" reference.
- 19 Jest fixtures (523 → 555 tests with Phase 3A, now 555 → unchanged since scripts ship outside `src/`).

## Decision paths

- **`file-request`** — all 5 criteria `yes`, no duplicate → emit `sf feedback request <name> [--description "…"]`.
- **`route-to-existing`** — all green but an open module-request issue already covers the name or an intent token (≥4 chars) → route the user to the existing issue with `sf feedback vote <n> up`.
- **`refuse`** — any criterion `no` or `unclear` → refuse filing, list the red flags with reasoning. Refusal short-circuits dedup so the output stays focused on "why we're saying no".

## Test plan

- [x] `npm run format` / `lint` / `build` — all clean
- [x] `npm test` — 555 passing / 0 failing
- [x] Pre-push Docker smoke (`multirepo-minimal` + `monorepo-minimal`) — both pass
- [x] Functional smoke — all 3 decision paths exercised end-to-end (`.js` + `.sh`)
- [x] `.sh` dedup filter — only `kind=module-request` issues enter dedup; `cli-bug` / `scaffold-bug` are skipped
- [x] `.sh` offline fallback — when `sf feedback list` fails, dedup falls back to empty and the classifier still emits a decision
- [x] Malformed-input handling — `exit 2` on empty stdin, invalid JSON, array, missing intent/name/scorecard, partial scorecard, unknown answer value
- [x] Human Testing validated

## Out of scope

- Phase 3C (#125) — Feedback Bug Report flow (auto-repro, passive detection)
- Pillar 6 — Community voting polish