### PR TITLE
feat(#169): SRS Story spawner + Rule 8 create-subtask guard

### DIFF
--- a/.claude/skills/sf-srs/scripts/srs-cli.sh
+++ b/.claude/skills/sf-srs/scripts/srs-cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # sf-srs orchestrator — single entrypoint for every skill that hands off to SRS work.
 # Body grows as sibling SUBs under #174 land ; this revision implements
-# `help`, `validate`, `browse`, `draft`, `write`.
+# `help`, `validate`, `browse`, `draft`, `write`, `spawn`.
 
 set -euo pipefail
 
@@ -23,10 +23,15 @@ Actions:
                                     Apply a DraftCandidate[] spec file : creates Epic /
                                     FR pages through the adapter and clears the
                                     `tools.srs.pendingIngestion` flag on success.
+  spawn  --ticket <n> --epic <page-url-or-id> [--dry-run] [--manifest] [--bypass-reason <text>]
+                                    Enumerate FR page children of a drafted Epic and
+                                    create a Story sub-ticket per FR under the parent
+                                    ticket. Each child lands in Backlog with the
+                                    `srs:new` label. `--dry-run` previews without
+                                    writing.
 
 Actions populated by sibling SUBs under #174 :
   draft --from codebase             Codebase audit drafter                       (SUB-13)
-  spawn                             Spawn GitHub tickets from a published SRS   (SUB-9)
   eval                              Score SRS freshness against the codebase    (SUB-10)
 
 Common options :
@@ -92,6 +97,8 @@ run_browse() { run_bin browse-tree "$@"; }
 
 run_write() { run_bin write-srs "$@"; }
 
+run_spawn() { run_bin spawn "$@"; }
+
 run_draft() {
   # `--from <source>` selects which drafter to invoke ; default = notion-pages.
   local source="notion-pages"
@@ -125,7 +132,8 @@ case "$ACTION" in
   browse) run_browse "$@" ;;
   draft) run_draft "$@" ;;
   write) run_write "$@" ;;
-  spawn|eval)
+  spawn) run_spawn "$@" ;;
+  eval)
     echo "sf-srs: action '$ACTION' not implemented yet — owned by a sibling SUB under #174." >&2
     exit 2
     ;;

--- a/.claude/skills/sf-srs/scripts/srs-cli.sh
+++ b/.claude/skills/sf-srs/scripts/srs-cli.sh
@@ -26,9 +26,10 @@ Actions:
   spawn  --ticket <n> --epic <page-url-or-id> [--dry-run] [--manifest] [--bypass-reason <text>]
                                     Enumerate FR page children of a drafted Epic and
                                     create a Story sub-ticket per FR under the parent
-                                    ticket. Each child lands in Backlog with the
-                                    `srs:new` label. `--dry-run` previews without
-                                    writing.
+                                    ticket. Each child is created as a GitHub
+                                    sub-issue tagged `srs:new`; board placement
+                                    follows the project's default automation.
+                                    `--dry-run` previews without writing.
 
 Actions populated by sibling SUBs under #174 :
   draft --from codebase             Codebase audit drafter                       (SUB-13)

--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -223,16 +223,69 @@ get_ticket_status() {
 cmd_create_subtask() {
   if [ "$#" -lt 2 ]; then
     echo -e "${RED}Error: Missing arguments${NC}"
-    echo "Usage: $0 create-subtask <parent-number> <title> [body]"
+    echo "Usage: $0 create-subtask <parent-number> <title> [body] [--bypass-srs <reason>]"
     exit 1
   fi
 
-  PARENT_NUMBER=$1
-  TITLE=$2
-  BODY=${3:-""}
+  # Separate positional args from the --bypass-srs flag. The flag can appear
+  # anywhere on the command line, carries a mandatory reason, and trips rule 8
+  # off. We accept up to three positional args (parent, title, body).
+  local -a POSITIONAL=()
+  local BYPASS_SRS_REASON=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --bypass-srs)
+        if [ -z "${2:-}" ] || [[ "${2}" == --* ]]; then
+          echo -e "${RED}Error: --bypass-srs requires a reason (e.g. --bypass-srs \"emergency hotfix\")${NC}" >&2
+          exit 1
+        fi
+        BYPASS_SRS_REASON=$2
+        shift 2
+        ;;
+      *)
+        POSITIONAL+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [ "${#POSITIONAL[@]}" -lt 2 ]; then
+    echo -e "${RED}Error: Missing arguments${NC}"
+    echo "Usage: $0 create-subtask <parent-number> <title> [body] [--bypass-srs <reason>]"
+    exit 1
+  fi
+
+  PARENT_NUMBER="${POSITIONAL[0]}"
+  TITLE="${POSITIONAL[1]}"
+  BODY="${POSITIONAL[2]:-}"
   FULL_TITLE="[Parent #${PARENT_NUMBER}] ${TITLE}"
 
+  # Rule 8 (sf-workflow SKILL.md) — on SRS-enabled projects, subtask creation
+  # is supposed to flow through `srs-cli.sh spawn` so tickets inherit an SRS
+  # page. Any ad-hoc call must opt out explicitly with --bypass-srs <reason>.
+  # The reason is not interpreted — it's an audit-trail hint echoed after the
+  # success line so the intent is visible in shell history / PR review.
+  if [ -f ".saasfoundry.json" ]; then
+    local srs_backend
+    srs_backend=$(jq -r '.tools.srs.backend // empty' .saasfoundry.json 2>/dev/null)
+    if [ -n "$srs_backend" ] && [ -z "$BYPASS_SRS_REASON" ]; then
+      echo -e "${RED}✗ Rule 8: this project has SRS enabled (tools.srs.backend=${srs_backend}).${NC}" >&2
+      echo "  Feature subtasks must be spawned from a drafted SRS page via:" >&2
+      echo "    .claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url>" >&2
+      echo "" >&2
+      echo "  If this subtask is genuinely off-spec (emergency, infra work, meta-ticket, …)," >&2
+      echo "  re-run with an explicit bypass + reason:" >&2
+      echo "    $0 create-subtask ${PARENT_NUMBER} \"${TITLE}\" --bypass-srs \"<reason>\"" >&2
+      echo "" >&2
+      echo "  See .claude/skills/sf-workflow/SKILL.md → Critical rule 8." >&2
+      exit 2
+    fi
+  fi
+
   echo -e "${YELLOW}Creating subtask for parent issue #${PARENT_NUMBER}...${NC}"
+  if [ -n "$BYPASS_SRS_REASON" ]; then
+    echo -e "${BLUE}  (bypassing rule 8 — reason: ${BYPASS_SRS_REASON})${NC}"
+  fi
 
   PARENT_NODE_ID=$(gh issue view "$PARENT_NUMBER" --json id --jq ".id" 2>/dev/null)
   if [ -z "$PARENT_NODE_ID" ]; then

--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -228,12 +228,21 @@ cmd_create_subtask() {
   fi
 
   # Separate positional args from the --bypass-srs flag. The flag can appear
-  # anywhere on the command line, carries a mandatory reason, and trips rule 8
+  # anywhere on the command line in either --bypass-srs <reason> or
+  # --bypass-srs=<reason> form, carries a mandatory reason, and trips rule 8
   # off. We accept up to three positional args (parent, title, body).
   local -a POSITIONAL=()
   local BYPASS_SRS_REASON=""
   while [ $# -gt 0 ]; do
     case "$1" in
+      --bypass-srs=*)
+        BYPASS_SRS_REASON="${1#--bypass-srs=}"
+        if [ -z "$BYPASS_SRS_REASON" ]; then
+          echo -e "${RED}Error: --bypass-srs= requires a reason (e.g. --bypass-srs=\"emergency hotfix\")${NC}" >&2
+          exit 1
+        fi
+        shift
+        ;;
       --bypass-srs)
         if [ -z "${2:-}" ] || [[ "${2}" == --* ]]; then
           echo -e "${RED}Error: --bypass-srs requires a reason (e.g. --bypass-srs \"emergency hotfix\")${NC}" >&2
