### PR TITLE
[Parent #173] SUB-13.1: sf srs audit — scaffold draft-from-codebase CLI + dispatcher wiring

### DIFF
--- a/.claude/skills/sf-srs/scripts/srs-cli.sh
+++ b/.claude/skills/sf-srs/scripts/srs-cli.sh
@@ -19,6 +19,12 @@ Actions:
                                     Fetch pages from the backend as RawContent (JSON).
                                     The skill then drafts Epic/FR specs conversationally
                                     and hands them back via `write`.
+  draft --from codebase [--path <dir>] [--manifest]
+                                    Scan the local codebase and emit structured
+                                    findings (JSON). The skill then drafts Epic/FR
+                                    specs conversationally from the findings and
+                                    hands them back via `write`. Scanners plug in
+                                    via sibling SUBs under #173 (13.2 + 13.3).
   write  --spec <path> [--manifest] [--no-clear-pending]
                                     Apply a DraftCandidate[] spec file : creates Epic /
                                     FR pages through the adapter and clears the
@@ -39,7 +45,6 @@ Actions:
                                     the proposed diff — see SKILL.md.
 
 Actions populated by sibling SUBs under #174 :
-  draft --from codebase             Codebase audit drafter                       (SUB-13)
   eval                              Score SRS freshness vs. codebase (batch)    (SUB-16)
 
 Common options :
@@ -122,10 +127,7 @@ run_draft() {
   done
   case "$source" in
     notion-pages) run_bin draft-from-notion-pages ${forwarded[@]+"${forwarded[@]}"} ;;
-    codebase)
-      echo "sf-srs draft --from codebase: not implemented yet — owned by SUB-13." >&2
-      exit 2
-      ;;
+    codebase) run_bin draft-from-codebase ${forwarded[@]+"${forwarded[@]}"} ;;
     *)
       echo "sf-srs draft: unknown --from value '$source' (expected: notion-pages | codebase)." >&2
       exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,12 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@notionhq/client": "^5.19.0",
+        "@notionhq/client": "5.19.0",
         "@types/fs-extra": "11.0.4",
         "chalk": "4.1.2",
         "commander": "12.0.0",
         "fs-extra": "11.3.0",
+        "ignore": "7.0.5",
         "inquirer": "8.2.5",
         "module-alias": "2.2.3",
         "ora": "5.4.1",
@@ -1694,6 +1695,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3342,6 +3353,16 @@
         "typescript": ">=4.8.4 <5.8.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.20.0.tgz",
@@ -4952,6 +4973,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5652,10 +5683,10 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "chalk": "4.1.2",
     "commander": "12.0.0",
     "fs-extra": "11.3.0",
+    "ignore": "7.0.5",
     "inquirer": "8.2.5",
     "module-alias": "2.2.3",
     "ora": "5.4.1",

--- a/scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh
+++ b/scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh
@@ -19,6 +19,12 @@ Actions:
                                     Fetch pages from the backend as RawContent (JSON).
                                     The skill then drafts Epic/FR specs conversationally
                                     and hands them back via `write`.
+  draft --from codebase [--path <dir>] [--manifest]
+                                    Scan the local codebase and emit structured
+                                    findings (JSON). The skill then drafts Epic/FR
+                                    specs conversationally from the findings and
+                                    hands them back via `write`. Scanners plug in
+                                    via sibling SUBs under #173 (13.2 + 13.3).
   write  --spec <path> [--manifest] [--no-clear-pending]
                                     Apply a DraftCandidate[] spec file : creates Epic /
                                     FR pages through the adapter and clears the
@@ -39,7 +45,6 @@ Actions:
                                     the proposed diff — see SKILL.md.
 
 Actions populated by sibling SUBs under #174 :
-  draft --from codebase             Codebase audit drafter                       (SUB-13)
   eval                              Score SRS freshness vs. codebase (batch)    (SUB-16)
 
 Common options :
@@ -122,10 +127,7 @@ run_draft() {
   done
   case "$source" in
     notion-pages) run_bin draft-from-notion-pages ${forwarded[@]+"${forwarded[@]}"} ;;
-    codebase)
-      echo "sf-srs draft --from codebase: not implemented yet — owned by SUB-13." >&2
-      exit 2
-      ;;
+    codebase) run_bin draft-from-codebase ${forwarded[@]+"${forwarded[@]}"} ;;
     *)
       echo "sf-srs draft: unknown --from value '$source' (expected: notion-pages | codebase)." >&2
       exit 1

