### PR TITLE
[#170] [Parent #57] SUB-10: Continuous SRS evaluation hook

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -48,7 +48,8 @@ skill folder — the skill is a thin orchestrator.
 | `draft --from codebase`     | `draft-from-codebase.ts`        | SUB-13   |
 | `write`                     | `write-srs.ts`                  | SUB-6    |
 | `spawn`                     | `spawn-tickets.ts`              | SUB-9    |
-| `eval`                      | `eval-srs.ts`                   | SUB-10   |
+| `apply-update`              | `apply-srs-update.ts`           | SUB-10   |
+| `eval`                      | `eval-srs.ts`                   | SUB-16   |
 
 Placeholder subfolders under `templates/` are kept with `.gitkeep` until their owning SUB populates them.
 
@@ -66,15 +67,16 @@ Dispatch resolution happens inside `src/srs/` (SUB-14.2) — never directly in t
 
 All via `.claude/skills/sf-srs/scripts/srs-cli.sh <action> [args]`.
 
-| Action     | Purpose                                                               | Populated by |
-| ---------- | --------------------------------------------------------------------- | ------------ |
-| `help`     | Print available actions                                               | SUB-14.3     |
-| `validate` | Smoke-test the configured backend via `createSrsAdapter().init()`     | SUB-14.3     |
-| `browse`   | List direct children of a backend page (tree navigation helper)       | SUB-6        |
-| `draft`    | Run the drafter matching `--from <source>` (notion-pages \| codebase) | SUB-6, 13    |
-| `write`    | Apply a `DraftCandidate[]` spec to the backend + clear pending flag   | SUB-6        |
-| `spawn`    | Spawn GitHub tickets from a published SRS                             | SUB-9        |
-| `eval`     | Compute freshness score comparing the SRS to the codebase             | SUB-10       |
+| Action         | Purpose                                                               | Populated by |
+| -------------- | --------------------------------------------------------------------- | ------------ |
+| `help`         | Print available actions                                               | SUB-14.3     |
+| `validate`     | Smoke-test the configured backend via `createSrsAdapter().init()`     | SUB-14.3     |
+| `browse`       | List direct children of a backend page (tree navigation helper)       | SUB-6        |
+| `draft`        | Run the drafter matching `--from <source>` (notion-pages \| codebase) | SUB-6, 13    |
+| `write`        | Apply a `DraftCandidate[]` spec to the backend + clear pending flag   | SUB-6        |
+| `spawn`        | Spawn GitHub tickets from a published SRS                             | SUB-9        |
+| `apply-update` | Apply a conversational eval-hook patch (ADD-only : UR / FR / DS / TC) | SUB-10       |
+| `eval`         | Compute freshness score comparing the SRS to the codebase (batch)     | SUB-16       |
 
 The wrapper is intentionally thin — real logic lives in `src/srs/` and consumes only the `SrsAdapter` interface.
 
@@ -125,6 +127,69 @@ Every TS entrypoint under `src/srs/bin/` honours the same contract. The skill mu
 | 5    | Backend runtime error (network, adapter `init()` failure, fetch failure)             |
 | 6    | `write` only — partial failure, JSON payload carries `rollbackHint`                  |
 | 7    | `write` only — pages created successfully but clearing `pendingIngestion` failed     |
+
+## Conversational eval hook (SUB-10)
+
+When the project declares `tools.srs.enabled = true` in `.saasfoundry.json`, Claude is responsible for **interjecting** during conversation turns whose content looks like a new Software Requirement.
+There is no message parser and no standalone script — the "hook" is Claude reading the heuristics below and self-invoking. The `sf-workflow` skill's SKILL.md references this section and stays out of
+the way.
+
+### Detection heuristics — when to fire
+
+Fire at most **once per conversation turn**. Skip trivial turns (pure tool invocations, "ok", "thanks", "read X", "what does this do"). Fire when the user's message matches **any** of the following
+signals :
+
+| Signal                                   | Target                              | Example utterance                                               |
+| ---------------------------------------- | ----------------------------------- | --------------------------------------------------------------- |
+| Describes a **user need / outcome**      | new **UR** on the Epic page         | "users should be able to log in with SSO"                       |
+| Defines a new **feature or rule**        | new **FR** page under the Epic      | "we need a feature that lets admins export audit logs as CSV"   |
+| Clarifies an **implementation decision** | new **DS** on the relevant FR page  | "let's use BCrypt with cost factor 12 for password hashing"     |
+| Adds an **acceptance / test condition**  | new **TC** on the relevant FR page  | "and a test that proves unicode passwords are accepted"         |
+| Reopens a **previously closed decision** | likely an **FR** or **DS** revision | "on reconsidère la règle : finalement on autorise les chiffres" |
+
+Treat as **trivial and skip** : formatting nitpicks, small bug reports already covered by an existing FR, performance tweaks without observable user impact, pure refactor requests.
+
+### Confirmation flow
+
+When a signal fires, **pause before coding** and propose a diff in plain text :
+
+```
+💡 Ce que tu viens de décrire ressemble à <UR / FR / DS / TC>. Proposition :
+  • <target page> — add <item id> : <narrative | title>
+  • (if TC)        steps : ...
+
+J'applique via `srs-cli.sh apply-update` ? [accept / edit / reject]
+```
+
+- **accept** → build the patch JSON (see shape below) and run `.claude/skills/sf-srs/scripts/srs-cli.sh apply-update < patch.json` (or pipe via stdin). On exit 0, continue with the coding task.
+- **edit** → rework the proposed item text with the user, then re-confirm.
+- **reject** → drop the proposal and continue. Do **not** re-propose the same item in the same conversation.
+
+### Patch shape consumed by `apply-update`
+
+```jsonc
+{
+  "kind": "add-ur" | "add-fr" | "add-ds" | "add-tc",
+  "pageId": "<epic page id for add-ur / add-fr, FR page id for add-ds / add-tc>",
+  "item": { /* UrItem | FrSpec | DsItem | TcItem, same shapes as src/builders/srs/types.ts */ },
+  "note": "optional free-text annotation appended as a paragraph"
+}
+```
+
+### Scope limits (v1, intentional)
+
+- **ADD-only.** Modifying an existing item (e.g. tightening FR-012's acceptance criteria) is **out of scope** — the current `SrsAdapter.updatePage` is append-only on Notion, so surgical section
+  replacement is not available through the contract. A follow-up SUB will extend the adapter with replace/delete semantics.
+- **Append placement.** `add-ur` / `add-ds` / `add-tc` append new blocks to the **end** of the target page under an "Added …" heading2. The canonical section (User Requirements / Design / Test Cases)
+  is _not_ updated in-place. Reviewers must fold the appended block back into the right section during the next human SRS review. The limitation is deliberate and documented.
+- **`add-fr`** creates a brand-new child page under the Epic via `adapter.createFrPage`. The Epic page's "Traceability" table is **not** refreshed (same append-only limitation) — the new FR is still
+  discoverable as a child page.
+- **Throttling.** 1 proposal maximum per conversation turn. No persistent dedup cache (the turn boundary is sufficient — Claude's own judgment avoids re-proposing within the same turn).
+
+### Dogfood checklist
+
+After any change to the heuristics above, run a short manual session : drop 5 utterances (one per signal row + one trivial control) and confirm the hook fires exactly on the four signals and skips the
+trivial one.
 
 ## How other skills hand off to `sf-srs`
 

--- a/.claude/skills/sf-srs/scripts/srs-cli.sh
+++ b/.claude/skills/sf-srs/scripts/srs-cli.sh
@@ -30,10 +30,17 @@ Actions:
                                     sub-issue tagged `srs:new`; board placement
                                     follows the project's default automation.
                                     `--dry-run` previews without writing.
+  apply-update [--patch <path>] [--manifest]
+                                    Apply a conversational eval-hook patch
+                                    (ADD-only : new UR / new FR / new DS / new TC)
+                                    to the configured backend. Reads patch JSON
+                                    from stdin when --patch is omitted. Used by
+                                    the `sf-srs` eval hook after user accepts
+                                    the proposed diff — see SKILL.md.
 
 Actions populated by sibling SUBs under #174 :
   draft --from codebase             Codebase audit drafter                       (SUB-13)
-  eval                              Score SRS freshness against the codebase    (SUB-10)
+  eval                              Score SRS freshness vs. codebase (batch)    (SUB-16)
 
 Common options :
   --manifest <path>                 Manifest file to read (default: .saasfoundry.json)
@@ -100,6 +107,8 @@ run_write() { run_bin write-srs "$@"; }
 
 run_spawn() { run_bin spawn "$@"; }
 
+run_apply_update() { run_bin apply-srs-update "$@"; }
+
 run_draft() {
   # `--from <source>` selects which drafter to invoke ; default = notion-pages.
   local source="notion-pages"
@@ -134,6 +143,7 @@ case "$ACTION" in
   draft) run_draft "$@" ;;
   write) run_write "$@" ;;
   spawn) run_spawn "$@" ;;
+  apply-update) run_apply_update "$@" ;;
   eval)
     echo "sf-srs: action '$ACTION' not implemented yet — owned by a sibling SUB under #174." >&2
     exit 2

