### PR TITLE
feat(#164): SRS-linked ticket body templates (Epic + Story)

### DIFF
--- a/.claude/skills/sf-srs/templates/tickets/README.md
+++ b/.claude/skills/sf-srs/templates/tickets/README.md
@@ -1,0 +1,72 @@
+# sf-srs — ticket body templates
+
+Agnostic Markdown templates for GitHub issue bodies linked to SRS pages. Each renderer consumes a typed spec (`EpicTicketBodySpec`, `StoryTicketBodySpec`) and emits a Markdown string suitable for
+posting to any ticketing backend that accepts Markdown (GitHub Projects, Jira, Linear…).
+
+## Runtime location
+
+The TypeScript source lives in the CLI repository:
+
+- `src/builders/srs/templates/tickets/epic.tpl.ts` — exports `renderEpicTicketBody(spec: EpicTicketBodySpec): string`
+- `src/builders/srs/templates/tickets/story.tpl.ts` — exports `renderStoryTicketBody(spec: StoryTicketBodySpec): string`
+
+The skill bundle ships this README as reference; the subtask spawner (SUB-9) loads the compiled module from `dist/` (or the TS source via `tsx` in dogfood mode).
+
+## Spec contracts
+
+```ts
+interface EpicTicketBodySpec {
+  epic: EpicSpec
+  epicPageUrl?: string
+  frPages?: { frId: string; frTitle: string; pageUrl?: string }[]
+  scopeIncluded?: string[]
+  scopeExcluded?: string[]
+  dependencies?: string[]
+  constraints?: string[]
+  assumptions?: string[]
+  definitionOfDone?: string[]
+}
+
+interface StoryTicketBodySpec {
+  fr: FrItem
+  frPageUrl?: string
+  mainSpecUrl?: string
+  urRefs?: UrItem[]
+  frRefs?: { id: string; title?: string }[]
+  acceptanceCriteria?: { id: string; text: string; sourceFr?: string }[]
+  dsRefs?: { id: string; title?: string }[]
+  dependencies?: string[]
+  constraints?: string[]
+}
+```
+
+## Epic ticket sections
+
+Produced by `renderEpicTicketBody(spec)` in this order:
+
+1. `## Goal` — `spec.epic.title`
+2. `## Business Value` — `spec.epic.businessValue` (placeholder when absent)
+3. `## Scope` — `### Included` + `### Excluded` bulleted lists (placeholders when empty)
+4. `## Specifications` — main SRS page link + Markdown table `[FR | Title | Page]`
+5. `## Dependencies` — bulleted list (placeholder when empty)
+6. `## Constraints` — bulleted list (placeholder when empty)
+7. `## Assumptions` — bulleted list (placeholder when empty)
+8. `## Definition of Done` — bulleted list (placeholder when empty)
+
+## Story ticket sections
+
+Produced by `renderStoryTicketBody(spec)` in this order:
+
+1. `## Objective` — `spec.fr.description` (fallback: `Implement {FR-id} — {title}.`)
+2. `## Context (User Requirements)` — `UR-XXX` bulleted list with narratives (placeholder when empty)
+3. `## Scope (Functional Requirements)` — `FR-XXX` bulleted list (defaults to the current FR when `frRefs` is absent)
+4. `## Acceptance Criteria` — Markdown table `[AC | Criterion | Source FR]` (placeholder when empty)
+5. `## Specifications` — FR page link + optional Epic spec link
+6. `## Dependencies` — bulleted list (placeholder when empty)
+7. `## Constraints` — bulleted list (placeholder when empty)
+8. `## Design References` — `DS-XXX` bulleted list (placeholder when empty)
+
+## Adding a new ticket body variant
+
+Add a new template under `src/builders/srs/templates/tickets/`, export it from `src/srs/index.ts`, and wire the subtask spawner (SUB-9) to dispatch to the right renderer based on the parent label
+(`srs:drafting`, `srs:new`, …). The Markdown output is backend-agnostic — the body string is posted verbatim.

--- a/scaffolds/skills-templates/sf-srs/templates/tickets/README.md
+++ b/scaffolds/skills-templates/sf-srs/templates/tickets/README.md
@@ -1,0 +1,72 @@
+# sf-srs — ticket body templates
+
+Agnostic Markdown templates for GitHub issue bodies linked to SRS pages. Each renderer consumes a typed spec (`EpicTicketBodySpec`, `StoryTicketBodySpec`) and emits a Markdown string suitable for
+posting to any ticketing backend that accepts Markdown (GitHub Projects, Jira, Linear…).
+
+## Runtime location
+
+The TypeScript source lives in the CLI repository:
+
+- `src/builders/srs/templates/tickets/epic.tpl.ts` — exports `renderEpicTicketBody(spec: EpicTicketBodySpec): string`
+- `src/builders/srs/templates/tickets/story.tpl.ts` — exports `renderStoryTicketBody(spec: StoryTicketBodySpec): string`
+
+The skill bundle ships this README as reference; the subtask spawner (SUB-9) loads the compiled module from `dist/` (or the TS source via `tsx` in dogfood mode).
+
+## Spec contracts
+
+```ts
+interface EpicTicketBodySpec {
+  epic: EpicSpec
+  epicPageUrl?: string
+  frPages?: { frId: string; frTitle: string; pageUrl?: string }[]
+  scopeIncluded?: string[]
+  scopeExcluded?: string[]
+  dependencies?: string[]
+  constraints?: string[]
+  assumptions?: string[]
+  definitionOfDone?: string[]
+}
+
+interface StoryTicketBodySpec {
+  fr: FrItem
+  frPageUrl?: string
+  mainSpecUrl?: string
+  urRefs?: UrItem[]
+  frRefs?: { id: string; title?: string }[]
+  acceptanceCriteria?: { id: string; text: string; sourceFr?: string }[]
+  dsRefs?: { id: string; title?: string }[]
+  dependencies?: string[]
+  constraints?: string[]
+}
+```
+
+## Epic ticket sections
+
+Produced by `renderEpicTicketBody(spec)` in this order:
+
+1. `## Goal` — `spec.epic.title`
+2. `## Business Value` — `spec.epic.businessValue` (placeholder when absent)
+3. `## Scope` — `### Included` + `### Excluded` bulleted lists (placeholders when empty)
+4. `## Specifications` — main SRS page link + Markdown table `[FR | Title | Page]`
+5. `## Dependencies` — bulleted list (placeholder when empty)
+6. `## Constraints` — bulleted list (placeholder when empty)
+7. `## Assumptions` — bulleted list (placeholder when empty)
+8. `## Definition of Done` — bulleted list (placeholder when empty)
+
+## Story ticket sections
+
+Produced by `renderStoryTicketBody(spec)` in this order:
+
+1. `## Objective` — `spec.fr.description` (fallback: `Implement {FR-id} — {title}.`)
+2. `## Context (User Requirements)` — `UR-XXX` bulleted list with narratives (placeholder when empty)
+3. `## Scope (Functional Requirements)` — `FR-XXX` bulleted list (defaults to the current FR when `frRefs` is absent)
+4. `## Acceptance Criteria` — Markdown table `[AC | Criterion | Source FR]` (placeholder when empty)
+5. `## Specifications` — FR page link + optional Epic spec link
+6. `## Dependencies` — bulleted list (placeholder when empty)
+7. `## Constraints` — bulleted list (placeholder when empty)
+8. `## Design References` — `DS-XXX` bulleted list (placeholder when empty)
+
+## Adding a new ticket body variant
+
+Add a new template under `src/builders/srs/templates/tickets/`, export it from `src/srs/index.ts`, and wire the subtask spawner (SUB-9) to dispatch to the right renderer based on the parent label
+(`srs:drafting`, `srs:new`, …). The Markdown output is backend-agnostic — the body string is posted verbatim.

--- a/src/__tests__/unit/skill/tool-skill-drift.spec.ts
+++ b/src/__tests__/unit/skill/tool-skill-drift.spec.ts
@@ -26,6 +26,11 @@ const PAIRS = [
     name: 'sf-srs templates/pages/README.md',
     inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/pages/README.md'),
     scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/pages/README.md')
+  },
+  {
+    name: 'sf-srs templates/tickets/README.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/tickets/README.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/tickets/README.md')
   }
 ]
 