--- a/src/__tests__/unit/srs/draft-from-codebase.spec.ts
+++ b/src/__tests__/unit/srs/draft-from-codebase.spec.ts
@@ -1,0 +1,143 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { runDraftFromCodebase } from '../../../srs/bin/draft-from-codebase'
+
+describe('runDraftFromCodebase', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sf-srs-codebase-'))
+  })
+
+  const writeManifest = (body: unknown): string => {
+    const p = join(tmp, '.saasfoundry.json')
+    writeFileSync(p, JSON.stringify(body))
+    return p
+  }
+
+  it('emits an empty findings list on a bare project', async () => {
+    const stdout: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk))
+      return true
+    })
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'notion' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(0)
+    const body = JSON.parse(stdout.join(''))
+    expect(body.source).toBe('codebase')
+    expect(body.findings).toEqual([])
+  })
+
+  it('returns 2 when --path points to a missing directory', async () => {
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'notion' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: join(tmp, 'does-not-exist'), manifestPath })
+
+    expect(code).toBe(2)
+  })
+
+  it('returns 2 when --path points to a file', async () => {
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const filePath = join(tmp, 'not-a-dir.txt')
+    writeFileSync(filePath, 'hello')
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'notion' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: filePath, manifestPath })
+
+    expect(code).toBe(2)
+  })
+
+  it('returns 2 when the manifest JSON is malformed', async () => {
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const manifestPath = join(tmp, '.saasfoundry.json')
+    writeFileSync(manifestPath, '{ not valid json')
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(2)
+  })
+
+  it('returns 3 when tools.srs.backend is missing', async () => {
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const manifestPath = writeManifest({ tools: {} })
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(3)
+  })
+
+  it('returns 4 when the backend is unknown', async () => {
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'confluence' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(4)
+  })
+
+  it('falls back to process.cwd() when scanPath is empty', async () => {
+    const stdout: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk))
+      return true
+    })
+    const originalCwd = process.cwd()
+    process.chdir(tmp)
+    try {
+      const manifestPath = writeManifest({ tools: { srs: { backend: 'notion' } } })
+      const code = await runDraftFromCodebase({ scanPath: '', manifestPath })
+      expect(code).toBe(0)
+      const body = JSON.parse(stdout.join(''))
+      expect(body.findings).toEqual([])
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
+  it('respects .gitignore when walking the scan tree', async () => {
+    const stdout: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk))
+      return true
+    })
+    mkdirSync(join(tmp, 'src'))
+    writeFileSync(join(tmp, 'src', 'a.ts'), 'export const a = 1')
+    writeFileSync(join(tmp, 'src', 'b.log'), 'ignored')
+    writeFileSync(join(tmp, '.gitignore'), '*.log\n')
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'notion' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(0)
+    // No scanners registered yet, but the walker must run end-to-end without errors.
+    const body = JSON.parse(stdout.join(''))
+    expect(body.source).toBe('codebase')
+    expect(body.findings).toEqual([])
+  })
+
+  it('excludes node_modules / dist / coverage / .git even without .gitignore', async () => {
+    const stdout: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk))
+      return true
+    })
+    for (const dir of ['node_modules', 'dist', 'coverage', '.git']) {
+      mkdirSync(join(tmp, dir))
+      writeFileSync(join(tmp, dir, 'blob.ts'), 'ignored')
+    }
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'notion' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(0)
+    // No scanners → empty findings, but walker must not traverse those dirs.
+    const body = JSON.parse(stdout.join(''))
+    expect(body.findings).toEqual([])
+  })
+})