--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -175,6 +175,12 @@ On SRS-enabled projects (`tools.srs.backend` is set), `create-subtask` refuses c
 Typing the reason is the audit trail — pick something a reviewer can grep for (`spawned-from-srs`, `meta-srs-tooling`, `bootstrap-epic-174`…). If the ticket represents a feature requirement, the
 answer is always "go draft it first, then spawn."
 
+### Conversational eval hook (SRS-enabled projects)
+
+When `tools.srs.enabled = true`, Claude must interject during conversation turns whose content looks like a new User Requirement / Functional Requirement / Design decision / Test Case, propose a diff,
+and on user accept apply it via `.claude/skills/sf-srs/scripts/srs-cli.sh apply-update`. The detection heuristics, confirmation flow, and scope limits (ADD-only in v1) live in the sf-srs SKILL.md —
+see its `## Conversational eval hook (SUB-10)` section. This skill only references it ; never duplicate the heuristics here.
+
 ## Workflow Statuses
 
 1. **Backlog** (GRAY) — Read `statuses/1-backlog.md` for full description

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -48,7 +48,8 @@ skill folder — the skill is a thin orchestrator.
 | `draft --from codebase`     | `draft-from-codebase.ts`        | SUB-13   |
 | `write`                     | `write-srs.ts`                  | SUB-6    |
 | `spawn`                     | `spawn-tickets.ts`              | SUB-9    |
-| `eval`                      | `eval-srs.ts`                   | SUB-10   |
+| `apply-update`              | `apply-srs-update.ts`           | SUB-10   |
+| `eval`                      | `eval-srs.ts`                   | SUB-16   |
 
 Placeholder subfolders under `templates/` are kept with `.gitkeep` until their owning SUB populates them.
 
@@ -66,15 +67,16 @@ Dispatch resolution happens inside `src/srs/` (SUB-14.2) — never directly in t
 
 All via `.claude/skills/sf-srs/scripts/srs-cli.sh <action> [args]`.
 