@@ -267,7 +276,7 @@ cmd_create_subtask() {
   # success line so the intent is visible in shell history / PR review.
   if [ -f ".saasfoundry.json" ]; then
     local srs_backend
-    srs_backend=$(jq -r '.tools.srs.backend // empty' .saasfoundry.json 2>/dev/null)
+    srs_backend=$(jq -r 'if (.tools.srs.backend | type) == "string" then .tools.srs.backend else empty end' .saasfoundry.json 2>/dev/null)
     if [ -n "$srs_backend" ] && [ -z "$BYPASS_SRS_REASON" ]; then
       echo -e "${RED}✗ Rule 8: this project has SRS enabled (tools.srs.backend=${srs_backend}).${NC}" >&2
       echo "  Feature subtasks must be spawned from a drafted SRS page via:" >&2
@@ -284,7 +293,7 @@ cmd_create_subtask() {
 
   echo -e "${YELLOW}Creating subtask for parent issue #${PARENT_NUMBER}...${NC}"
   if [ -n "$BYPASS_SRS_REASON" ]; then
-    echo -e "${BLUE}  (bypassing rule 8 — reason: ${BYPASS_SRS_REASON})${NC}"
+    printf '%b  (bypassing rule 8 — reason: %s)%b\n' "${BLUE}" "${BYPASS_SRS_REASON}" "${NC}"
   fi
 
   PARENT_NODE_ID=$(gh issue view "$PARENT_NUMBER" --json id --jq ".id" 2>/dev/null)

--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -156,6 +156,25 @@ Each phase is documented in detail:
 **Guard** — `update-status <ticket> "AI testing|Human testing|In review"` is rejected when the ticket carries an `srs:*` label. Use `transition-drafting` instead. The guard fails open if label fetch
 errors (offline / auth issues) so normal teams are not punished by infrastructure hiccups.
 
+### Rule 8 — spawning Stories from SRS
+
+Once an Epic page tree is drafted (Main spec + FR-001…FR-N children), the Story sub-tickets under the parent must be created by the spawner, not by hand:
+
+```bash
+.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>
+```
+
+The spawner enumerates FR pages, renders each Story body from `renderStoryTicketBody`, invokes `workflow-cli.sh create-subtask` with `--bypass-srs spawned-from-srs`, and tags the new issue with
+`srs:new`. Use `--dry-run` to preview without writing.
+
+On SRS-enabled projects (`tools.srs.backend` is set), `create-subtask` refuses calls without `--bypass-srs <reason>` and exits 2. The escape hatch is legitimate only for:
+
+- Meta tickets that don't map to an FR page (SRS tooling, drafter refactors, eval polish)
+- Bootstrapping an Epic's own SUBs during rollout before the page tree exists
+
+Typing the reason is the audit trail — pick something a reviewer can grep for (`spawned-from-srs`, `meta-srs-tooling`, `bootstrap-epic-174`…). If the ticket represents a feature requirement, the
+answer is always "go draft it first, then spawn."
+
 ## Workflow Statuses
 
 1. **Backlog** (GRAY) — Read `statuses/1-backlog.md` for full description
@@ -180,6 +199,10 @@ errors (offline / auth issues) so normal teams are not punished by infrastructur
    ensure it returns empty. If not, go back and close the children first.
 7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only
    override is an explicit developer request to pause.
+8. **TICKETS FROM SRS** — when `tools.srs.backend` is set in `.saasfoundry.json`, Story sub-tickets under an SRS Epic must be spawned from the canonical FR pages, not hand-written. Use
+   `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody` and labelled
+   `srs:new`. The `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section below. The escape hatch exists for meta tickets (SRS
+   refactors, tooling) but must never be used to duplicate an FR that already has a page.
 
 ## Implementation
 

--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -164,8 +164,8 @@ Once an Epic page tree is drafted (Main spec + FR-001…FR-N children), the Stor
 .claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>
 ```
 
-The spawner enumerates FR pages, renders each Story body from `renderStoryTicketBody`, invokes `workflow-cli.sh create-subtask` with `--bypass-srs spawned-from-srs`, and tags the new issue with
-`srs:new`. Use `--dry-run` to preview without writing.
+The spawner enumerates FR pages, renders each Story body from `renderStoryTicketBody`, and invokes `workflow-cli.sh create-subtask` with `--bypass-srs spawned-from-srs`. Children land as regular
+sub-issues under the parent ticket (no `srs:*` label — they flow through the normal code-path workflow). Use `--dry-run` to preview without writing.
 
 On SRS-enabled projects (`tools.srs.backend` is set), `create-subtask` refuses calls without `--bypass-srs <reason>` and exits 2. The escape hatch is legitimate only for:
 
@@ -200,9 +200,9 @@ answer is always "go draft it first, then spawn."
 7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only
    override is an explicit developer request to pause.
 8. **TICKETS FROM SRS** — when `tools.srs.backend` is set in `.saasfoundry.json`, Story sub-tickets under an SRS Epic must be spawned from the canonical FR pages, not hand-written. Use
-   `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody` and labelled
-   `srs:new`. The `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section below. The escape hatch exists for meta tickets (SRS
-   refactors, tooling) but must never be used to duplicate an FR that already has a page.
+   `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody`. The
+   `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section below. The escape hatch exists for meta tickets (SRS refactors,
+   tooling) but must never be used to duplicate an FR that already has a page.
 
 ## Implementation
 

--- a/scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh
+++ b/scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # sf-srs orchestrator — single entrypoint for every skill that hands off to SRS work.
 # Body grows as sibling SUBs under #174 land ; this revision implements
-# `help`, `validate`, `browse`, `draft`, `write`.
+# `help`, `validate`, `browse`, `draft`, `write`, `spawn`.
 
 set -euo pipefail
 
@@ -23,10 +23,15 @@ Actions:
                                     Apply a DraftCandidate[] spec file : creates Epic /
                                     FR pages through the adapter and clears the
                                     `tools.srs.pendingIngestion` flag on success.
+  spawn  --ticket <n> --epic <page-url-or-id> [--dry-run] [--manifest] [--bypass-reason <text>]
+                                    Enumerate FR page children of a drafted Epic and
+                                    create a Story sub-ticket per FR under the parent
+                                    ticket. Each child lands in Backlog with the
+                                    `srs:new` label. `--dry-run` previews without
+                                    writing.
 
 Actions populated by sibling SUBs under #174 :
   draft --from codebase             Codebase audit drafter                       (SUB-13)
-  spawn                             Spawn GitHub tickets from a published SRS   (SUB-9)
   eval                              Score SRS freshness against the codebase    (SUB-10)
 
 Common options :
@@ -92,6 +97,8 @@ run_browse() { run_bin browse-tree "$@"; }
 
 run_write() { run_bin write-srs "$@"; }
 
+run_spawn() { run_bin spawn "$@"; }
+
 run_draft() {
   # `--from <source>` selects which drafter to invoke ; default = notion-pages.
   local source="notion-pages"
@@ -125,7 +132,8 @@ case "$ACTION" in
   browse) run_browse "$@" ;;
   draft) run_draft "$@" ;;
   write) run_write "$@" ;;
-  spawn|eval)
+  spawn) run_spawn "$@" ;;
+  eval)
     echo "sf-srs: action '$ACTION' not implemented yet — owned by a sibling SUB under #174." >&2
     exit 2
     ;;

--- a/scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh
+++ b/scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh
@@ -26,9 +26,10 @@ Actions:
   spawn  --ticket <n> --epic <page-url-or-id> [--dry-run] [--manifest] [--bypass-reason <text>]
                                     Enumerate FR page children of a drafted Epic and
                                     create a Story sub-ticket per FR under the parent
-                                    ticket. Each child lands in Backlog with the
-                                    `srs:new` label. `--dry-run` previews without
-                                    writing.
+                                    ticket. Each child is created as a GitHub
+                                    sub-issue tagged `srs:new`; board placement
+                                    follows the project's default automation.
+                                    `--dry-run` previews without writing.
 
 Actions populated by sibling SUBs under #174 :
   draft --from codebase             Codebase audit drafter                       (SUB-13)

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -223,16 +223,69 @@ get_ticket_status() {
 cmd_create_subtask() {
   if [ "$#" -lt 2 ]; then
     echo -e "${RED}Error: Missing arguments${NC}"
-    echo "Usage: $0 create-subtask <parent-number> <title> [body]"
+    echo "Usage: $0 create-subtask <parent-number> <title> [body] [--bypass-srs <reason>]"
     exit 1
   fi
 
-  PARENT_NUMBER=$1
-  TITLE=$2
-  BODY=${3:-""}
+  # Separate positional args from the --bypass-srs flag. The flag can appear
+  # anywhere on the command line, carries a mandatory reason, and trips rule 8
+  # off. We accept up to three positional args (parent, title, body).
+  local -a POSITIONAL=()
+  local BYPASS_SRS_REASON=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --bypass-srs)
+        if [ -z "${2:-}" ] || [[ "${2}" == --* ]]; then
+          echo -e "${RED}Error: --bypass-srs requires a reason (e.g. --bypass-srs \"emergency hotfix\")${NC}" >&2
+          exit 1
+        fi
+        BYPASS_SRS_REASON=$2
+        shift 2
+        ;;
+      *)
+        POSITIONAL+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [ "${#POSITIONAL[@]}" -lt 2 ]; then
+    echo -e "${RED}Error: Missing arguments${NC}"
+    echo "Usage: $0 create-subtask <parent-number> <title> [body] [--bypass-srs <reason>]"
+    exit 1
+  fi
+
+  PARENT_NUMBER="${POSITIONAL[0]}"
+  TITLE="${POSITIONAL[1]}"
+  BODY="${POSITIONAL[2]:-}"
   FULL_TITLE="[Parent #${PARENT_NUMBER}] ${TITLE}"
 
