### PR TITLE
[Parent #57] SUB-1: Schema + SrsAdapter contract + types

### DIFF
--- a/.claude/docs/architecture-modules.md
+++ b/.claude/docs/architecture-modules.md
@@ -211,3 +211,28 @@ When adding a new optional module to SaaSFoundry, follow these steps:
 10. **Update this CLAUDE.md**
     - Add module to "Current Modules" table
     - Add "Files Affected" section for the new module
+
+## Naming Convention — Tool-Agnostic Capabilities
+
+Some SaaSFoundry capabilities are **tool-agnostic by design**: the capability is the contract, and the tool behind it is swappable (Notion vs. Confluence, GitHub Projects vs. Linear, MailerSend vs.
+Resend, …). When you add one, follow this pattern so every capability looks the same from the outside.
+
+**Three layers, one name per layer:**
+
+| Layer              | Shape                                                        | Example (SRS capability, Notion tool)                                |
+| ------------------ | ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| Config key         | `tools.<capability>.backend: "<tool>"` in `.saasfoundry.json` | `tools.srs.backend: "notion"`                                        |
+| TypeScript contract | `<Capability>Adapter` interface                              | `SrsAdapter` in `src/builders/srs/types.ts`                          |
+| Implementation     | `<Tool><Capability>Adapter` class                            | `NotionSrsAdapter` (binds the adapter to the `sf-tool-notion` skill) |
+
+**Why the `Adapter` suffix**: the pattern is literally the Adapter pattern — we expose a tool-agnostic contract (`SrsAdapter`) and plug concrete tool bindings (`NotionSrsAdapter`,
+`ConfluenceSrsAdapter`, …) behind it. The name should tell the reader that immediately.
+
+**Anticipated capabilities** (apply the same naming when they land):
+
+- **Ticketing**: `tools.ticketing.backend: "github-projects"` → `TicketingAdapter` / `GithubProjectsTicketingAdapter`
+- **Email**: `tools.email.backend: "mailersend"` → `EmailAdapter` / `MailersendEmailAdapter`
+- **Analytics**: `tools.analytics.backend: "umami"` → `AnalyticsAdapter` / `UmamiAnalyticsAdapter`
+
+**Skill pairing**: each tool-agnostic capability has an agnostic skill (e.g. `sf-srs`) that orchestrates the flow and dispatches tool-specific work to a tool skill (`sf-tool-notion`). Keep the split —
+the agnostic skill never knows which backend it's talking to.

--- a/.claude/docs/architecture-modules.md
+++ b/.claude/docs/architecture-modules.md
@@ -219,11 +219,11 @@ Resend, …). When you add one, follow this pattern so every capability looks th
 
 **Three layers, one name per layer:**
 
-| Layer              | Shape                                                        | Example (SRS capability, Notion tool)                                |
-| ------------------ | ------------------------------------------------------------ | -------------------------------------------------------------------- |
-| Config key         | `tools.<capability>.backend: "<tool>"` in `.saasfoundry.json` | `tools.srs.backend: "notion"`                                        |
-| TypeScript contract | `<Capability>Adapter` interface                              | `SrsAdapter` in `src/builders/srs/types.ts`                          |
-| Implementation     | `<Tool><Capability>Adapter` class                            | `NotionSrsAdapter` (binds the adapter to the `sf-tool-notion` skill) |
+| Layer               | Shape                                                         | Example (SRS capability, Notion tool)                                |
+| ------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Config key          | `tools.<capability>.backend: "<tool>"` in `.saasfoundry.json` | `tools.srs.backend: "notion"`                                        |
+| TypeScript contract | `<Capability>Adapter` interface                               | `SrsAdapter` in `src/builders/srs/types.ts`                          |
+| Implementation      | `<Tool><Capability>Adapter` class                             | `NotionSrsAdapter` (binds the adapter to the `sf-tool-notion` skill) |
 
 **Why the `Adapter` suffix**: the pattern is literally the Adapter pattern — we expose a tool-agnostic contract (`SrsAdapter`) and plug concrete tool bindings (`NotionSrsAdapter`,
 `ConfluenceSrsAdapter`, …) behind it. The name should tell the reader that immediately.