-| Action     | Purpose                                                               | Populated by |
-| ---------- | --------------------------------------------------------------------- | ------------ |
-| `help`     | Print available actions                                               | SUB-14.3     |
-| `validate` | Smoke-test the configured backend via `createSrsAdapter().init()`     | SUB-14.3     |
-| `browse`   | List direct children of a backend page (tree navigation helper)       | SUB-6        |
-| `draft`    | Run the drafter matching `--from <source>` (notion-pages \| codebase) | SUB-6, 13    |
-| `write`    | Apply a `DraftCandidate[]` spec to the backend + clear pending flag   | SUB-6        |
-| `spawn`    | Spawn GitHub tickets from a published SRS                             | SUB-9        |
-| `eval`     | Compute freshness score comparing the SRS to the codebase             | SUB-10       |
+| Action         | Purpose                                                               | Populated by |
+| -------------- | --------------------------------------------------------------------- | ------------ |
+| `help`         | Print available actions                                               | SUB-14.3     |
+| `validate`     | Smoke-test the configured backend via `createSrsAdapter().init()`     | SUB-14.3     |
+| `browse`       | List direct children of a backend page (tree navigation helper)       | SUB-6        |
+| `draft`        | Run the drafter matching `--from <source>` (notion-pages \| codebase) | SUB-6, 13    |
+| `write`        | Apply a `DraftCandidate[]` spec to the backend + clear pending flag   | SUB-6        |
+| `spawn`        | Spawn GitHub tickets from a published SRS                             | SUB-9        |
+| `apply-update` | Apply a conversational eval-hook patch (ADD-only : UR / FR / DS / TC) | SUB-10       |
+| `eval`         | Compute freshness score comparing the SRS to the codebase (batch)     | SUB-16       |
 
 The wrapper is intentionally thin — real logic lives in `src/srs/` and consumes only the `SrsAdapter` interface.
 
@@ -125,6 +127,69 @@ Every TS entrypoint under `src/srs/bin/` honours the same contract. The skill mu
 | 5    | Backend runtime error (network, adapter `init()` failure, fetch failure)             |
 | 6    | `write` only — partial failure, JSON payload carries `rollbackHint`                  |
 | 7    | `write` only — pages created successfully but clearing `pendingIngestion` failed     |
+
+## Conversational eval hook (SUB-10)
+
+When the project declares `tools.srs.enabled = true` in `.saasfoundry.json`, Claude is responsible for **interjecting** during conversation turns whose content looks like a new Software Requirement.
+There is no message parser and no standalone script — the "hook" is Claude reading the heuristics below and self-invoking. The `sf-workflow` skill's SKILL.md references this section and stays out of
+the way.
+
+### Detection heuristics — when to fire
+
+Fire at most **once per conversation turn**. Skip trivial turns (pure tool invocations, "ok", "thanks", "read X", "what does this do"). Fire when the user's message matches **any** of the following
+signals :
+
+| Signal                                   | Target                              | Example utterance                                               |
+| ---------------------------------------- | ----------------------------------- | --------------------------------------------------------------- |
+| Describes a **user need / outcome**      | new **UR** on the Epic page         | "users should be able to log in with SSO"                       |
+| Defines a new **feature or rule**        | new **FR** page under the Epic      | "we need a feature that lets admins export audit logs as CSV"   |
+| Clarifies an **implementation decision** | new **DS** on the relevant FR page  | "let's use BCrypt with cost factor 12 for password hashing"     |
+| Adds an **acceptance / test condition**  | new **TC** on the relevant FR page  | "and a test that proves unicode passwords are accepted"         |
+| Reopens a **previously closed decision** | likely an **FR** or **DS** revision | "on reconsidère la règle : finalement on autorise les chiffres" |
+
+Treat as **trivial and skip** : formatting nitpicks, small bug reports already covered by an existing FR, performance tweaks without observable user impact, pure refactor requests.
+
+### Confirmation flow
+
+When a signal fires, **pause before coding** and propose a diff in plain text :
+
+```
+💡 Ce que tu viens de décrire ressemble à <UR / FR / DS / TC>. Proposition :
+  • <target page> — add <item id> : <narrative | title>
+  • (if TC)        steps : ...
+
+J'applique via `srs-cli.sh apply-update` ? [accept / edit / reject]
+```
+
+- **accept** → build the patch JSON (see shape below) and run `.claude/skills/sf-srs/scripts/srs-cli.sh apply-update < patch.json` (or pipe via stdin). On exit 0, continue with the coding task.
+- **edit** → rework the proposed item text with the user, then re-confirm.
+- **reject** → drop the proposal and continue. Do **not** re-propose the same item in the same conversation.
+
+### Patch shape consumed by `apply-update`
+
+```jsonc
+{
+  "kind": "add-ur" | "add-fr" | "add-ds" | "add-tc",
+  "pageId": "<epic page id for add-ur / add-fr, FR page id for add-ds / add-tc>",
+  "item": { /* UrItem | FrSpec | DsItem | TcItem, same shapes as src/builders/srs/types.ts */ },
+  "note": "optional free-text annotation appended as a paragraph"
+}
+```
+
+### Scope limits (v1, intentional)
+
+- **ADD-only.** Modifying an existing item (e.g. tightening FR-012's acceptance criteria) is **out of scope** — the current `SrsAdapter.updatePage` is append-only on Notion, so surgical section
+  replacement is not available through the contract. A follow-up SUB will extend the adapter with replace/delete semantics.
+- **Append placement.** `add-ur` / `add-ds` / `add-tc` append new blocks to the **end** of the target page under an "Added …" heading2. The canonical section (User Requirements / Design / Test Cases)
+  is _not_ updated in-place. Reviewers must fold the appended block back into the right section during the next human SRS review. The limitation is deliberate and documented.
+- **`add-fr`** creates a brand-new child page under the Epic via `adapter.createFrPage`. The Epic page's "Traceability" table is **not** refreshed (same append-only limitation) — the new FR is still
+  discoverable as a child page.
+- **Throttling.** 1 proposal maximum per conversation turn. No persistent dedup cache (the turn boundary is sufficient — Claude's own judgment avoids re-proposing within the same turn).
+
+### Dogfood checklist
+
+After any change to the heuristics above, run a short manual session : drop 5 utterances (one per signal row + one trivial control) and confirm the hook fires exactly on the four signals and skips the
+trivial one.
 
 ## How other skills hand off to `sf-srs`
 

--- a/scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh
+++ b/scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh
@@ -30,10 +30,17 @@ Actions:
                                     sub-issue tagged `srs:new`; board placement
                                     follows the project's default automation.
                                     `--dry-run` previews without writing.
+  apply-update [--patch <path>] [--manifest]
+                                    Apply a conversational eval-hook patch
+                                    (ADD-only : new UR / new FR / new DS / new TC)
+                                    to the configured backend. Reads patch JSON
+                                    from stdin when --patch is omitted. Used by
+                                    the `sf-srs` eval hook after user accepts
+                                    the proposed diff — see SKILL.md.
 
 Actions populated by sibling SUBs under #174 :
   draft --from codebase             Codebase audit drafter                       (SUB-13)
-  eval                              Score SRS freshness against the codebase    (SUB-10)
+  eval                              Score SRS freshness vs. codebase (batch)    (SUB-16)
 
 Common options :
   --manifest <path>                 Manifest file to read (default: .saasfoundry.json)
@@ -100,6 +107,8 @@ run_write() { run_bin write-srs "$@"; }
 
 run_spawn() { run_bin spawn "$@"; }
 
+run_apply_update() { run_bin apply-srs-update "$@"; }
+
 run_draft() {
   # `--from <source>` selects which drafter to invoke ; default = notion-pages.
   local source="notion-pages"
@@ -134,6 +143,7 @@ case "$ACTION" in
   draft) run_draft "$@" ;;
   write) run_write "$@" ;;
   spawn) run_spawn "$@" ;;