+  # Rule 8 (sf-workflow SKILL.md) — on SRS-enabled projects, subtask creation
+  # is supposed to flow through `srs-cli.sh spawn` so tickets inherit an SRS
+  # page. Any ad-hoc call must opt out explicitly with --bypass-srs <reason>.
+  # The reason is not interpreted — it's an audit-trail hint echoed after the
+  # success line so the intent is visible in shell history / PR review.
+  if [ -f ".saasfoundry.json" ]; then
+    local srs_backend
+    srs_backend=$(jq -r '.tools.srs.backend // empty' .saasfoundry.json 2>/dev/null)
+    if [ -n "$srs_backend" ] && [ -z "$BYPASS_SRS_REASON" ]; then
+      echo -e "${RED}✗ Rule 8: this project has SRS enabled (tools.srs.backend=${srs_backend}).${NC}" >&2
+      echo "  Feature subtasks must be spawned from a drafted SRS page via:" >&2
+      echo "    .claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url>" >&2
+      echo "" >&2
+      echo "  If this subtask is genuinely off-spec (emergency, infra work, meta-ticket, …)," >&2
+      echo "  re-run with an explicit bypass + reason:" >&2
+      echo "    $0 create-subtask ${PARENT_NUMBER} \"${TITLE}\" --bypass-srs \"<reason>\"" >&2
+      echo "" >&2
+      echo "  See .claude/skills/sf-workflow/SKILL.md → Critical rule 8." >&2
+      exit 2
+    fi
+  fi
+
   echo -e "${YELLOW}Creating subtask for parent issue #${PARENT_NUMBER}...${NC}"
+  if [ -n "$BYPASS_SRS_REASON" ]; then
+    echo -e "${BLUE}  (bypassing rule 8 — reason: ${BYPASS_SRS_REASON})${NC}"
+  fi
 
   PARENT_NODE_ID=$(gh issue view "$PARENT_NUMBER" --json id --jq ".id" 2>/dev/null)
   if [ -z "$PARENT_NODE_ID" ]; then

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -228,12 +228,21 @@ cmd_create_subtask() {
   fi
 
   # Separate positional args from the --bypass-srs flag. The flag can appear
-  # anywhere on the command line, carries a mandatory reason, and trips rule 8
+  # anywhere on the command line in either --bypass-srs <reason> or
+  # --bypass-srs=<reason> form, carries a mandatory reason, and trips rule 8
   # off. We accept up to three positional args (parent, title, body).
   local -a POSITIONAL=()
   local BYPASS_SRS_REASON=""
   while [ $# -gt 0 ]; do
     case "$1" in
+      --bypass-srs=*)
+        BYPASS_SRS_REASON="${1#--bypass-srs=}"
+        if [ -z "$BYPASS_SRS_REASON" ]; then
+          echo -e "${RED}Error: --bypass-srs= requires a reason (e.g. --bypass-srs=\"emergency hotfix\")${NC}" >&2
+          exit 1
+        fi
+        shift
+        ;;
       --bypass-srs)
         if [ -z "${2:-}" ] || [[ "${2}" == --* ]]; then
           echo -e "${RED}Error: --bypass-srs requires a reason (e.g. --bypass-srs \"emergency hotfix\")${NC}" >&2