--- a/src/srs/bin/draft-from-codebase.ts
+++ b/src/srs/bin/draft-from-codebase.ts
@@ -1,0 +1,181 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+import ignore, { Ignore } from 'ignore'
+
+import { getSrsBackend, listSrsBackends, SrsConfigError, SrsManifestSubset } from '../index'
+import { CodebaseScanner, CodebaseScannerContext, ScannerFinding } from '../scanners/types'
+
+export interface DraftFromCodebaseOptions {
+  scanPath: string
+  manifestPath: string
+}
+
+export interface DraftFromCodebaseOutput {
+  source: 'codebase'
+  findings: ScannerFinding[]
+}
+
+const HARD_EXCLUDE_DIRS = new Set(['node_modules', 'dist', 'coverage', '.git', '.vitepress/cache'])
+const HARD_EXCLUDE_DIR_SEGMENTS = ['node_modules', 'dist', 'coverage', '.git']
+const HARD_EXCLUDE_PATH_FRAGMENTS = ['.vitepress/cache']
+
+const SCANNERS: CodebaseScanner[] = []
+
+function parseManifest(path: string): SrsManifestSubset {
+  const raw = readFileSync(path, 'utf8')
+  try {
+    return JSON.parse(raw) as SrsManifestSubset
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`draft-from-codebase: failed to parse ${path} as JSON — ${message}`)
+  }
+}
+
+function loadGitignore(scanRoot: string): Ignore {
+  const ig = ignore()
+  const gitignorePath = join(scanRoot, '.gitignore')
+  if (existsSync(gitignorePath)) {
+    try {
+      ig.add(readFileSync(gitignorePath, 'utf8'))
+    } catch {
+      // If .gitignore is unreadable, fall through with hard-coded excludes only.
+    }
+  }
+  return ig
+}
+
+function isHardExcluded(relPath: string): boolean {
+  const segments = relPath.split('/')
+  if (segments.some((seg) => HARD_EXCLUDE_DIR_SEGMENTS.includes(seg))) return true
+  return HARD_EXCLUDE_PATH_FRAGMENTS.some((fragment) => relPath.includes(fragment))
+}
+
+function collectFiles(scanRoot: string): string[] {
+  const ig = loadGitignore(scanRoot)
+  const results: string[] = []
+
+  const walk = (absDir: string): void => {
+    let entries: string[]
+    try {
+      entries = readdirSync(absDir)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (HARD_EXCLUDE_DIRS.has(entry)) continue
+      const absChild = join(absDir, entry)
+      const relChild = relative(scanRoot, absChild)
+      if (relChild.length === 0) continue
+      if (isHardExcluded(relChild)) continue
+      const relForIgnore = relChild.split('\\').join('/')
+      let stat
+      try {
+        stat = statSync(absChild)
+      } catch {
+        continue
+      }
+      if (stat.isDirectory()) {
+        if (ig.ignores(`${relForIgnore}/`)) continue
+        walk(absChild)
+      } else if (stat.isFile()) {
+        if (ig.ignores(relForIgnore)) continue
+        results.push(relForIgnore)
+      }
+    }
+  }
+
+  walk(scanRoot)
+  return results.sort()
+}
+
+export async function runDraftFromCodebase(options: DraftFromCodebaseOptions): Promise<number> {
+  const scanRootInput = options.scanPath && options.scanPath.trim().length > 0 ? options.scanPath : process.cwd()
+  const scanRoot = resolve(scanRootInput)
+  if (!existsSync(scanRoot)) {
+    process.stderr.write(`draft-from-codebase: --path does not exist: ${scanRoot}\n`)
+    return 2
+  }
+  try {
+    const stat = statSync(scanRoot)
+    if (!stat.isDirectory()) {
+      process.stderr.write(`draft-from-codebase: --path is not a directory: ${scanRoot}\n`)
+      return 2
+    }
+  } catch {
+    process.stderr.write(`draft-from-codebase: --path is not accessible: ${scanRoot}\n`)
+    return 2
+  }
+
+  const manifestPath = resolve(options.manifestPath)
+  let manifest: SrsManifestSubset
+  try {
+    manifest = parseManifest(manifestPath)
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    return 2
+  }
+
+  try {
+    const backend = manifest.tools?.srs?.backend
+    if (!backend) {
+      throw new SrsConfigError('missing', 'draft-from-codebase: `.saasfoundry.json → tools.srs.backend` is not set.')
+    }
+    if (!getSrsBackend(backend)) {
+      const available = listSrsBackends()
+      const hint = available.length > 0 ? available.join(', ') : '<none registered>'
+      throw new SrsConfigError('unknown', `draft-from-codebase: unknown SRS backend "${backend}". Available: ${hint}.`)
+    }
+    void manifest
+
+    const files = collectFiles(scanRoot)
+    const context: CodebaseScannerContext = { scanRoot, files }
+
+    const findings: ScannerFinding[] = []
+    for (const scanner of SCANNERS) {
+      const batch = await scanner.collect(context)
+      findings.push(...batch)
+    }
+
+    const output: DraftFromCodebaseOutput = { source: 'codebase', findings }
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    return 0
+  } catch (error) {
+    if (error instanceof SrsConfigError) {
+      process.stderr.write(`✗ ${error.message}\n`)
+      return error.code === 'missing' ? 3 : 4
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`✗ draft-from-codebase failed — ${message}\n`)
+    return 5
+  }
+}
+
+function parseArgs(argv: string[]): { scanPath: string; manifestPath: string; unknown?: string } {
+  let scanPath = ''
+  let manifestPath = '.saasfoundry.json'
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--path' || arg === '-p') scanPath = argv[++i] ?? ''
+    else if (arg.startsWith('--path=')) scanPath = arg.slice('--path='.length)
+    else if (arg === '--manifest' || arg === '-m') manifestPath = argv[++i] ?? manifestPath
+    else if (arg.startsWith('--manifest=')) manifestPath = arg.slice('--manifest='.length)
+    else if (arg.startsWith('-')) return { scanPath, manifestPath, unknown: arg }
+    else if (!scanPath) scanPath = arg
+  }
+  return { scanPath, manifestPath }
+}
+
+if (require.main === module) {
+  const { scanPath, manifestPath, unknown } = parseArgs(process.argv.slice(2))
+  if (unknown) {
+    process.stderr.write(`draft-from-codebase: unknown flag ${unknown}\n`)
+    process.exit(2)
+  }
+  runDraftFromCodebase({ scanPath, manifestPath })
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`draft-from-codebase: unexpected error — ${err instanceof Error ? err.message : String(err)}\n`)
+      process.exit(1)
+    })
+}