+  apply-update) run_apply_update "$@" ;;
   eval)
     echo "sf-srs: action '$ACTION' not implemented yet — owned by a sibling SUB under #174." >&2
     exit 2

--- a/scaffolds/skills-templates/workflow/SKILL.md
+++ b/scaffolds/skills-templates/workflow/SKILL.md
@@ -174,6 +174,10 @@ On SRS-enabled projects (`tools.srs.backend` is set), `create-subtask` refuses c
 
 Typing the reason is the audit trail — pick something a reviewer can grep for (`spawned-from-srs`, `meta-srs-tooling`, `bootstrap-epic-174`…). If the ticket represents a feature requirement, the answer is always "go draft it first, then spawn."
 
+### Conversational eval hook (SRS-enabled projects)
+
+When `tools.srs.enabled = true`, Claude must interject during conversation turns whose content looks like a new User Requirement / Functional Requirement / Design decision / Test Case, propose a diff, and on user accept apply it via `.claude/skills/sf-srs/scripts/srs-cli.sh apply-update`. The detection heuristics, confirmation flow, and scope limits (ADD-only in v1) live in the sf-srs SKILL.md — see its `## Conversational eval hook (SUB-10)` section. This skill only references it ; never duplicate the heuristics here.
+
 ## Workflow Statuses
 
 {{STATUSES_LIST}}