@@ -267,7 +276,7 @@ cmd_create_subtask() {
   # success line so the intent is visible in shell history / PR review.
   if [ -f ".saasfoundry.json" ]; then
     local srs_backend
-    srs_backend=$(jq -r '.tools.srs.backend // empty' .saasfoundry.json 2>/dev/null)
+    srs_backend=$(jq -r 'if (.tools.srs.backend | type) == "string" then .tools.srs.backend else empty end' .saasfoundry.json 2>/dev/null)
     if [ -n "$srs_backend" ] && [ -z "$BYPASS_SRS_REASON" ]; then
       echo -e "${RED}✗ Rule 8: this project has SRS enabled (tools.srs.backend=${srs_backend}).${NC}" >&2
       echo "  Feature subtasks must be spawned from a drafted SRS page via:" >&2
@@ -284,7 +293,7 @@ cmd_create_subtask() {
 
   echo -e "${YELLOW}Creating subtask for parent issue #${PARENT_NUMBER}...${NC}"
   if [ -n "$BYPASS_SRS_REASON" ]; then
-    echo -e "${BLUE}  (bypassing rule 8 — reason: ${BYPASS_SRS_REASON})${NC}"
+    printf '%b  (bypassing rule 8 — reason: %s)%b\n' "${BLUE}" "${BYPASS_SRS_REASON}" "${NC}"
   fi
 
   PARENT_NODE_ID=$(gh issue view "$PARENT_NUMBER" --json id --jq ".id" 2>/dev/null)

--- a/scaffolds/skills-templates/workflow/SKILL.md
+++ b/scaffolds/skills-templates/workflow/SKILL.md
@@ -157,6 +157,23 @@ Each phase is documented in detail:
 
 **Guard** — `update-status <ticket> "AI testing|Human testing|In review"` is rejected when the ticket carries an `srs:*` label. Use `transition-drafting` instead. The guard fails open if label fetch errors (offline / auth issues) so normal teams are not punished by infrastructure hiccups.
 
+### Rule 8 — spawning Stories from SRS
+
+Once an Epic page tree is drafted (Main spec + FR-001…FR-N children), the Story sub-tickets under the parent must be created by the spawner, not by hand:
+
+```bash
+.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>
+```
+
+The spawner enumerates FR pages, renders each Story body from `renderStoryTicketBody`, invokes `workflow-cli.sh create-subtask` with `--bypass-srs spawned-from-srs`, and tags the new issue with `srs:new`. Use `--dry-run` to preview without writing.
+
+On SRS-enabled projects (`tools.srs.backend` is set), `create-subtask` refuses calls without `--bypass-srs <reason>` and exits 2. The escape hatch is legitimate only for:
+
+- Meta tickets that don't map to an FR page (SRS tooling, drafter refactors, eval polish)
+- Bootstrapping an Epic's own SUBs during rollout before the page tree exists
+
+Typing the reason is the audit trail — pick something a reviewer can grep for (`spawned-from-srs`, `meta-srs-tooling`, `bootstrap-epic-174`…). If the ticket represents a feature requirement, the answer is always "go draft it first, then spawn."
+
 ## Workflow Statuses
 
 {{STATUSES_LIST}}
@@ -172,6 +189,7 @@ Each phase is documented in detail:
 5. **CLOSE SUBTASKS AS YOU GO** — after a subtask's commit lands, immediately run `workflow-cli.sh update-status <sub> Done` and verify `gh issue view <sub> --json state` prints `CLOSED` before starting the next one. Never batch closures at the end of the parent ticket.
 6. **GATE PARENT TRANSITIONS ON OPEN CHILDREN** — before any parent transition (`AI Testing` → `Human Testing` → `In Review` → `Done`), run `gh issue list --state open --search "parent #<N>"` and ensure it returns empty. If not, go back and close the children first.
 7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only override is an explicit developer request to pause.
+8. **TICKETS FROM SRS** — when `tools.srs.backend` is set in `.saasfoundry.json`, Story sub-tickets under an SRS Epic must be spawned from the canonical FR pages, not hand-written. Use `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody` and labelled `srs:new`. The `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section above. The escape hatch exists for meta tickets (SRS refactors, tooling) but must never be used to duplicate an FR that already has a page.
 
 ## Implementation
 

--- a/scaffolds/skills-templates/workflow/SKILL.md
+++ b/scaffolds/skills-templates/workflow/SKILL.md
@@ -165,7 +165,7 @@ Once an Epic page tree is drafted (Main spec + FR-001…FR-N children), the Stor
 .claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>
 ```
 
-The spawner enumerates FR pages, renders each Story body from `renderStoryTicketBody`, invokes `workflow-cli.sh create-subtask` with `--bypass-srs spawned-from-srs`, and tags the new issue with `srs:new`. Use `--dry-run` to preview without writing.
+The spawner enumerates FR pages, renders each Story body from `renderStoryTicketBody`, and invokes `workflow-cli.sh create-subtask` with `--bypass-srs spawned-from-srs`. Children land as regular sub-issues under the parent ticket (no `srs:*` label — they flow through the normal code-path workflow). Use `--dry-run` to preview without writing.
 
 On SRS-enabled projects (`tools.srs.backend` is set), `create-subtask` refuses calls without `--bypass-srs <reason>` and exits 2. The escape hatch is legitimate only for:
 
@@ -189,7 +189,7 @@ Typing the reason is the audit trail — pick something a reviewer can grep for 
 5. **CLOSE SUBTASKS AS YOU GO** — after a subtask's commit lands, immediately run `workflow-cli.sh update-status <sub> Done` and verify `gh issue view <sub> --json state` prints `CLOSED` before starting the next one. Never batch closures at the end of the parent ticket.
 6. **GATE PARENT TRANSITIONS ON OPEN CHILDREN** — before any parent transition (`AI Testing` → `Human Testing` → `In Review` → `Done`), run `gh issue list --state open --search "parent #<N>"` and ensure it returns empty. If not, go back and close the children first.
 7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only override is an explicit developer request to pause.
-8. **TICKETS FROM SRS** — when `tools.srs.backend` is set in `.saasfoundry.json`, Story sub-tickets under an SRS Epic must be spawned from the canonical FR pages, not hand-written. Use `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody` and labelled `srs:new`. The `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section above. The escape hatch exists for meta tickets (SRS refactors, tooling) but must never be used to duplicate an FR that already has a page.
+8. **TICKETS FROM SRS** — when `tools.srs.backend` is set in `.saasfoundry.json`, Story sub-tickets under an SRS Epic must be spawned from the canonical FR pages, not hand-written. Use `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody`. The `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section above. The escape hatch exists for meta tickets (SRS refactors, tooling) but must never be used to duplicate an FR that already has a page.
 
 ## Implementation
 

--- a/src/__tests__/unit/skill/github-projects-cli.bypass-srs.spec.ts
+++ b/src/__tests__/unit/skill/github-projects-cli.bypass-srs.spec.ts
@@ -120,6 +120,26 @@ describe('sf-tool-github-projects — create-subtask Rule 8 guard', () => {
       expect(res.code).toBe(1)
       expect(res.stderr).toMatch(/--bypass-srs requires a reason/)
     })
+
+    it('accepts the --bypass-srs=<reason> attached-value syntax', async () => {
+      const res = await runCli(['create-subtask', '42', 'Meta tooling', '--bypass-srs=meta-srs-tooling'], sandbox)
+      expect(res.code).toBe(0)
+      expect(res.stdout).toMatch(/bypassing rule 8/)
+      expect(res.stdout).toMatch(/meta-srs-tooling/)
+    })
+
+    it('rejects --bypass-srs= with an empty attached value (exit 1)', async () => {
+      const res = await runCli(['create-subtask', '42', 'Thing', '--bypass-srs='], sandbox)
+      expect(res.code).toBe(1)
+      expect(res.stderr).toMatch(/--bypass-srs=? requires a reason/)
+    })
+
+    it('echoes the bypass reason verbatim without interpreting escape sequences', async () => {
+      const res = await runCli(['create-subtask', '42', 'Thing', '--bypass-srs', 'audit\\ttrail\\n'], sandbox)
+      expect(res.code).toBe(0)
+      expect(res.stdout).toContain('audit\\ttrail\\n')
+      expect(res.stdout).not.toContain('audit\ttrail\n')
+    })
   })
 
   describe('non-SRS project (tools.srs.backend absent)', () => {
@@ -166,6 +186,32 @@ describe('sf-tool-github-projects — create-subtask Rule 8 guard', () => {
       const sandbox = await buildSandbox({
         workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' },
         tools: { srs: { backend: null } }
+      })
+      try {
+        const res = await runCli(['create-subtask', '42', 'Thing'], sandbox)
+        expect(res.code).toBe(0)
+      } finally {
+        await sandbox.cleanup()
+      }
+    })
+
+    it('treats a non-string tools.srs.backend (e.g. number) as "not set" (Rule 8 dormant)', async () => {
+      const sandbox = await buildSandbox({
+        workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' },
+        tools: { srs: { backend: 42 } }
+      })
+      try {
+        const res = await runCli(['create-subtask', '42', 'Thing'], sandbox)
+        expect(res.code).toBe(0)
+      } finally {
+        await sandbox.cleanup()
+      }
+    })
+
+    it('treats a boolean tools.srs.backend as "not set" (Rule 8 dormant)', async () => {
+      const sandbox = await buildSandbox({
+        workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' },
+        tools: { srs: { backend: true } }
       })
       try {
         const res = await runCli(['create-subtask', '42', 'Thing'], sandbox)

--- a/src/__tests__/unit/skill/github-projects-cli.bypass-srs.spec.ts
+++ b/src/__tests__/unit/skill/github-projects-cli.bypass-srs.spec.ts
@@ -1,0 +1,178 @@
+import { execFile } from 'node:child_process'
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileP = promisify(execFile)
+
+const CLI = path.resolve(__dirname, '../../../../.claude/skills/sf-tool-github-projects/github-projects-cli.sh')
+const BASH = '/bin/bash'
+
+// Sandbox focused on the Rule 8 guard : write a manifest with or without
+// tools.srs.backend, then invoke create-subtask through a gh shim that
+// short-circuits to success — so any code path that reaches the issue
+// creation would succeed, letting us assert only on the guard outcome.
+async function buildSandbox(manifest: object): Promise<{
+  dir: string
+  env: NodeJS.ProcessEnv
+  cleanup: () => Promise<void>
+}> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sf-gh-bypass-srs-'))
+  const binDir = path.join(dir, 'bin')
+  await mkdir(binDir, { recursive: true })
+
+  await writeFile(path.join(dir, '.saasfoundry.json'), JSON.stringify(manifest))
+
+  // Minimal gh shim — the guard runs before any gh call, but we still need
+  // the create-subtask happy path to succeed when the guard is disarmed.
+  const shim = `#!/bin/bash
+case "$1" in
+  issue)
+    case "$2" in
+      view)
+        echo '{"id":"I_FAKE","url":"https://github.com/FakeOrg/FakeRepo/issues/42"}'
+        ;;
+      create)
+        echo "https://github.com/FakeOrg/FakeRepo/issues/999"
+        ;;
+      *)
+        echo '{}'
+        ;;
+    esac
+    ;;
+  api)
+    echo '{"data":{"addSubIssue":{"issue":{"number":42,"title":"p"},"subIssue":{"number":999,"title":"c"}}}}'
+    ;;
+  *)
+    echo '{}'
+    ;;
+esac
+`
+  const shimPath = path.join(binDir, 'gh')
+  writeFileSync(shimPath, shim)
+  chmodSync(shimPath, 0o755)
+
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    PWD: dir
+  }
+
+  return { dir, env, cleanup: () => rm(dir, { recursive: true, force: true }) }
+}
+
+async function runCli(args: string[], sandbox: { dir: string; env: NodeJS.ProcessEnv }): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await execFileP(BASH, [CLI, ...args], { cwd: sandbox.dir, env: sandbox.env })
+    return { stdout, stderr, code: 0 }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; code?: number }
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: typeof e.code === 'number' ? e.code : 1 }
+  }
+}
+
+describe('sf-tool-github-projects — create-subtask Rule 8 guard', () => {
+  describe('SRS-enabled project (tools.srs.backend is set)', () => {
+    let sandbox: Awaited<ReturnType<typeof buildSandbox>>
+
+    beforeEach(async () => {
+      sandbox = await buildSandbox({
+        workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' },
+        tools: { srs: { backend: 'notion' } }
+      })
+    })
+
+    afterEach(async () => {
+      await sandbox.cleanup()
+    })
+
+    it('rejects create-subtask without --bypass-srs (exit 2)', async () => {
+      const res = await runCli(['create-subtask', '42', 'Ad hoc feature'], sandbox)
+      expect(res.code).toBe(2)
+      expect(res.stderr).toMatch(/Rule 8/)
+      expect(res.stderr).toMatch(/tools\.srs\.backend=notion/)
+      expect(res.stderr).toMatch(/srs-cli\.sh spawn/)
+    })
+
+    it('accepts create-subtask with --bypass-srs <reason>', async () => {
+      const res = await runCli(['create-subtask', '42', 'Meta tooling', '--bypass-srs', 'meta-srs-tooling'], sandbox)
+      expect(res.code).toBe(0)
+      expect(res.stdout).toMatch(/bypassing rule 8/)
+      expect(res.stdout).toMatch(/meta-srs-tooling/)
+    })
+
+    it('accepts --bypass-srs with a body positional argument between parent and title', async () => {
+      const res = await runCli(['create-subtask', '42', 'Meta tooling', 'Some body', '--bypass-srs', 'meta-srs-tooling'], sandbox)
+      expect(res.code).toBe(0)
+      expect(res.stdout).toMatch(/bypassing rule 8/)
+    })
+
+    it('rejects --bypass-srs with no reason (exit 1)', async () => {
+      const res = await runCli(['create-subtask', '42', 'Thing', '--bypass-srs'], sandbox)
+      expect(res.code).toBe(1)
+      expect(res.stderr).toMatch(/--bypass-srs requires a reason/)
+    })
+
+    it('rejects --bypass-srs followed by another flag instead of a reason (exit 1)', async () => {
+      const res = await runCli(['create-subtask', '42', 'Thing', '--bypass-srs', '--something-else'], sandbox)
+      expect(res.code).toBe(1)
+      expect(res.stderr).toMatch(/--bypass-srs requires a reason/)
+    })
+  })
+
+  describe('non-SRS project (tools.srs.backend absent)', () => {
+    let sandbox: Awaited<ReturnType<typeof buildSandbox>>
+
+    beforeEach(async () => {
+      sandbox = await buildSandbox({
+        workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' }
+      })
+    })
+
+    afterEach(async () => {
+      await sandbox.cleanup()
+    })
+
+    it('accepts create-subtask without --bypass-srs (Rule 8 dormant)', async () => {
+      const res = await runCli(['create-subtask', '42', 'Classic feature'], sandbox)
+      expect(res.code).toBe(0)
+      expect(res.stdout).not.toMatch(/Rule 8/)
+    })
+
+    it('tolerates --bypass-srs anyway (the reason is echoed but the guard was never armed)', async () => {
+      const res = await runCli(['create-subtask', '42', 'Belt-and-suspenders', '--bypass-srs', 'paranoid'], sandbox)
+      expect(res.code).toBe(0)
+      expect(res.stdout).toMatch(/paranoid/)
+    })
+  })
+
+  describe('manifest edge cases', () => {
+    it('treats an empty tools.srs.backend as "not set" (Rule 8 dormant)', async () => {
+      const sandbox = await buildSandbox({
+        workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' },
+        tools: { srs: { backend: '' } }
+      })
+      try {
+        const res = await runCli(['create-subtask', '42', 'Thing'], sandbox)
+        expect(res.code).toBe(0)
+      } finally {
+        await sandbox.cleanup()
+      }
+    })
+
+    it('treats a null tools.srs.backend as "not set" (Rule 8 dormant)', async () => {
+      const sandbox = await buildSandbox({
+        workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' },
+        tools: { srs: { backend: null } }
+      })
+      try {
+        const res = await runCli(['create-subtask', '42', 'Thing'], sandbox)
+        expect(res.code).toBe(0)
+      } finally {
+        await sandbox.cleanup()
+      }
+    })
+  })
+})