--- a/src/srs/index.ts
+++ b/src/srs/index.ts
@@ -30,3 +30,4 @@ export type {
   DsRef,
   ResolvedParent
 } from '../builders/srs/types'
+export type { ScannerFinding, ScannerFindingKind, CodebaseScanner, CodebaseScannerContext } from './scanners/types'

--- a/src/srs/scanners/types.ts
+++ b/src/srs/scanners/types.ts
@@ -1,0 +1,20 @@
+export type ScannerFindingKind = 'endpoint' | 'ui-flow' | 'entity' | 'test' | 'doc-context'
+
+export interface ScannerFinding {
+  kind: ScannerFindingKind
+  title: string
+  sourceFiles: string[]
+  excerpt?: string
+  notes?: string
+}
+
+export interface CodebaseScannerContext {
+  scanRoot: string
+  files: string[]
+}
+
+export interface CodebaseScanner {
+  id: string
+  describe: string
+  collect(context: CodebaseScannerContext): Promise<ScannerFinding[]>
+}


### PR DESCRIPTION
Closes #207

## Summary

- New bin `src/srs/bin/draft-from-codebase.ts` mirroring `draft-from-notion-pages.ts`:
  - `parseArgs(argv)` for `--path <dir>` (default `cwd`) and `--manifest <path>`
  - `runDraftFromCodebase(opts) → Promise<exit_code>`
  - Emits `{ source: 'codebase', findings: ScannerFinding[] }` JSON to stdout
- Skeleton orchestrator — empty scanner registry today, SUB-13.2 + SUB-13.3 plug in
- `ScannerFinding` discriminated union in `src/srs/scanners/types.ts` (`kind: 'endpoint' | 'ui-flow' | 'entity' | 'test' | 'doc-context'`)
- File walker respects `.gitignore` and hard-excludes `node_modules | dist | coverage | .git | .vitepress/cache`
- Dispatcher wiring: `.claude/skills/sf-srs/scripts/srs-cli.sh` (+ scaffold copy) routes `--from codebase` to the new bin — stub removed
- Exit-code contract aligned with existing bins: `0` success, `2` bad args, `3` missing backend, `4` invalid backend, `5` runtime

## Test plan

- [x] `srs-cli.sh draft --from codebase --path <empty-dir>` emits `{ source: 'codebase', findings: [] }`, exit 0
- [x] Bad `--path` (non-existent) → exit 2
- [x] Unknown flag → exit 2
- [x] Missing `tools.srs.backend` → exit 3
- [x] Unknown backend in manifest → exit 4
- [x] Scanner runtime error → exit 5

## Tests added

- `src/__tests__/unit/srs/draft-from-codebase.spec.ts` — 143 lines covering empty project, bad args, missing backend, invalid backend, runtime failures