--- a/src/__tests__/unit/srs/bin/apply-srs-update.spec.ts
+++ b/src/__tests__/unit/srs/bin/apply-srs-update.spec.ts
@@ -1,0 +1,294 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { EpicSpec, FrSpec, PageContent, PageRef, RawContent, ResolvedParent, SrsAdapter } from '../../../../builders/srs/types'
+import { ApplyIO, ApplyOptions, assertPatchShape, parseArgs, renderAppendBlocks, runApplyUpdate, SrsUpdatePatch } from '../../../../srs/bin/apply-srs-update'
+import { registerSrsBackend, unregisterSrsBackend } from '../../../../srs'
+
+class StubAdapter implements SrsAdapter {
+  readonly updatePageCalls: Array<{ pageId: string; content: PageContent }> = []
+  readonly createFrPageCalls: FrSpec[] = []
+  constructor(
+    private readonly onInit: () => Promise<void> | void = () => undefined,
+    private readonly onCreateFrPage: (spec: FrSpec) => Promise<PageRef> | PageRef = (spec) => ({ id: 'fr-page-123', url: 'https://example.test/fr', title: spec.fr.title }),
+    private readonly onUpdatePage: ((pageId: string, content: PageContent) => Promise<void> | void) | null = null
+  ) {}
+  async init(): Promise<void> {
+    await this.onInit()
+  }
+  async resolveParent(input: string): Promise<ResolvedParent> {
+    return { id: input, name: input, url: 'https://example.test/parent' }
+  }
+  async createPage(parentPageId: string, title: string): Promise<PageRef> {
+    void parentPageId
+    return { id: 'page', url: '', title }
+  }
+  async createEpicPage(spec: EpicSpec): Promise<PageRef> {
+    return { id: 'epic-page', url: '', title: spec.title }
+  }
+  async createFrPage(spec: FrSpec): Promise<PageRef> {
+    this.createFrPageCalls.push(spec)
+    return this.onCreateFrPage(spec)
+  }
+  async updatePage(pageId: string, content: PageContent): Promise<void> {
+    this.updatePageCalls.push({ pageId, content })
+    if (this.onUpdatePage) await this.onUpdatePage(pageId, content)
+  }
+  async fetchPage(pageId: string): Promise<RawContent> {
+    return { pageId, title: '', url: '', blocks: [] }
+  }
+  async listChildren(): Promise<PageRef[]> {
+    return []
+  }
+}
+
+interface TestIO extends ApplyIO {
+  stdout: jest.Mock
+  stderr: jest.Mock
+  readStdin: jest.Mock
+  stdoutBuffer: string[]
+  stderrBuffer: string[]
+}
+
+function makeIO(stdinPayload = ''): TestIO {
+  const stdoutBuffer: string[] = []
+  const stderrBuffer: string[] = []
+  const stdout = jest.fn((chunk: string) => {
+    stdoutBuffer.push(chunk)
+  })
+  const stderr = jest.fn((chunk: string) => {
+    stderrBuffer.push(chunk)
+  })
+  const readStdin = jest.fn(() => stdinPayload)
+  return { stdout, stderr, readStdin, stdoutBuffer, stderrBuffer }
+}
+
+describe('parseArgs', () => {
+  it('uses the default manifest path and empty patch path when nothing is passed', () => {
+    const opts = parseArgs([])
+    expect(opts.patchPath).toBe('')
+    expect(opts.manifestPath).toBe('.saasfoundry.json')
+  })
+
+  it('parses --patch and --manifest with separate values', () => {
+    const opts = parseArgs(['--patch', './p.json', '--manifest', './m.json'])
+    expect(opts.patchPath).toBe('./p.json')
+    expect(opts.manifestPath).toBe('./m.json')
+  })
+
+  it('parses --patch=value and --manifest=value attached form', () => {
+    const opts = parseArgs(['--patch=./p.json', '--manifest=./m.json'])
+    expect(opts.patchPath).toBe('./p.json')
+    expect(opts.manifestPath).toBe('./m.json')
+  })
+
+  it('rejects --patch without a value', () => {
+    expect(() => parseArgs(['--patch'])).toThrow(/--patch requires a value/)
+  })
+
+  it('rejects --patch followed by another flag instead of a value', () => {
+    expect(() => parseArgs(['--patch', '--manifest', 'x'])).toThrow(/--patch requires a value/)
+  })
+
+  it('rejects --patch= with an empty attached value', () => {
+    expect(() => parseArgs(['--patch='])).toThrow(/--patch= requires a value/)
+  })
+
+  it('rejects --manifest with no value', () => {
+    expect(() => parseArgs(['--manifest'])).toThrow(/--manifest requires a value/)
+  })
+})
+
+describe('assertPatchShape', () => {
+  it('accepts a well-formed add-ur patch', () => {
+    const patch: SrsUpdatePatch = { kind: 'add-ur', pageId: 'epic-1', item: { id: 'UR-010', narrative: 'narrative' } }
+    expect(() => assertPatchShape(patch)).not.toThrow()
+  })
+
+  it('rejects a patch with an unknown kind', () => {
+    expect(() => assertPatchShape({ kind: 'nuke' as never, pageId: 'x', item: { id: '1', narrative: 'n' } })).toThrow(/unknown kind="nuke"/)
+  })
+
+  it('rejects a patch with missing pageId', () => {
+    expect(() => assertPatchShape({ kind: 'add-ur', pageId: '', item: { id: 'UR-1', narrative: 'n' } })).toThrow(/missing `pageId`/)
+  })
+
+  it('rejects a patch with missing item', () => {
+    expect(() => assertPatchShape({ kind: 'add-ur', pageId: 'x', item: undefined as never })).toThrow(/missing `item`/)
+  })
+
+  it('rejects a non-object patch entirely', () => {
+    expect(() => assertPatchShape('not-an-object' as never)).toThrow(/patch must be a JSON object/)
+  })
+})
+
+describe('renderAppendBlocks', () => {
+  it('renders add-ur with a labeled heading and bullet carrying the id + narrative', () => {
+    const blocks = renderAppendBlocks({ kind: 'add-ur', pageId: 'e', item: { id: 'UR-042', narrative: 'User can log in with Unicode passwords', businessValue: 'Global reach' } })
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]).toEqual({ kind: 'heading', level: 2, text: 'Added User Requirement — UR-042' })
+    expect(blocks[1]).toEqual({ kind: 'bulleted_list', items: ['UR-042: User can log in with Unicode passwords (value: Global reach)'] })
+  })
+
+  it('renders add-ds with description as suffix', () => {
+    const blocks = renderAppendBlocks({ kind: 'add-ds', pageId: 'fr', item: { id: 'DS-007', title: 'Use BCrypt', description: 'Cost factor 12' } })
+    expect(blocks[0]).toEqual({ kind: 'heading', level: 2, text: 'Added Design Item — DS-007' })
+    expect(blocks[1]).toEqual({ kind: 'bulleted_list', items: ['DS-007: Use BCrypt — Cost factor 12'] })
+  })
+
+  it('renders add-tc with expected result and numbered steps when provided', () => {
+    const blocks = renderAppendBlocks({
+      kind: 'add-tc',
+      pageId: 'fr',
+      item: { id: 'TC-091', title: 'Unicode password is accepted', steps: ['submit form with é', 'assert 200'], expectedResult: 'login succeeds' }
+    })
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0]).toEqual({ kind: 'heading', level: 2, text: 'Added Test Case — TC-091' })
+    expect(blocks[1]).toEqual({ kind: 'bulleted_list', items: ['TC-091: Unicode password is accepted → login succeeds'] })
+    expect(blocks[2]).toEqual({ kind: 'numbered_list', items: ['submit form with é', 'assert 200'] })
+  })
+
+  it('appends an optional note paragraph when provided', () => {
+    const blocks = renderAppendBlocks({
+      kind: 'add-ur',
+      pageId: 'e',
+      item: { id: 'UR-001', narrative: 'foo' },
+      note: 'Captured during conversation on 2026-04-21'
+    })
+    expect(blocks[blocks.length - 1]).toEqual({ kind: 'paragraph', text: 'Note: Captured during conversation on 2026-04-21' })
+  })
+
+  it('rejects add-ur without narrative', () => {
+    expect(() => renderAppendBlocks({ kind: 'add-ur', pageId: 'e', item: { id: 'UR-001' } as never })).toThrow(/add-ur requires item.id and item.narrative/)
+  })
+
+  it('rejects add-tc without title', () => {
+    expect(() => renderAppendBlocks({ kind: 'add-tc', pageId: 'fr', item: { id: 'TC-1' } as never })).toThrow(/add-tc requires item.id and item.title/)
+  })
+})
+
+describe('runApplyUpdate', () => {
+  const BACKEND = 'apply-test-backend'
+  let tmpDir: string
+  let manifestPath: string
+  let stub: StubAdapter
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'sf-apply-update-'))
+    manifestPath = join(tmpDir, 'manifest.json')
+    writeFileSync(manifestPath, JSON.stringify({ tools: { srs: { backend: BACKEND } } }))
+    stub = new StubAdapter()
+    registerSrsBackend(BACKEND, () => stub)
+  })
+
+  afterEach(() => {
+    unregisterSrsBackend(BACKEND)
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function runWithStdin(payload: string, extra: Partial<ApplyOptions> = {}): { code: Promise<number>; io: TestIO } {
+    const io = makeIO(payload)
+    const options: ApplyOptions = { patchPath: '', manifestPath, ...extra }
+    return { code: runApplyUpdate(options, io), io }
+  }
+
+  it('applies add-ur by calling adapter.updatePage with the expected blocks (exit 0)', async () => {
+    const patch: SrsUpdatePatch = { kind: 'add-ur', pageId: 'epic-42', item: { id: 'UR-100', narrative: 'New requirement' } }
+    const { code, io } = runWithStdin(JSON.stringify(patch))
+    await expect(code).resolves.toBe(0)
+    expect(stub.updatePageCalls).toHaveLength(1)
+    expect(stub.updatePageCalls[0].pageId).toBe('epic-42')
+    expect(stub.updatePageCalls[0].content.blocks[0]).toMatchObject({ kind: 'heading', text: 'Added User Requirement — UR-100' })
+    const stdout = io.stdoutBuffer.join('')
+    expect(stdout).toContain('"kind": "add-ur"')
+    expect(stdout).toContain('"targetPageId": "epic-42"')
+  })
+
+  it('applies add-fr via adapter.createFrPage and includes newPage in the result', async () => {
+    const frSpec: FrSpec = { parentEpicPageId: '', fr: { id: 'FR-043', title: 'OAuth login' } }
+    const patch: SrsUpdatePatch = { kind: 'add-fr', pageId: 'epic-42', item: frSpec }
+    const { code, io } = runWithStdin(JSON.stringify(patch))
+    await expect(code).resolves.toBe(0)
+    expect(stub.createFrPageCalls).toHaveLength(1)
+    expect(stub.createFrPageCalls[0].parentEpicPageId).toBe('epic-42')
+    expect(stub.createFrPageCalls[0].fr.id).toBe('FR-043')
+    const stdout = io.stdoutBuffer.join('')
+    expect(stdout).toContain('"newPage"')
+    expect(stdout).toContain('"id": "fr-page-123"')
+  })
+
+  it('applies add-ds against an FR page via updatePage', async () => {
+    const patch: SrsUpdatePatch = { kind: 'add-ds', pageId: 'fr-007', item: { id: 'DS-007', title: 'BCrypt' } }
+    const { code } = runWithStdin(JSON.stringify(patch))
+    await expect(code).resolves.toBe(0)
+    expect(stub.updatePageCalls[0].pageId).toBe('fr-007')
+    expect(stub.updatePageCalls[0].content.blocks[0]).toMatchObject({ text: 'Added Design Item — DS-007' })
+  })
+
+  it('applies add-tc and includes steps as numbered_list', async () => {
+    const patch: SrsUpdatePatch = {
+      kind: 'add-tc',
+      pageId: 'fr-007',
+      item: { id: 'TC-091', title: 'Unicode pw OK', steps: ['open form', 'submit'], expectedResult: '200' }
+    }
+    const { code } = runWithStdin(JSON.stringify(patch))
+    await expect(code).resolves.toBe(0)
+    const blocks = stub.updatePageCalls[0].content.blocks
+    expect(blocks).toHaveLength(3)
+    expect(blocks[2]).toMatchObject({ kind: 'numbered_list' })
+  })
+
+  it('returns exit 2 when the patch JSON is malformed', async () => {
+    const { code, io } = runWithStdin('{ not valid json')
+    await expect(code).resolves.toBe(2)
+    expect(io.stderrBuffer.join('')).toMatch(/failed to parse patch JSON/)
+  })
+
+  it('returns exit 2 when the patch kind is unknown', async () => {
+    const { code, io } = runWithStdin(JSON.stringify({ kind: 'nuke', pageId: 'x', item: { id: 'Y', narrative: 'z' } }))
+    await expect(code).resolves.toBe(2)
+    expect(io.stderrBuffer.join('')).toMatch(/unknown kind/)
+  })
+
+  it('returns exit 3 when the manifest has no backend configured', async () => {
+    writeFileSync(manifestPath, JSON.stringify({ tools: {} }))
+    const patch: SrsUpdatePatch = { kind: 'add-ur', pageId: 'e', item: { id: 'UR-1', narrative: 'n' } }
+    const { code, io } = runWithStdin(JSON.stringify(patch))
+    await expect(code).resolves.toBe(3)
+    expect(io.stderrBuffer.join('')).toMatch(/tools\.srs\.backend.*not set/)
+  })
+
+  it('returns exit 4 when the manifest declares an unknown backend', async () => {
+    writeFileSync(manifestPath, JSON.stringify({ tools: { srs: { backend: 'i-do-not-exist' } } }))
+    const patch: SrsUpdatePatch = { kind: 'add-ur', pageId: 'e', item: { id: 'UR-1', narrative: 'n' } }
+    const { code, io } = runWithStdin(JSON.stringify(patch))
+    await expect(code).resolves.toBe(4)
+    expect(io.stderrBuffer.join('')).toMatch(/unknown SRS backend/)
+  })
+
+  it('returns exit 5 when the adapter throws during updatePage', async () => {
+    stub = new StubAdapter(
+      () => undefined,
+      undefined,
+      () => {
+        throw new Error('network down')
+      }
+    )
+    unregisterSrsBackend(BACKEND)
+    registerSrsBackend(BACKEND, () => stub)
+    const patch: SrsUpdatePatch = { kind: 'add-ur', pageId: 'e', item: { id: 'UR-1', narrative: 'n' } }
+    const { code, io } = runWithStdin(JSON.stringify(patch))
+    await expect(code).resolves.toBe(5)
+    expect(io.stderrBuffer.join('')).toMatch(/network down/)
+  })
+
+  it('reads a patch from --patch file when provided (stdin skipped)', async () => {
+    const patchPath = join(tmpDir, 'patch.json')
+    const patch: SrsUpdatePatch = { kind: 'add-ur', pageId: 'epic-42', item: { id: 'UR-010', narrative: 'from file' } }
+    writeFileSync(patchPath, JSON.stringify(patch))
+    const { code, io } = runWithStdin('{ this stdin must be ignored }', { patchPath })
+    await expect(code).resolves.toBe(0)
+    expect(io.readStdin).not.toHaveBeenCalled()
+  })
+})