--- a/src/__tests__/unit/srs/bin/spawn.spec.ts
+++ b/src/__tests__/unit/srs/bin/spawn.spec.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { EpicSpec, FrSpec, PageContent, PageRef, RawContent, ResolvedParent, SrsAdapter } from '../../../../builders/srs/types'
-import { extractFrId, extractFrTitle, runSpawn, SpawnIO, SpawnOptions } from '../../../../srs/bin/spawn'
+import { extractFrId, extractFrTitle, parseArgs, runSpawn, SpawnIO, SpawnOptions } from '../../../../srs/bin/spawn'
 import { registerSrsBackend, unregisterSrsBackend } from '../../../../srs'
 
 class StubAdapter implements SrsAdapter {
@@ -47,7 +47,6 @@ interface TestIO extends SpawnIO {
   stdout: jest.Mock
   stderr: jest.Mock
   createSubtask: jest.Mock
-  applyLabel: jest.Mock
   stdoutBuffer: string[]
   stderrBuffer: string[]
 }
@@ -69,9 +68,54 @@ function makeIO(overrides?: Partial<SpawnIO>): TestIO {
     void reason
     return { childNumber: String(nextNumber++) }
   })
-  const applyLabel = jest.fn(() => undefined)
-  return Object.assign({ stdout, stderr, createSubtask, applyLabel, stdoutBuffer, stderrBuffer }, overrides)
+  return Object.assign({ stdout, stderr, createSubtask, stdoutBuffer, stderrBuffer }, overrides)
 }