--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -348,5 +348,83 @@ describe('utils', () => {
       expect(result?.version).toBe('1.1.0')
       expect(result?.projectName).toBe('test')
     })
+
+    it('should round-trip a manifest with tools.srs populated', async () => {
+      const manifest: Partial<SaaSFoundryManifest> = {
+        version: '1.0.0-beta',
+        generatedAt: '2026-04-19T10:00:00.000Z',
+        structure: 'monorepo',
+        projectName: 'srs-enabled',
+        modules: {
+          emailService: 'none',
+          s3Setup: 'manual',
+          dbSetup: 'docker',
+          includeAnalytics: false,
+          advancedSkills: []
+        },
+        tools: {
+          srs: {
+            enabled: true,
+            backend: 'notion',
+            rootPage: {
+              id: 'abc-123',
+              url: 'https://www.notion.so/SaaSFoundry-abc123'
+            },
+            categories: ['User flows & Specifications']
+          }
+        }
+      }
+
+      await writeManifest(tempDir, manifest)
+      const result = await readManifest(tempDir)
+
+      expect(result?.tools?.srs?.enabled).toBe(true)
+      expect(result?.tools?.srs?.backend).toBe('notion')
+      expect(result?.tools?.srs?.rootPage?.id).toBe('abc-123')
+      expect(result?.tools?.srs?.categories).toEqual(['User flows & Specifications'])
+    })
+
+    it('should preserve manifests without tools field (backward compat)', async () => {
+      const legacyManifest: Partial<SaaSFoundryManifest> = {
+        version: '1.0.0-beta',
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        structure: 'multirepo',
+        projectName: 'legacy',
+        modules: {
+          emailService: 'mailersend',
+          s3Setup: 'manual',
+          dbSetup: 'docker',
+          includeAnalytics: true,
+          advancedSkills: ['sf-tool-notion']
+        }
+      }
+
+      await writeManifest(tempDir, legacyManifest)
+      const result = await readManifest(tempDir)
+
+      expect(result).toEqual(legacyManifest)
+      expect(result?.tools).toBeUndefined()
+    })
+
+    it('should merge tools.srs into an existing tool-less manifest', async () => {
+      await writeManifest(tempDir, {
+        version: '1.0.0-beta',
+        projectName: 'add-srs'
+      } as Partial<SaaSFoundryManifest>)
+
+      await writeManifest(tempDir, {
+        tools: {
+          srs: {
+            enabled: true,
+            backend: 'notion'
+          }
+        }
+      } as Partial<SaaSFoundryManifest>)
+
+      const result = await readManifest(tempDir)
+      expect(result?.projectName).toBe('add-srs')
+      expect(result?.tools?.srs?.enabled).toBe(true)
+      expect(result?.tools?.srs?.backend).toBe('notion')
+    })
   })
 })