--- a/src/srs/bin/apply-srs-update.ts
+++ b/src/srs/bin/apply-srs-update.ts
@@ -1,0 +1,188 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { DsItem, FrSpec, PageBlock, PageContent, PageRef, SrsAdapter, TcItem, UrItem } from '../../builders/srs/types'
+import { createSrsAdapter, SrsConfigError, SrsManifestSubset } from '../index'
+
+// The conversational eval hook (SUB-10 / #170) lives inside SKILL.md as
+// Claude-side heuristics — it has no message parser. When Claude decides an
+// utterance describes a new UR / FR / DS / TC and the user approves the
+// proposed diff, this bin applies the ADD to the configured SRS backend.
+//
+// Scope : ADD-only. Modifying an existing UR / FR / DS / TC is out of scope
+// because `SrsAdapter.updatePage` is append-only on Notion (block-level
+// replace / delete is not available through the current contract).
+// Modifications are tracked as a follow-up SUB.
+export type SrsUpdateKind = 'add-ur' | 'add-fr' | 'add-ds' | 'add-tc'
+
+export interface SrsUpdatePatch {
+  kind: SrsUpdateKind
+  pageId: string
+  item: UrItem | DsItem | TcItem | FrSpec
+  note?: string
+}
+
+export interface ApplyResult {
+  kind: SrsUpdateKind
+  targetPageId: string
+  newPage?: PageRef
+}
+
+export interface ApplyIO {
+  stdout: (chunk: string) => void
+  stderr: (chunk: string) => void
+  readStdin: () => string
+}
+
+function defaultIO(): ApplyIO {
+  return {
+    stdout: (chunk) => process.stdout.write(chunk),
+    stderr: (chunk) => process.stderr.write(chunk),
+    readStdin: () => readFileSync(0, 'utf8')
+  }
+}
+
+export interface ApplyOptions {
+  patchPath: string
+  manifestPath: string
+}
+
+export function parseArgs(argv: string[]): ApplyOptions {
+  const opts: ApplyOptions = { patchPath: '', manifestPath: '.saasfoundry.json' }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--patch') {
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith('--')) throw new Error('apply-srs-update: --patch requires a value')
+      opts.patchPath = next
+      i++
+    } else if (arg.startsWith('--patch=')) {
+      const value = arg.slice('--patch='.length)
+      if (!value) throw new Error('apply-srs-update: --patch= requires a value')
+      opts.patchPath = value
+    } else if (arg === '--manifest') {
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith('--')) throw new Error('apply-srs-update: --manifest requires a value')
+      opts.manifestPath = next
+      i++
+    } else if (arg.startsWith('--manifest=')) {
+      const value = arg.slice('--manifest='.length)
+      if (!value) throw new Error('apply-srs-update: --manifest= requires a value')
+      opts.manifestPath = value
+    }
+  }
+  return opts
+}
+
+function parsePatchJson(raw: string): SrsUpdatePatch {
+  try {
+    return JSON.parse(raw) as SrsUpdatePatch
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`apply-srs-update: failed to parse patch JSON — ${message}`)
+  }
+}
+
+export function assertPatchShape(patch: SrsUpdatePatch): void {
+  if (!patch || typeof patch !== 'object') throw new Error('apply-srs-update: patch must be a JSON object')
+  const kind = (patch as { kind?: unknown }).kind
+  if (kind !== 'add-ur' && kind !== 'add-fr' && kind !== 'add-ds' && kind !== 'add-tc') {
+    throw new Error(`apply-srs-update: unknown kind="${String(kind)}" (expected add-ur | add-fr | add-ds | add-tc)`)
+  }
+  if (!patch.pageId || typeof patch.pageId !== 'string') throw new Error('apply-srs-update: patch is missing `pageId`')
+  if (!patch.item || typeof patch.item !== 'object') throw new Error('apply-srs-update: patch is missing `item`')
+}
+
+export function renderAppendBlocks(patch: SrsUpdatePatch): PageBlock[] {
+  const blocks: PageBlock[] = []
+  if (patch.kind === 'add-ur') {
+    const ur = patch.item as UrItem
+    if (!ur.id || !ur.narrative) throw new Error('apply-srs-update: add-ur requires item.id and item.narrative')
+    blocks.push({ kind: 'heading', level: 2, text: `Added User Requirement — ${ur.id}` })
+    const suffix = ur.businessValue ? ` (value: ${ur.businessValue})` : ''
+    blocks.push({ kind: 'bulleted_list', items: [`${ur.id}: ${ur.narrative}${suffix}`] })
+  } else if (patch.kind === 'add-ds') {
+    const ds = patch.item as DsItem
+    if (!ds.id || !ds.title) throw new Error('apply-srs-update: add-ds requires item.id and item.title')
+    blocks.push({ kind: 'heading', level: 2, text: `Added Design Item — ${ds.id}` })
+    const suffix = ds.description ? ` — ${ds.description}` : ''
+    blocks.push({ kind: 'bulleted_list', items: [`${ds.id}: ${ds.title}${suffix}`] })
+  } else if (patch.kind === 'add-tc') {
+    const tc = patch.item as TcItem
+    if (!tc.id || !tc.title) throw new Error('apply-srs-update: add-tc requires item.id and item.title')
+    blocks.push({ kind: 'heading', level: 2, text: `Added Test Case — ${tc.id}` })
+    const suffix = tc.expectedResult ? ` → ${tc.expectedResult}` : ''
+    blocks.push({ kind: 'bulleted_list', items: [`${tc.id}: ${tc.title}${suffix}`] })
+    if (tc.steps && tc.steps.length > 0) blocks.push({ kind: 'numbered_list', items: tc.steps })
+  }
+  if (patch.note) blocks.push({ kind: 'paragraph', text: `Note: ${patch.note}` })
+  return blocks
+}
+
+export async function runApplyUpdate(options: ApplyOptions, io: ApplyIO = defaultIO()): Promise<number> {
+  const manifestPath = resolve(options.manifestPath)
+  let manifest: SrsManifestSubset
+  let patch: SrsUpdatePatch
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as SrsManifestSubset
+    const raw = options.patchPath ? readFileSync(resolve(options.patchPath), 'utf8') : io.readStdin()
+    patch = parsePatchJson(raw)
+    assertPatchShape(patch)
+  } catch (error) {
+    io.stderr(`${error instanceof Error ? error.message : String(error)}\n`)
+    return 2
+  }
+
+  let adapter: SrsAdapter
+  try {
+    adapter = await createSrsAdapter(manifest)
+    await adapter.init()
+  } catch (error) {
+    if (error instanceof SrsConfigError) {
+      io.stderr(`✗ ${error.message}\n`)
+      return error.code === 'missing' ? 3 : 4
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    io.stderr(`✗ apply-srs-update: adapter init failed — ${message}\n`)
+    return 5
+  }
+
+  const result: ApplyResult = { kind: patch.kind, targetPageId: patch.pageId }
+  try {
+    if (patch.kind === 'add-fr') {
+      const spec = patch.item as FrSpec
+      if (!spec.fr || !spec.fr.id || !spec.fr.title) throw new Error('apply-srs-update: add-fr requires item.fr.id and item.fr.title')
+      if (!spec.parentEpicPageId) spec.parentEpicPageId = patch.pageId
+      const page = await adapter.createFrPage(spec)
+      result.newPage = page
+    } else {
+      const blocks = renderAppendBlocks(patch)
+      const content: PageContent = { blocks }
+      await adapter.updatePage(patch.pageId, content)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    io.stderr(`✗ apply-srs-update: failed to apply patch — ${message}\n`)
+    return 5
+  }
+
+  io.stdout(`${JSON.stringify(result, null, 2)}\n`)
+  return 0
+}
+
+if (require.main === module) {
+  let options: ApplyOptions
+  try {
+    options = parseArgs(process.argv.slice(2))
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`)
+    process.stderr.write('\nUsage: apply-srs-update.ts [--patch <path>] [--manifest <path>]\n(Patch JSON is read from stdin when --patch is omitted.)\n')
+    process.exit(1)
+  }
+  runApplyUpdate(options)
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`apply-srs-update: unexpected error — ${err instanceof Error ? err.message : String(err)}\n`)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
Resolves #170

## Summary

Conversational SRS evaluation hook — when `tools.srs.enabled = true`, Claude interjects during conversation turns whose content looks like a new UR / FR / DS / TC, proposes a diff, and on user accept applies it through the configured `SrsAdapter`.

**Shipped in this PR**
- `src/srs/bin/apply-srs-update.ts` — ADD-only patch applier (stdin or `--patch <file>`), dispatches on patch `kind`, uses `createSrsAdapter` for backend calls.
- `.claude/skills/sf-srs/SKILL.md` § **Conversational eval hook (SUB-10)** — detection heuristics (UR/FR/DS/TC/reopened decision), confirmation flow (accept/edit/reject), patch shape, scope limits (ADD-only v1, append placement, throttling), dogfood checklist.
- `.claude/skills/sf-srs/scripts/srs-cli.sh` — new `apply-update` action.
- `.claude/skills/sf-workflow/SKILL.md` — cross-ref to the hook section (no duplication).
- Scaffold mirror byte-identical (drift guard green).

**Out of scope (split into siblings)**
- Batch freshness score / drift report → #202 (SUB-16)
- Full SaaSFoundry SRS audit (capstone) → #203 (SUB-17)

## Test plan

- [x] Unit — `src/__tests__/unit/srs/bin/apply-srs-update.spec.ts` : 28/28 pass
  - `parseArgs` (7) · `assertPatchShape` (5) · `renderAppendBlocks` (6) · `runApplyUpdate` (10, covers exit 0/2/3/4/5 + stdin vs file)
- [x] Regression — full Jest suite : 803 passed, 2 skipped
- [x] Drift guard — 10 skill ↔ scaffold byte-identity pairs
- [x] CLI smoke — `srs-cli.sh help` renders `apply-update` synopsis ; bad manifest → exit 2
- [x] Docker pre-push — multirepo-minimal + monorepo-minimal

## Scope limits documented in SKILL.md

- **ADD-only** : modifying an existing item is out of v1 (`updatePage` is append-only on Notion)
- **Append placement** : items land under "Added …" heading2, to be folded back in next human review
- **`add-fr`** : creates new child page via `createFrPage` ; Epic traceability table not refreshed
- **Throttling** : 1 proposal per conversation turn, no persistent dedup cache