+
+describe('parseArgs', () => {
+  it('parses the minimal happy path', () => {
+    const opts = parseArgs(['--ticket', '42', '--epic', 'epic-url'])
+    expect(opts.ticket).toBe('42')
+    expect(opts.epic).toBe('epic-url')
+    expect(opts.dryRun).toBe(false)
+    expect(opts.manifestPath).toBe('.saasfoundry.json')
+    expect(opts.bypassReason).toBe('spawned-from-srs')
+  })
+
+  it('accepts --dry-run and custom --manifest / --bypass-reason', () => {
+    const opts = parseArgs(['--ticket', '1', '--epic', 'e', '--dry-run', '--manifest', '/tmp/m.json', '--bypass-reason', 'bootstrap'])
+    expect(opts.dryRun).toBe(true)
+    expect(opts.manifestPath).toBe('/tmp/m.json')
+    expect(opts.bypassReason).toBe('bootstrap')
+  })
+
+  it('throws when --ticket has no value', () => {
+    expect(() => parseArgs(['--ticket'])).toThrow(/--ticket requires a value/)
+  })
+
+  it('throws when --ticket is followed by another flag', () => {
+    expect(() => parseArgs(['--ticket', '--epic', 'e'])).toThrow(/--ticket requires a value/)
+  })
+
+  it('throws when --epic is followed by another flag', () => {
+    expect(() => parseArgs(['--ticket', '42', '--epic', '--dry-run'])).toThrow(/--epic requires a value/)
+  })
+
+  it('throws when --manifest has no value', () => {
+    expect(() => parseArgs(['--ticket', '42', '--epic', 'e', '--manifest'])).toThrow(/--manifest requires a value/)
+  })
+
+  it('throws when --bypass-reason is followed by another flag', () => {
+    expect(() => parseArgs(['--ticket', '42', '--epic', 'e', '--bypass-reason', '--dry-run'])).toThrow(/--bypass-reason requires a value/)
+  })
+
+  it('throws when --ticket is missing altogether', () => {
+    expect(() => parseArgs(['--epic', 'e'])).toThrow(/missing --ticket/)
+  })
+
+  it('throws when --epic is missing altogether', () => {
+    expect(() => parseArgs(['--ticket', '42'])).toThrow(/missing --epic/)
+  })
+})
 
 describe('extractFrId / extractFrTitle', () => {
   it('parses "FR-001 — Login flow"', () => {
@@ -222,7 +266,6 @@ describe('runSpawn', () => {
     const code = await runSpawn(baseOptions({ dryRun: true }), io)
     expect(code).toBe(0)
     expect(io.createSubtask).not.toHaveBeenCalled()
-    expect(io.applyLabel).not.toHaveBeenCalled()
     const out = io.stdoutBuffer.join('')
     expect(out).toMatch(/found 2 FR page\(s\)/)
     expect(out).toMatch(/FR-001 → FR-001: Login flow/)
@@ -230,7 +273,7 @@ describe('runSpawn', () => {
     expect(out).toMatch(/dry-run/)
   })
 
-  it('creates one Story per FR page and labels each with srs:new', async () => {
+  it('creates one Story sub-issue per FR page under the parent', async () => {
     const children: PageRef[] = [
       { id: 'p1', url: 'https://example.test/fr1', title: 'FR-001 — Login flow' },
       { id: 'p2', url: 'https://example.test/fr2', title: 'FR-002 — Password reset' }
@@ -247,8 +290,18 @@ describe('runSpawn', () => {
     expect(firstBody).toMatch(/## Objective/)
     expect(firstBody).toMatch(/FR-001 — Login flow/)
     expect(firstBody).toMatch(/https:\/\/example\.test\/fr1/)
-    expect(io.applyLabel).toHaveBeenCalledTimes(2)
-    expect(io.applyLabel.mock.calls[0][1]).toBe('srs:new')
+  })
+
+  it('warns and uses the raw title (no "X: X" duplication) when a child page is missing the FR-### prefix', async () => {
+    const children: PageRef[] = [{ id: 'p1', url: 'https://example.test/ad-hoc', title: 'Ad hoc page' }]
+    registerSrsBackend('stub', () => new StubAdapter(children))
+    writeManifest({ tools: { srs: { backend: 'stub' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(0)
+    expect(io.createSubtask).toHaveBeenCalledTimes(1)
+    expect(io.createSubtask.mock.calls[0][1]).toBe('Ad hoc page')
+    expect(io.stderrBuffer.join('')).toMatch(/does not match the "FR-### — Title" convention/)
   })
 
   it('propagates a custom --bypass-reason to createSubtask', async () => {
@@ -283,23 +336,5 @@ describe('runSpawn', () => {
     const code = await runSpawn(baseOptions(), io)
     expect(code).toBe(8)
     expect(io.stderrBuffer.join('')).toMatch(/gh failed/)
-  })
-
-  it('still succeeds when applyLabel throws — surfaces a warning but does not abort', async () => {
-    const children: PageRef[] = [
-      { id: 'p1', url: 'https://example.test/fr1', title: 'FR-001 — A' },
-      { id: 'p2', url: 'https://example.test/fr2', title: 'FR-002 — B' }
-    ]
-    registerSrsBackend('stub', () => new StubAdapter(children))
-    writeManifest({ tools: { srs: { backend: 'stub' } } })
-    const io = makeIO({
-      applyLabel: jest.fn(() => {
-        throw new Error('no label perms')
-      })
-    })
-    const code = await runSpawn(baseOptions(), io)
-    expect(code).toBe(0)
-    expect(io.createSubtask).toHaveBeenCalledTimes(2)
-    expect(io.stderrBuffer.join('')).toMatch(/could not add srs:new label/)
   })
 })

--- a/src/__tests__/unit/srs/bin/spawn.spec.ts
+++ b/src/__tests__/unit/srs/bin/spawn.spec.ts
@@ -1,0 +1,305 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { EpicSpec, FrSpec, PageContent, PageRef, RawContent, ResolvedParent, SrsAdapter } from '../../../../builders/srs/types'
+import { extractFrId, extractFrTitle, runSpawn, SpawnIO, SpawnOptions } from '../../../../srs/bin/spawn'
+import { registerSrsBackend, unregisterSrsBackend } from '../../../../srs'
+
+class StubAdapter implements SrsAdapter {
+  constructor(
+    private readonly children: PageRef[] = [],
+    private readonly onInit: () => Promise<void> | void = () => undefined,
+    private readonly onResolveParent: (input: string) => Promise<ResolvedParent> | ResolvedParent = (input) => ({ id: input, name: input, url: 'https://example.test/epic' }),
+    private readonly onListChildren: ((parentId: string) => Promise<PageRef[]> | PageRef[]) | null = null
+  ) {}
+
+  async init(): Promise<void> {
+    await this.onInit()
+  }
+  async resolveParent(input: string): Promise<ResolvedParent> {
+    return this.onResolveParent(input)
+  }
+  async createPage(parentPageId: string, title: string): Promise<PageRef> {
+    void parentPageId
+    return { id: 'page', url: '', title }
+  }
+  async createEpicPage(spec: EpicSpec): Promise<PageRef> {
+    return { id: 'e', url: '', title: spec.title }
+  }
+  async createFrPage(spec: FrSpec): Promise<PageRef> {
+    return { id: 'f', url: '', title: spec.fr.title }
+  }
+  async updatePage(pageId: string, content: PageContent): Promise<void> {
+    void pageId
+    void content
+  }
+  async fetchPage(pageId: string): Promise<RawContent> {
+    return { pageId, title: '', url: '', blocks: [] }
+  }
+  async listChildren(parentPageId: string): Promise<PageRef[]> {
+    if (this.onListChildren) return this.onListChildren(parentPageId)
+    return this.children
+  }
+}
+
+interface TestIO extends SpawnIO {
+  stdout: jest.Mock
+  stderr: jest.Mock
+  createSubtask: jest.Mock
+  applyLabel: jest.Mock
+  stdoutBuffer: string[]
+  stderrBuffer: string[]
+}
+
+function makeIO(overrides?: Partial<SpawnIO>): TestIO {
+  const stdoutBuffer: string[] = []
+  const stderrBuffer: string[] = []
+  let nextNumber = 100
+  const stdout = jest.fn((chunk: string) => {
+    stdoutBuffer.push(chunk)
+  })
+  const stderr = jest.fn((chunk: string) => {
+    stderrBuffer.push(chunk)
+  })
+  const createSubtask = jest.fn((parent: string, title: string, body: string, reason: string) => {
+    void parent
+    void title
+    void body
+    void reason
+    return { childNumber: String(nextNumber++) }
+  })
+  const applyLabel = jest.fn(() => undefined)
+  return Object.assign({ stdout, stderr, createSubtask, applyLabel, stdoutBuffer, stderrBuffer }, overrides)
+}
+
+describe('extractFrId / extractFrTitle', () => {
+  it('parses "FR-001 — Login flow"', () => {
+    expect(extractFrId('FR-001 — Login flow')).toBe('FR-001')
+    expect(extractFrTitle('FR-001 — Login flow')).toBe('Login flow')
+  })
+
+  it('parses "FR-042: Password reset"', () => {
+    expect(extractFrId('FR-042: Password reset')).toBe('FR-042')
+    expect(extractFrTitle('FR-042: Password reset')).toBe('Password reset')
+  })
+
+  it('uppercases the FR id', () => {
+    expect(extractFrId('fr-009 — Something')).toBe('FR-009')
+  })
+
+  it('falls back to the raw title when no FR pattern is present', () => {
+    expect(extractFrId('Ad hoc page')).toBe('Ad hoc page')
+    expect(extractFrTitle('Ad hoc page')).toBe('Ad hoc page')
+  })
+
+  it('trims surrounding whitespace in the fallback', () => {
+    expect(extractFrId('  FR-010 - Typed hyphen  ')).toBe('FR-010')
+    expect(extractFrTitle('  FR-010 - Typed hyphen  ')).toBe('Typed hyphen')
+  })
+})
+
+describe('runSpawn', () => {
+  let tmp: string
+
+  const baseOptions = (overrides: Partial<SpawnOptions> = {}): SpawnOptions => ({
+    ticket: '42',
+    epic: 'https://example.test/epic',
+    dryRun: false,
+    manifestPath: join(tmp, '.saasfoundry.json'),
+    bypassReason: 'spawned-from-srs',
+    ...overrides
+  })
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sf-srs-spawn-'))
+  })
+
+  afterEach(() => {
+    unregisterSrsBackend('stub')
+    unregisterSrsBackend('explode-init')
+    unregisterSrsBackend('explode-resolve')
+    unregisterSrsBackend('explode-children')
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  const writeManifest = (body: unknown): void => {
+    writeFileSync(join(tmp, '.saasfoundry.json'), JSON.stringify(body))
+  }
+
+  it('returns 2 when the manifest is missing', async () => {
+    const io = makeIO()
+    const code = await runSpawn(baseOptions({ manifestPath: join(tmp, 'nope.json') }), io)
+    expect(code).toBe(2)
+    expect(io.stderrBuffer.join('')).toMatch(/ENOENT|no such file/)
+  })
+
+  it('returns 2 when the manifest is malformed JSON', async () => {
+    writeFileSync(join(tmp, '.saasfoundry.json'), '{not valid json')
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(2)
+    expect(io.stderrBuffer.join('')).toMatch(/failed to parse/)
+  })
+
+  it('returns 3 when tools.srs.backend is missing', async () => {
+    writeManifest({ tools: {} })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(3)
+  })
+
+  it('returns 4 when the backend key is unknown', async () => {
+    writeManifest({ tools: { srs: { backend: 'nope' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(4)
+  })
+
+  it('returns 5 when adapter.init() throws a non-config error', async () => {
+    registerSrsBackend(
+      'explode-init',
+      () =>
+        new StubAdapter([], async () => {
+          throw new Error('network down')
+        })
+    )
+    writeManifest({ tools: { srs: { backend: 'explode-init' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(5)
+    expect(io.stderrBuffer.join('')).toMatch(/network down/)
+  })
+
+  it('returns 6 when resolveParent throws', async () => {
+    registerSrsBackend(
+      'explode-resolve',
+      () =>
+        new StubAdapter([], undefined, () => {
+          throw new Error('unknown epic')
+        })
+    )
+    writeManifest({ tools: { srs: { backend: 'explode-resolve' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(6)
+    expect(io.stderrBuffer.join('')).toMatch(/could not resolve epic/)
+  })
+
+  it('returns 7 when listChildren throws', async () => {
+    registerSrsBackend(
+      'explode-children',
+      () =>
+        new StubAdapter([], undefined, undefined, () => {
+          throw new Error('permission denied')
+        })
+    )
+    writeManifest({ tools: { srs: { backend: 'explode-children' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(7)
+    expect(io.stderrBuffer.join('')).toMatch(/listChildren failed/)
+  })
+
+  it('returns 0 and emits a "nothing to spawn" message when the Epic has no child pages', async () => {
+    registerSrsBackend('stub', () => new StubAdapter([]))
+    writeManifest({ tools: { srs: { backend: 'stub' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(0)
+    expect(io.createSubtask).not.toHaveBeenCalled()
+    expect(io.stdoutBuffer.join('')).toMatch(/nothing to spawn/)
+  })
+
+  it('dry-run: plans without creating, then exits 0', async () => {
+    const children: PageRef[] = [
+      { id: 'p1', url: 'https://example.test/fr1', title: 'FR-001 — Login flow' },
+      { id: 'p2', url: 'https://example.test/fr2', title: 'FR-002: Password reset' }
+    ]
+    registerSrsBackend('stub', () => new StubAdapter(children))
+    writeManifest({ tools: { srs: { backend: 'stub' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions({ dryRun: true }), io)
+    expect(code).toBe(0)
+    expect(io.createSubtask).not.toHaveBeenCalled()
+    expect(io.applyLabel).not.toHaveBeenCalled()
+    const out = io.stdoutBuffer.join('')
+    expect(out).toMatch(/found 2 FR page\(s\)/)
+    expect(out).toMatch(/FR-001 → FR-001: Login flow/)
+    expect(out).toMatch(/FR-002 → FR-002: Password reset/)
+    expect(out).toMatch(/dry-run/)
+  })
+
+  it('creates one Story per FR page and labels each with srs:new', async () => {
+    const children: PageRef[] = [
+      { id: 'p1', url: 'https://example.test/fr1', title: 'FR-001 — Login flow' },
+      { id: 'p2', url: 'https://example.test/fr2', title: 'FR-002 — Password reset' }
+    ]
+    registerSrsBackend('stub', () => new StubAdapter(children))
+    writeManifest({ tools: { srs: { backend: 'stub' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(0)
+    expect(io.createSubtask).toHaveBeenCalledTimes(2)
+    expect(io.createSubtask.mock.calls[0]).toEqual(['42', 'FR-001: Login flow', expect.any(String), 'spawned-from-srs'])
+    expect(io.createSubtask.mock.calls[1]).toEqual(['42', 'FR-002: Password reset', expect.any(String), 'spawned-from-srs'])
+    const firstBody = io.createSubtask.mock.calls[0][2] as string
+    expect(firstBody).toMatch(/## Objective/)
+    expect(firstBody).toMatch(/FR-001 — Login flow/)
+    expect(firstBody).toMatch(/https:\/\/example\.test\/fr1/)
+    expect(io.applyLabel).toHaveBeenCalledTimes(2)
+    expect(io.applyLabel.mock.calls[0][1]).toBe('srs:new')
+  })
+
+  it('propagates a custom --bypass-reason to createSubtask', async () => {
+    const children: PageRef[] = [{ id: 'p1', url: 'https://example.test/fr1', title: 'FR-001 — Thing' }]
+    registerSrsBackend('stub', () => new StubAdapter(children))
+    writeManifest({ tools: { srs: { backend: 'stub' } } })
+    const io = makeIO()
+    const code = await runSpawn(baseOptions({ bypassReason: 'bootstrap-epic-174' }), io)
+    expect(code).toBe(0)
+    expect(io.createSubtask.mock.calls[0][3]).toBe('bootstrap-epic-174')
+  })
+
+  it('returns 8 when the subtask-creation shim yields an empty childNumber', async () => {
+    const children: PageRef[] = [{ id: 'p1', url: 'https://example.test/fr1', title: 'FR-001 — Thing' }]
+    registerSrsBackend('stub', () => new StubAdapter(children))
+    writeManifest({ tools: { srs: { backend: 'stub' } } })
+    const io = makeIO({ createSubtask: jest.fn(() => ({ childNumber: '' })) })
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(8)
+    expect(io.stderrBuffer.join('')).toMatch(/could not determine new ticket number/)
+  })
+
+  it('returns 8 when createSubtask throws', async () => {
+    const children: PageRef[] = [{ id: 'p1', url: 'https://example.test/fr1', title: 'FR-001 — Thing' }]
+    registerSrsBackend('stub', () => new StubAdapter(children))
+    writeManifest({ tools: { srs: { backend: 'stub' } } })
+    const io = makeIO({
+      createSubtask: jest.fn(() => {
+        throw new Error('gh failed')
+      })
+    })
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(8)
+    expect(io.stderrBuffer.join('')).toMatch(/gh failed/)
+  })
+
+  it('still succeeds when applyLabel throws — surfaces a warning but does not abort', async () => {
+    const children: PageRef[] = [
+      { id: 'p1', url: 'https://example.test/fr1', title: 'FR-001 — A' },
+      { id: 'p2', url: 'https://example.test/fr2', title: 'FR-002 — B' }
+    ]
+    registerSrsBackend('stub', () => new StubAdapter(children))
+    writeManifest({ tools: { srs: { backend: 'stub' } } })
+    const io = makeIO({
+      applyLabel: jest.fn(() => {
+        throw new Error('no label perms')
+      })
+    })
+    const code = await runSpawn(baseOptions(), io)
+    expect(code).toBe(0)
+    expect(io.createSubtask).toHaveBeenCalledTimes(2)
+    expect(io.stderrBuffer.join('')).toMatch(/could not add srs:new label/)
+  })
+})

--- a/src/srs/bin/spawn.ts
+++ b/src/srs/bin/spawn.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { renderStoryTicketBody } from '../../builders/srs/templates/tickets/story.tpl'
+import { FrItem, StoryTicketBodySpec } from '../../builders/srs/types'
+import { createSrsAdapter, SrsConfigError, SrsManifestSubset } from '../index'
+
+export interface SpawnOptions {
+  ticket: string
+  epic: string
+  dryRun: boolean
+  manifestPath: string
+  bypassReason: string
+}
+
+export interface PlannedCreation {
+  frId: string
+  title: string
+  frPageUrl: string
+  body: string
+}
+
+export interface SpawnIO {
+  stdout: (chunk: string) => void
+  stderr: (chunk: string) => void
+  createSubtask: (parent: string, title: string, body: string, bypassReason: string) => { childNumber: string }
+  applyLabel: (issueNumber: string, label: string) => void
+}
+
+function parseArgs(argv: string[]): SpawnOptions {
+  const opts: SpawnOptions = { ticket: '', epic: '', dryRun: false, manifestPath: '.saasfoundry.json', bypassReason: 'spawned-from-srs' }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--ticket') opts.ticket = argv[++i] ?? ''
+    else if (a === '--epic') opts.epic = argv[++i] ?? ''
+    else if (a === '--dry-run') opts.dryRun = true
+    else if (a === '--manifest') opts.manifestPath = argv[++i] ?? '.saasfoundry.json'
+    else if (a === '--bypass-reason') opts.bypassReason = argv[++i] ?? opts.bypassReason
+  }
+  if (!opts.ticket) throw new Error('spawn: missing --ticket <ticket-number>')
+  if (!opts.epic) throw new Error('spawn: missing --epic <page-url-or-id>')
+  return opts
+}
+
+function parseManifest(path: string): SrsManifestSubset {
+  const raw = readFileSync(path, 'utf8')
+  try {
+    return JSON.parse(raw) as SrsManifestSubset
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`spawn: failed to parse ${path} as JSON — ${message}`)
+  }
+}
+
+// Best-effort FR id extraction from the child page title. Convention (SUB-3
+// page template): "FR-001 — Login flow" / "FR-001: Login flow". Falls back
+// to the full title when no id pattern is present.
+export function extractFrId(title: string): string {
+  const match = title.match(/^\s*(FR-\d+)/i)
+  return match ? match[1].toUpperCase() : title.trim()
+}
+
+export function extractFrTitle(title: string): string {
+  const match = title.match(/^\s*FR-\d+\s*[—:\-]\s*(.+)$/i)
+  return match ? match[1].trim() : title.trim()
+}
+
+function defaultIO(): SpawnIO {
+  return {
+    stdout: (chunk) => process.stdout.write(chunk),
+    stderr: (chunk) => process.stderr.write(chunk),
+    createSubtask: (parent, title, body, bypassReason) => {
+      const output = execFileSync('.claude/skills/sf-workflow/workflow-cli.sh', ['create-subtask', parent, title, body, '--bypass-srs', bypassReason], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'inherit']
+      })
+      const match = output.match(/#(\d+)\s+linked/)
+      return { childNumber: match ? match[1] : '' }
+    },
+    applyLabel: (issueNumber, label) => {
+      execFileSync('gh', ['issue', 'edit', issueNumber, '--add-label', label], { stdio: ['ignore', 'pipe', 'pipe'] })
+    }
+  }
+}
+
+export async function runSpawn(options: SpawnOptions, io: SpawnIO = defaultIO()): Promise<number> {
+  const manifestPath = resolve(options.manifestPath)
+  let manifest: SrsManifestSubset
+  try {
+    manifest = parseManifest(manifestPath)
+  } catch (error) {
+    io.stderr(`${error instanceof Error ? error.message : String(error)}\n`)
+    return 2
+  }
+
+  let adapter
+  try {
+    adapter = await createSrsAdapter(manifest)
+    await adapter.init()
+  } catch (error) {
+    if (error instanceof SrsConfigError) {
+      io.stderr(`✗ ${error.message}\n`)
+      return error.code === 'missing' ? 3 : 4
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    io.stderr(`✗ spawn: adapter init failed — ${message}\n`)
+    return 5
+  }
+
+  let epicPageId: string
+  let mainSpecUrl: string | undefined
+  try {
+    const resolved = await adapter.resolveParent(options.epic)
+    epicPageId = resolved.id
+    mainSpecUrl = resolved.url
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    io.stderr(`✗ spawn: could not resolve epic "${options.epic}" — ${message}\n`)
+    return 6
+  }
+
+  let children
+  try {
+    children = await adapter.listChildren(epicPageId)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    io.stderr(`✗ spawn: listChildren failed — ${message}\n`)
+    return 7
+  }
+
+  if (children.length === 0) {
+    io.stdout(`spawn: epic has no child pages — nothing to spawn\n`)
+    return 0
+  }
+
+  const planned: PlannedCreation[] = children.map((child) => {
+    const fr: FrItem = { id: extractFrId(child.title), title: extractFrTitle(child.title) }
+    const spec: StoryTicketBodySpec = { fr, frPageUrl: child.url, mainSpecUrl }
+    return { frId: fr.id, title: `${fr.id}: ${fr.title}`, frPageUrl: child.url, body: renderStoryTicketBody(spec) }
+  })
+
+  io.stdout(`spawn: found ${planned.length} FR page(s) under the epic — planning Story tickets under parent #${options.ticket}\n`)
+  for (const p of planned) {
+    io.stdout(`  • ${p.frId} → ${p.title} (${p.frPageUrl})\n`)
+  }
+
+  if (options.dryRun) {
+    io.stdout(`\n[dry-run] No tickets created. Re-run without --dry-run to apply.\n`)
+    return 0
+  }
+
+  const created: string[] = []
+  for (const p of planned) {
+    try {
+      const { childNumber } = io.createSubtask(options.ticket, p.title, p.body, options.bypassReason)
+      if (!childNumber) {
+        io.stderr(`  ✗ ${p.frId}: could not determine new ticket number from create-subtask output\n`)
+        return 8
+      }
+      io.stdout(`  ✓ ${p.frId} → #${childNumber}\n`)
+      created.push(childNumber)
+      try {
+        io.applyLabel(childNumber, 'srs:new')
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        io.stderr(`    (warning: could not add srs:new label to #${childNumber}: ${message})\n`)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      io.stderr(`  ✗ failed to create ${p.frId}: ${message}\n`)
+      return 8
+    }
+  }
+
+  io.stdout(`\nspawn: created ${created.length} Story ticket(s) under #${options.ticket}.\n`)
+  return 0
+}
+
+if (require.main === module) {
+  let options: SpawnOptions
+  try {
+    options = parseArgs(process.argv.slice(2))
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`)
+    process.stderr.write(`\nUsage: spawn.ts --ticket <ticket-number> --epic <page-url-or-id> [--dry-run] [--manifest <path>] [--bypass-reason <text>]\n`)
+    process.exit(1)
+  }
+  runSpawn(options)
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`spawn: unexpected error — ${err instanceof Error ? err.message : String(err)}\n`)
+      process.exit(1)
+    })
+}

--- a/src/srs/bin/spawn.ts
+++ b/src/srs/bin/spawn.ts
@@ -25,18 +25,35 @@ export interface SpawnIO {
   stdout: (chunk: string) => void
   stderr: (chunk: string) => void
   createSubtask: (parent: string, title: string, body: string, bypassReason: string) => { childNumber: string }
-  applyLabel: (issueNumber: string, label: string) => void
 }
 
-function parseArgs(argv: string[]): SpawnOptions {
+function takeValue(argv: string[], i: number, flag: string): string {
+  const next = argv[i + 1]
+  if (next === undefined || next.startsWith('--')) {
+    throw new Error(`spawn: ${flag} requires a value`)
+  }
+  return next
+}
+
+export function parseArgs(argv: string[]): SpawnOptions {
   const opts: SpawnOptions = { ticket: '', epic: '', dryRun: false, manifestPath: '.saasfoundry.json', bypassReason: 'spawned-from-srs' }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
-    if (a === '--ticket') opts.ticket = argv[++i] ?? ''
-    else if (a === '--epic') opts.epic = argv[++i] ?? ''
-    else if (a === '--dry-run') opts.dryRun = true
-    else if (a === '--manifest') opts.manifestPath = argv[++i] ?? '.saasfoundry.json'
-    else if (a === '--bypass-reason') opts.bypassReason = argv[++i] ?? opts.bypassReason
+    if (a === '--ticket') {
+      opts.ticket = takeValue(argv, i, '--ticket')
+      i++
+    } else if (a === '--epic') {
+      opts.epic = takeValue(argv, i, '--epic')
+      i++
+    } else if (a === '--dry-run') {
+      opts.dryRun = true
+    } else if (a === '--manifest') {
+      opts.manifestPath = takeValue(argv, i, '--manifest')
+      i++
+    } else if (a === '--bypass-reason') {
+      opts.bypassReason = takeValue(argv, i, '--bypass-reason')
+      i++
+    }
   }
   if (!opts.ticket) throw new Error('spawn: missing --ticket <ticket-number>')
   if (!opts.epic) throw new Error('spawn: missing --epic <page-url-or-id>')
@@ -53,17 +70,22 @@ function parseManifest(path: string): SrsManifestSubset {
   }
 }
 
-// Best-effort FR id extraction from the child page title. Convention (SUB-3
-// page template): "FR-001 — Login flow" / "FR-001: Login flow". Falls back
-// to the full title when no id pattern is present.
+// Parse the SUB-3 page template convention ("FR-001 — Login flow" / "FR-001: Login flow").
+// When the title doesn't match, hasFrId=false and the id/title are identical (the raw title);
+// callers are expected to surface a warning and avoid rendering "title: title" duplicates.
+export function parseFrTitle(pageTitle: string): { id: string; title: string; hasFrId: boolean } {
+  const match = pageTitle.match(/^\s*(FR-\d+)\s*[—:\-]\s*(.+)$/i)
+  if (match) return { id: match[1].toUpperCase(), title: match[2].trim(), hasFrId: true }
+  const trimmed = pageTitle.trim()
+  return { id: trimmed, title: trimmed, hasFrId: false }
+}
+
 export function extractFrId(title: string): string {
-  const match = title.match(/^\s*(FR-\d+)/i)
-  return match ? match[1].toUpperCase() : title.trim()
+  return parseFrTitle(title).id
 }
 
 export function extractFrTitle(title: string): string {
-  const match = title.match(/^\s*FR-\d+\s*[—:\-]\s*(.+)$/i)
-  return match ? match[1].trim() : title.trim()
+  return parseFrTitle(title).title
 }
 
 function defaultIO(): SpawnIO {
@@ -77,9 +99,6 @@ function defaultIO(): SpawnIO {
       })
       const match = output.match(/#(\d+)\s+linked/)
       return { childNumber: match ? match[1] : '' }
-    },
-    applyLabel: (issueNumber, label) => {
-      execFileSync('gh', ['issue', 'edit', issueNumber, '--add-label', label], { stdio: ['ignore', 'pipe', 'pipe'] })
     }
   }
 }
@@ -135,9 +154,14 @@ export async function runSpawn(options: SpawnOptions, io: SpawnIO = defaultIO())
   }
 
   const planned: PlannedCreation[] = children.map((child) => {
-    const fr: FrItem = { id: extractFrId(child.title), title: extractFrTitle(child.title) }
+    const parsed = parseFrTitle(child.title)
+    if (!parsed.hasFrId) {
+      io.stderr(`  ⚠ spawn: child page "${child.title}" does not match the "FR-### — Title" convention; using raw title as the ticket name.\n`)
+    }
+    const fr: FrItem = { id: parsed.id, title: parsed.title }
     const spec: StoryTicketBodySpec = { fr, frPageUrl: child.url, mainSpecUrl }
-    return { frId: fr.id, title: `${fr.id}: ${fr.title}`, frPageUrl: child.url, body: renderStoryTicketBody(spec) }
+    const ticketTitle = parsed.hasFrId ? `${fr.id}: ${fr.title}` : fr.title
+    return { frId: fr.id, title: ticketTitle, frPageUrl: child.url, body: renderStoryTicketBody(spec) }
   })
 
   io.stdout(`spawn: found ${planned.length} FR page(s) under the epic — planning Story tickets under parent #${options.ticket}\n`)
@@ -160,12 +184,6 @@ export async function runSpawn(options: SpawnOptions, io: SpawnIO = defaultIO())
       }
       io.stdout(`  ✓ ${p.frId} → #${childNumber}\n`)
       created.push(childNumber)
-      try {
-        io.applyLabel(childNumber, 'srs:new')
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        io.stderr(`    (warning: could not add srs:new label to #${childNumber}: ${message})\n`)
-      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       io.stderr(`  ✗ failed to create ${p.frId}: ${message}\n`)


### PR DESCRIPTION
Closes #169

## Summary

- **SRS Story spawner** (`srs-cli.sh spawn --ticket <n> --epic <page-url-or-id>`) — reads the approved Epic page from the configured SRS backend, enumerates FR-### children, renders each Story body via `renderStoryTicketBody`, and creates one GitHub sub-issue per FR page under the parent ticket.
- **Rule 8 guard** on `create-subtask` — on SRS-enabled projects (`tools.srs.backend` is set), the command refuses to run without an explicit `--bypass-srs <reason>` opt-out, redirecting operators to the spawner. The reason is echoed as an audit trail (`bypassing rule 8 — reason: <text>`).
- **Docs** — SKILL.md "SRS Handoff → Rule 8 — spawning Stories from SRS" section + numbered Critical Rule 8 entry.

## Ship-blocker fixes from adversarial review (security / logic / DX)

- DX: `--bypass-srs=<reason>` attached-value syntax accepted; `parseArgs` guards against missing values on every flag (no more silent swallow of the next flag).
- Logic: when a child page lacks the `FR-### — Title` convention, the spawner warns and uses the raw title (no more `"Title: Title"` duplicates).
- Security: bypass reason echoed via `printf` (escape sequences stay inert); `jq` type-checks `tools.srs.backend` so non-string values don't arm the guard.
- Architectural: dropped the `srs:new` label application on spawned children — conflicted with #168's guard (which treats any `srs:*` label as draft-lifecycle and would have bricked the new Stories). Aligns with `statuses/3c-spawning.md` "no `srs:*` label" contract.

## Test plan

- [x] Unit tests — spawn.spec.ts (parseArgs guards, extractFrId/extractFrTitle, every exit code, fallback title warning, dry-run, custom bypass reason)
- [x] Unit tests — github-projects-cli.bypass-srs.spec.ts (SRS-enabled vs non-SRS, `--bypass-srs=value` syntax, escape hygiene, non-string backend values)
- [x] Full pre-commit: 774 passed / 2 skipped (format + lint + typecheck + jest)
- [x] Pre-push Docker build scenarios: multirepo-minimal + monorepo-minimal (green)
- [x] Byte-identical scaffold mirror enforced via `tool-skill-drift.spec.ts` PAIRS

🤖 Generated with [Claude Code](https://claude.com/claude-code)