--- a/src/builders/srs/types.ts
+++ b/src/builders/srs/types.ts
@@ -1,0 +1,90 @@
+export interface PageRef {
+  id: string
+  url: string
+  title: string
+}
+
+export interface UrItem {
+  id: string
+  narrative: string
+  businessValue?: string
+}
+
+export interface FrItem {
+  id: string
+  title: string
+  description?: string
+  acceptanceCriteria?: string[]
+  urRefs?: string[]
+  dsRefs?: string[]
+  tcRefs?: string[]
+}
+
+export interface DsItem {
+  id: string
+  title: string
+  description?: string
+  frRefs?: string[]
+}
+
+export interface TcItem {
+  id: string
+  title: string
+  steps?: string[]
+  expectedResult?: string
+  frRefs?: string[]
+}
+
+export interface EpicSpec {
+  title: string
+  parentPageId: string
+  businessValue?: string
+  scope?: string
+  urs: UrItem[]
+  frs: FrItem[]
+  dsItems?: DsItem[]
+  tcItems?: TcItem[]
+}
+
+export interface FrSpec {
+  parentEpicPageId: string
+  fr: FrItem
+  urs?: UrItem[]
+  dsItems?: DsItem[]
+  tcItems?: TcItem[]
+}
+
+export interface PageSection {
+  heading?: string
+  body: string
+}
+
+export interface PageContent {
+  title?: string
+  sections?: PageSection[]
+}
+
+export interface RawContent {
+  pageId: string
+  title: string
+  url: string
+  blocks: Array<{
+    kind: 'heading' | 'paragraph' | 'list' | 'table' | 'other'
+    text: string
+  }>
+  children?: RawContent[]
+}
+
+export interface SrsAdapter {
+  init(): Promise<void>
+
+  createEpicPage(spec: EpicSpec): Promise<PageRef>
+
+  createFrPage(spec: FrSpec): Promise<PageRef>
+
+  updatePage(pageId: string, content: PageContent): Promise<void>
+
+  fetchPage(pageId: string): Promise<RawContent>
+
+  listChildren(parentPageId: string): Promise<PageRef[]>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,20 @@ export interface WorkflowTemplate extends WorkflowConfig {
   aiRules?: AIRules
 }
 
+export interface SrsToolConfig {
+  enabled: boolean
+  backend: 'notion'
+  rootPage?: {
+    id: string
+    url: string
+  }
+  categories?: string[]
+}
+
+export interface ToolsConfig {
+  srs?: SrsToolConfig
+}
+
 export interface SaaSFoundryManifest {
   version: string
   generatedAt: string
@@ -187,6 +201,7 @@ export interface SaaSFoundryManifest {
   fileHashes?: Record<string, string>
   workflow?: WorkflowConfig
   aiRules?: AIRules
+  tools?: ToolsConfig
 }
 
 // Paths


### PR DESCRIPTION
Closes #161

## Summary

Lay the foundations of the SRS (Software Requirements Specifications) module:

- Extend `.saasfoundry.json` manifest with an optional `tools.srs` block (`enabled`, `backend`, `rootPage`, `categories`) — no-op for projects without it (backward compat guaranteed)
- Define the tool-agnostic `SrsAdapter` TypeScript contract in `src/builders/srs/types.ts`, plus shared SRS item types (`UrItem`, `FrItem`, `DsItem`, `TcItem`, `EpicSpec`, `FrSpec`, `PageContent`, `RawContent`, `PageRef`)
- Document the naming convention for tool-agnostic capabilities (`tools.<capability>.backend`, `<Capability>Adapter`, `<Tool><Capability>Adapter`) in `.claude/docs/architecture-modules.md` so future features (ticketing, email, analytics…) follow the same shape

## Test plan

- [x] `npm run build` — tsc clean
- [x] `npm run lint` — eslint clean
- [x] `jest` — 579 passed (was 576; +3 for `tools.srs` round-trip scenarios)
- [x] Manifest without `tools` field parses unchanged
- [x] Manifest with `tools.srs` round-trips all fields
- [x] Merging `tools.srs` into an existing manifest preserves prior fields
- [x] `SrsAdapter` interface importable and tsc-compilable

## Tests added

- `src/__tests__/unit/utils.spec.ts` — 3 new scenarios in `readManifest / writeManifest`:
  - `round-trips a manifest with tools.srs populated`
  - `preserves manifests without tools field (backward compat)`
  - `merges tools.srs into an existing tool-less manifest`

## No E2E tests

Pure foundational types + docs + unit tests — no new feature, command, or user-visible behaviour. E2E tests would have nothing meaningful to assert at this stage. Live runtime behaviour will land with SUB-2 (Notion adapter) and SUB-5 (bootstrap flow) and will be E2E-covered there.

## Atomic sub-issues

- #175 — Extend SaaSFoundryManifest with tools.srs schema ✅
- #176 — Create SrsAdapter contract + shared types ✅
- #177 — Unit tests: manifest round-trip with tools.srs ✅
- #178 — Doc: naming convention for tool-agnostic capabilities ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)