--- a/src/__tests__/unit/srs/templates/epic-ticket.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/epic-ticket.tpl.spec.ts
@@ -1,0 +1,57 @@
+import { renderEpicTicketBody } from '../../../../builders/srs/templates/tickets/epic.tpl'
+import { EpicTicketBodySpec } from '../../../../builders/srs/types'
+
+describe('renderEpicTicketBody', () => {
+  const baseSpec: EpicTicketBodySpec = {
+    epic: {
+      title: 'User authentication',
+      parentPageId: 'page-epic',
+      businessValue: 'Users can sign in securely.',
+      urs: [{ id: 'UR-1', narrative: 'sign in with email' }],
+      frs: [{ id: 'FR-1', title: 'Login endpoint' }]
+    }
+  }
+
+  it('renders every mandatory section heading in order for a rich spec', () => {
+    const body = renderEpicTicketBody({
+      ...baseSpec,
+      epicPageUrl: 'https://notion.so/epic',
+      frPages: [{ frId: 'FR-1', frTitle: 'Login endpoint', pageUrl: 'https://notion.so/fr-1' }],
+      scopeIncluded: ['Email + password'],
+      scopeExcluded: ['SSO'],
+      dependencies: ['Service auth v2'],
+      constraints: ['GDPR'],
+      assumptions: ['Single tenant'],
+      definitionOfDone: ['All FR stories merged']
+    })
+
+    const headings = body.match(/^## .+$/gm) ?? []
+    expect(headings).toEqual(['## Goal', '## Business Value', '## Scope', '## Specifications', '## Dependencies', '## Constraints', '## Assumptions', '## Definition of Done'])
+  })
+
+  it('embeds the FR table row linking to the Notion FR page when provided', () => {
+    const body = renderEpicTicketBody({
+      ...baseSpec,
+      epicPageUrl: 'https://notion.so/epic',
+      frPages: [{ frId: 'FR-1', frTitle: 'Login endpoint', pageUrl: 'https://notion.so/fr-1' }]
+    })
+
+    expect(body).toContain('Main spec: [Epic SRS page](https://notion.so/epic)')
+    expect(body).toContain('| FR-1 | Login endpoint | [Login endpoint](https://notion.so/fr-1) |')
+  })
+
+  it('falls back to placeholders when optional sections are empty', () => {
+    const body = renderEpicTicketBody(baseSpec)
+
+    expect(body).toContain('_Link the Epic SRS page here once the spec is published._')
+    expect(body).toContain('_No FR pages linked yet._')
+    expect(body).toContain('_List what is in scope._')
+    expect(body).toContain('_List upstream tickets or services this Epic depends on._')
+    expect(body).toContain('_List the exit criteria for this Epic._')
+  })
+
+  it('uses the epic title as the Goal body line', () => {
+    const body = renderEpicTicketBody(baseSpec)
+    expect(body).toMatch(/## Goal\n\nUser authentication/)
+  })
+})

--- a/src/__tests__/unit/srs/templates/story-ticket.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/story-ticket.tpl.spec.ts
@@ -1,0 +1,69 @@
+import { renderStoryTicketBody } from '../../../../builders/srs/templates/tickets/story.tpl'
+import { StoryTicketBodySpec } from '../../../../builders/srs/types'
+
+describe('renderStoryTicketBody', () => {
+  const baseSpec: StoryTicketBodySpec = {
+    fr: { id: 'FR-1', title: 'Login endpoint', description: 'POST /auth/login' }
+  }
+
+  it('renders every mandatory section heading in order for a rich spec', () => {
+    const body = renderStoryTicketBody({
+      ...baseSpec,
+      frPageUrl: 'https://notion.so/fr-1',
+      mainSpecUrl: 'https://notion.so/epic',
+      urRefs: [{ id: 'UR-1', narrative: 'sign in with email' }],
+      frRefs: [{ id: 'FR-1', title: 'Login endpoint' }],
+      acceptanceCriteria: [
+        { id: 'AC-01', text: 'returns 200 with valid creds', sourceFr: 'FR-1' },
+        { id: 'AC-02', text: 'returns 401 with invalid creds', sourceFr: 'FR-1' }
+      ],
+      dsRefs: [{ id: 'DS-1', title: 'Login form' }],
+      dependencies: ['Service auth v2'],
+      constraints: ['GDPR']
+    })
+
+    const headings = body.match(/^## .+$/gm) ?? []
+    expect(headings).toEqual([
+      '## Objective',
+      '## Context (User Requirements)',
+      '## Scope (Functional Requirements)',
+      '## Acceptance Criteria',
+      '## Specifications',
+      '## Dependencies',
+      '## Constraints',
+      '## Design References'
+    ])
+  })
+
+  it('emits the AC table with AC-NN and Source FR columns', () => {
+    const body = renderStoryTicketBody({
+      ...baseSpec,
+      acceptanceCriteria: [
+        { id: 'AC-01', text: 'returns 200', sourceFr: 'FR-1' },
+        { id: 'AC-02', text: 'returns 401' }
+      ]
+    })
+
+    expect(body).toContain('| AC | Criterion | Source FR |')
+    expect(body).toContain('| AC-01 | returns 200 | FR-1 |')
+    expect(body).toContain('| AC-02 | returns 401 | — |')
+  })
+
+  it('defaults the Scope FR list to the current FR when frRefs is absent', () => {
+    const body = renderStoryTicketBody(baseSpec)
+    expect(body).toContain('- **FR-1**')
+  })
+
+  it('uses the FR description for Objective when provided', () => {
+    const body = renderStoryTicketBody(baseSpec)
+    expect(body).toMatch(/## Objective\n\nPOST \/auth\/login/)
+  })
+
+  it('falls back to placeholder text when optional sections are empty', () => {
+    const body = renderStoryTicketBody(baseSpec)
+    expect(body).toContain('_No UR references yet._')
+    expect(body).toContain('_No acceptance criteria yet._')
+    expect(body).toContain('_No design references yet._')
+    expect(body).toContain('_Link the FR SRS page here once the spec is published._')
+  })
+})

--- a/src/builders/srs/templates/tickets/epic.tpl.ts
+++ b/src/builders/srs/templates/tickets/epic.tpl.ts
@@ -1,0 +1,48 @@
+import { EpicTicketBodySpec, FrPageLink } from '../../types'
+
+function bulletList(items: string[] | undefined, placeholder: string): string {
+  if (!items || items.length === 0) return `_${placeholder}_`
+  return items.map((item) => `- ${item}`).join('\n')
+}
+
+function frPagesTable(pages: FrPageLink[] | undefined): string {
+  if (!pages || pages.length === 0) return '_No FR pages linked yet._'
+  const header = ['| FR | Title | Page |', '| --- | --- | --- |']
+  const rows = pages.map((p) => {
+    const link = p.pageUrl ? `[${p.frTitle}](${p.pageUrl})` : '—'
+    return `| ${p.frId} | ${p.frTitle} | ${link} |`
+  })
+  return [...header, ...rows].join('\n')
+}
+
+function specReferenceLine(epicPageUrl: string | undefined): string {
+  if (!epicPageUrl) return '_Link the Epic SRS page here once the spec is published._'
+  return `Main spec: [Epic SRS page](${epicPageUrl})`
+}
+
+export function renderEpicTicketBody(spec: EpicTicketBodySpec): string {
+  const { epic } = spec
+  const sections: string[] = []
+
+  sections.push(`## Goal\n\n${epic.title}`)
+
+  sections.push(`## Business Value\n\n${epic.businessValue ?? '_Describe the business impact of this Epic._'}`)
+
+  const included = bulletList(spec.scopeIncluded, 'List what is in scope.')
+  const excluded = bulletList(spec.scopeExcluded, 'List what is out of scope.')
+  sections.push(`## Scope\n\n### Included\n\n${included}\n\n### Excluded\n\n${excluded}`)
+
+  const specRef = specReferenceLine(spec.epicPageUrl)
+  const frTable = frPagesTable(spec.frPages)
+  sections.push(`## Specifications\n\n${specRef}\n\n${frTable}`)
+
+  sections.push(`## Dependencies\n\n${bulletList(spec.dependencies, 'List upstream tickets or services this Epic depends on.')}`)
+
+  sections.push(`## Constraints\n\n${bulletList(spec.constraints, 'List technical or business constraints.')}`)
+
+  sections.push(`## Assumptions\n\n${bulletList(spec.assumptions, 'List assumptions made while drafting this Epic.')}`)
+
+  sections.push(`## Definition of Done\n\n${bulletList(spec.definitionOfDone, 'List the exit criteria for this Epic.')}`)
+
+  return sections.join('\n\n')
+}

--- a/src/builders/srs/templates/tickets/story.tpl.ts
+++ b/src/builders/srs/templates/tickets/story.tpl.ts
@@ -1,0 +1,59 @@
+import { AcceptanceCriterion, DsRef, StoryTicketBodySpec, UrItem } from '../../types'
+
+function bulletList(items: string[] | undefined, placeholder: string): string {
+  if (!items || items.length === 0) return `_${placeholder}_`
+  return items.map((item) => `- ${item}`).join('\n')
+}
+
+function urRefsList(refs: UrItem[] | undefined): string {
+  if (!refs || refs.length === 0) return '_No UR references yet._'
+  return refs.map((ur) => `- **${ur.id}** — ${ur.narrative}`).join('\n')
+}
+
+function frRefsList(refs: StoryTicketBodySpec['frRefs'], currentFrId: string): string {
+  const resolved = refs && refs.length > 0 ? refs : [{ id: currentFrId }]
+  return resolved.map((fr) => `- **${fr.id}**${fr.title ? ` — ${fr.title}` : ''}`).join('\n')
+}
+
+function acceptanceCriteriaTable(criteria: AcceptanceCriterion[] | undefined): string {
+  if (!criteria || criteria.length === 0) return '_No acceptance criteria yet._'
+  const header = ['| AC | Criterion | Source FR |', '| --- | --- | --- |']
+  const rows = criteria.map((ac) => `| ${ac.id} | ${ac.text} | ${ac.sourceFr ?? '—'} |`)
+  return [...header, ...rows].join('\n')
+}
+
+function dsRefsList(refs: DsRef[] | undefined): string {
+  if (!refs || refs.length === 0) return '_No design references yet._'
+  return refs.map((ds) => `- **${ds.id}**${ds.title ? ` — ${ds.title}` : ''}`).join('\n')
+}
+
+function specReferenceBlock(spec: StoryTicketBodySpec): string {
+  const lines: string[] = []
+  if (spec.frPageUrl) lines.push(`- FR page: [${spec.fr.id} — ${spec.fr.title}](${spec.frPageUrl})`)
+  else lines.push(`- FR page: _Link the FR SRS page here once the spec is published._`)
+  if (spec.mainSpecUrl) lines.push(`- Epic spec: [${spec.mainSpecUrl}](${spec.mainSpecUrl})`)
+  return lines.join('\n')
+}
+
+export function renderStoryTicketBody(spec: StoryTicketBodySpec): string {
+  const { fr } = spec
+  const sections: string[] = []
+
+  sections.push(`## Objective\n\n${fr.description ?? `Implement ${fr.id} — ${fr.title}.`}`)
+
+  sections.push(`## Context (User Requirements)\n\n${urRefsList(spec.urRefs)}`)
+
+  sections.push(`## Scope (Functional Requirements)\n\n${frRefsList(spec.frRefs, fr.id)}`)
+
+  sections.push(`## Acceptance Criteria\n\n${acceptanceCriteriaTable(spec.acceptanceCriteria)}`)
+
+  sections.push(`## Specifications\n\n${specReferenceBlock(spec)}`)
+
+  sections.push(`## Dependencies\n\n${bulletList(spec.dependencies, 'List upstream tickets or services this Story depends on.')}`)
+
+  sections.push(`## Constraints\n\n${bulletList(spec.constraints, 'List technical or business constraints.')}`)
+
+  sections.push(`## Design References\n\n${dsRefsList(spec.dsRefs)}`)
+
+  return sections.join('\n\n')
+}

--- a/src/builders/srs/types.ts
+++ b/src/builders/srs/types.ts
@@ -98,6 +98,47 @@ export interface PageContent {
   blocks: PageBlock[]
 }
 
+export interface FrPageLink {
+  frId: string
+  frTitle: string
+  pageUrl?: string
+}
+
+export interface EpicTicketBodySpec {
+  epic: EpicSpec
+  epicPageUrl?: string
+  frPages?: FrPageLink[]
+  scopeIncluded?: string[]
+  scopeExcluded?: string[]
+  dependencies?: string[]
+  constraints?: string[]
+  assumptions?: string[]
+  definitionOfDone?: string[]
+}
+
+export interface AcceptanceCriterion {
+  id: string
+  text: string
+  sourceFr?: string
+}
+
+export interface DsRef {
+  id: string
+  title?: string
+}
+
+export interface StoryTicketBodySpec {
+  fr: FrItem
+  frPageUrl?: string
+  mainSpecUrl?: string
+  urRefs?: UrItem[]
+  frRefs?: Array<{ id: string; title?: string }>
+  acceptanceCriteria?: AcceptanceCriterion[]
+  dsRefs?: DsRef[]
+  dependencies?: string[]
+  constraints?: string[]
+}
+
 export interface RawContent {
   pageId: string
   title: string

--- a/src/srs/index.ts
+++ b/src/srs/index.ts
@@ -22,5 +22,10 @@ export type {
   UrItem,
   FrItem,
   DsItem,
-  TcItem
+  TcItem,
+  EpicTicketBodySpec,
+  StoryTicketBodySpec,
+  FrPageLink,
+  AcceptanceCriterion,
+  DsRef
 } from '../builders/srs/types'


### PR DESCRIPTION
## Summary

- Add Markdown body renderers under `src/builders/srs/templates/tickets/`: `renderEpicTicketBody(spec)` and `renderStoryTicketBody(spec)` — plain strings, zero backend coupling.
- Introduce `EpicTicketBodySpec` / `StoryTicketBodySpec` types in `src/builders/srs/types.ts` — wrap `EpicSpec` / `FrItem` with ticket-specific fields (page URLs, AC table with `AC-NN` + source FR, refs).
- Document the contract in `.claude/skills/sf-srs/templates/tickets/README.md` (mirror in scaffold + drift guard).
- Section orders match parent #57 spec. SUB-9 (subtask spawner) will consume these renderers next.

Closes #164.

## Test plan

- [x] `npm run test:pre-commit` — 640 tests / 60 suites passing (9 new ticket template tests)
- [x] `npm run test:pre-push` — 2/2 Docker scenarios (`multirepo-minimal`, `monorepo-minimal`) green
- [x] Drift guard entry added for `sf-srs templates/tickets/README.md`; scaffold byte-identical
- [x] `no-notion-leak` guard untouched — ticket templates stay backend-agnostic