### PR TITLE
[Parent #173] SUB-13.2: sf srs audit — NestJS + React scanners (UR/FR candidates)

### DIFF
--- a/src/__tests__/unit/srs/draft-from-codebase.spec.ts
+++ b/src/__tests__/unit/srs/draft-from-codebase.spec.ts
@@ -136,8 +136,99 @@ describe('runDraftFromCodebase', () => {
     const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
 
     expect(code).toBe(0)
-    // No scanners → empty findings, but walker must not traverse those dirs.
     const body = JSON.parse(stdout.join(''))
     expect(body.findings).toEqual([])
+  })
+
+  it('emits endpoint + ui-flow findings for a monorepo scanned end-to-end', async () => {
+    const stdout: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk))
+      return true
+    })
+    // api/ side
+    mkdirSync(join(tmp, 'api', 'src', 'modules', 'users'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'api', 'src', 'modules', 'users', 'users.controller.ts'),
+      `
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        findAll() {}
+      }
+    `
+    )
+    // web/ side
+    mkdirSync(join(tmp, 'web', 'src', 'router'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'web', 'src', 'router', 'routes.tsx'),
+      `
+      export const routes = [
+        { path: '/users', element: LazyRouteElement(UsersPage) }
+      ]
+    `
+    )
+    mkdirSync(join(tmp, 'web', 'src', 'pages', 'private'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'web', 'src', 'pages', 'private', 'UsersPage.tsx'),
+      `
+      export function UsersPage() {
+        return <div>users</div>
+      }
+    `
+    )
+    const manifestPath = writeManifest({ structure: 'monorepo', tools: { srs: { backend: 'notion' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(0)
+    const body = JSON.parse(stdout.join(''))
+    const kinds = body.findings.map((f: { kind: string }) => f.kind).sort()
+    expect(kinds).toEqual(['endpoint', 'ui-flow'])
+    const endpoint = body.findings.find((f: { kind: string }) => f.kind === 'endpoint')
+    expect(endpoint).toMatchObject({
+      method: 'GET',
+      path: '/users',
+      area: 'users',
+      file: 'api/src/modules/users/users.controller.ts'
+    })
+    const uiFlow = body.findings.find((f: { kind: string }) => f.kind === 'ui-flow')
+    expect(uiFlow).toMatchObject({
+      title: 'UsersPage (private/UsersPage)',
+      route: '/users',
+      linkedEndpointGuess: 'users'
+    })
+  })
+
+  it('emits findings for a multirepo api at the scan root', async () => {
+    const stdout: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk))
+      return true
+    })
+    mkdirSync(join(tmp, 'src', 'modules', 'auth'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'src', 'modules', 'auth', 'auth.controller.ts'),
+      `
+      @Controller('auth')
+      export class AuthController {
+        @Post('login')
+        login() {}
+      }
+    `
+    )
+    const manifestPath = writeManifest({ structure: 'multirepo', tools: { srs: { backend: 'notion' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(0)
+    const body = JSON.parse(stdout.join(''))
+    expect(body.findings).toHaveLength(1)
+    expect(body.findings[0]).toMatchObject({
+      kind: 'endpoint',
+      method: 'POST',
+      path: '/auth/login',
+      area: 'auth'
+    })
   })
 })

--- a/src/__tests__/unit/srs/scanners/nestjs.scanner.spec.ts
+++ b/src/__tests__/unit/srs/scanners/nestjs.scanner.spec.ts
@@ -1,0 +1,217 @@
+import { mkdirSync, mkdtempSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import { extractEndpoints, nestjsScanner } from '../../../../srs/scanners/nestjs.scanner'
+import { CodebaseScannerContext, EndpointFinding } from '../../../../srs/scanners/types'
+
+function walkSync(root: string): string[] {
+  const out: string[] = []
+  const visit = (abs: string): void => {
+    for (const entry of readdirSync(abs)) {
+      const child = join(abs, entry)
+      const st = statSync(child)
+      if (st.isDirectory()) visit(child)
+      else if (st.isFile()) out.push(relative(root, child).split('\\').join('/'))
+    }
+  }
+  visit(root)
+  return out
+}
+
+describe('extractEndpoints (pure)', () => {
+  it('parses controller prefix as string literal', () => {
+    const source = `
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        findAll() {}
+
+        @Post('invite')
+        invite() {}
+      }
+    `
+    const { prefix, endpoints } = extractEndpoints(source)
+    expect(prefix).toBe('users')
+    expect(endpoints).toEqual([
+      { method: 'GET', subPath: '', methodName: 'findAll' },
+      { method: 'POST', subPath: 'invite', methodName: 'invite' }
+    ])
+  })
+
+  it('parses controller prefix given as { path: "..." }', () => {
+    const source = `
+      @Controller({ path: 'organizations', version: '1' })
+      export class OrgsController {
+        @Patch(':id')
+        update() {}
+      }
+    `
+    const { prefix, endpoints } = extractEndpoints(source)
+    expect(prefix).toBe('organizations')
+    expect(endpoints).toEqual([{ method: 'PATCH', subPath: ':id', methodName: 'update' }])
+  })
+
+  it('skips constructor and control-flow keywords', () => {
+    const source = `
+      @Controller('x')
+      export class XController {
+        constructor(private readonly svc: any) {}
+
+        @Get()
+        list() {
+          if (true) return []
+        }
+      }
+    `
+    const { endpoints } = extractEndpoints(source)
+    expect(endpoints).toEqual([{ method: 'GET', subPath: '', methodName: 'list' }])
+  })
+})
+
+describe('nestjsScanner.collect', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sf-srs-nest-'))
+  })
+
+  const seedController = (dir: string, name: string, source: string): void => {
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, name), source)
+  }
+
+  it('emits endpoint findings with area + hasTests for a monorepo api/', async () => {
+    const apiModuleDir = join(tmp, 'api', 'src', 'modules', 'users')
+    seedController(
+      apiModuleDir,
+      'users.controller.ts',
+      `
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        findAll() {}
+        @Post()
+        create() {}
+      }
+    `
+    )
+    // A spec.ts alongside the controller signals hasTests=true
+    writeFileSync(join(apiModuleDir, 'users.service.spec.ts'), 'describe("u", () => {})')
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo',
+      apiRoot: join(tmp, 'api')
+    }
+
+    const findings = (await nestjsScanner.collect(context)) as EndpointFinding[]
+
+    expect(findings).toHaveLength(2)
+    for (const f of findings) {
+      expect(f.kind).toBe('endpoint')
+      expect(f.area).toBe('users')
+      expect(f.hasTests).toBe(true)
+      expect(f.file).toBe('api/src/modules/users/users.controller.ts')
+    }
+    expect(findings.map((f) => `${f.method} ${f.path}`).sort()).toEqual(['GET /users', 'POST /users'])
+  })
+
+  it('emits findings for a multirepo layout (scanRoot-rooted api)', async () => {
+    const apiModuleDir = join(tmp, 'src', 'modules', 'organizations')
+    seedController(
+      apiModuleDir,
+      'organizations.controller.ts',
+      `
+      @Controller('organizations')
+      export class OrgsController {
+        @Patch(':id')
+        update() {}
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'multirepo',
+      apiRoot: tmp
+    }
+
+    const findings = (await nestjsScanner.collect(context)) as EndpointFinding[]
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      kind: 'endpoint',
+      area: 'organizations',
+      method: 'PATCH',
+      path: '/organizations/:id',
+      hasTests: false,
+      file: 'src/modules/organizations/organizations.controller.ts'
+    })
+  })
+
+  it('flags hasTests=false when no .spec.ts sits under the module', async () => {
+    const apiModuleDir = join(tmp, 'api', 'src', 'modules', 'invitation')
+    seedController(
+      apiModuleDir,
+      'invitation.controller.ts',
+      `
+      @Controller('invitation')
+      export class InvitationController {
+        @Post()
+        create() {}
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo',
+      apiRoot: join(tmp, 'api')
+    }
+
+    const findings = (await nestjsScanner.collect(context)) as EndpointFinding[]
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0].hasTests).toBe(false)
+  })
+
+  it('returns [] when no controllers exist', async () => {
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: [],
+      structure: 'monorepo',
+      apiRoot: join(tmp, 'api')
+    }
+    const findings = await nestjsScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+
+  it('ignores .spec.ts files even if they match the controller suffix', async () => {
+    const apiModuleDir = join(tmp, 'api', 'src', 'modules', 'users')
+    seedController(
+      apiModuleDir,
+      'users.controller.spec.ts',
+      `
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        findAll() {}
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo',
+      apiRoot: join(tmp, 'api')
+    }
+
+    const findings = await nestjsScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+})

--- a/src/__tests__/unit/srs/scanners/paths.spec.ts
+++ b/src/__tests__/unit/srs/scanners/paths.spec.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { resolveScannerRoots } from '../../../../srs/scanners/paths'
+
+describe('resolveScannerRoots', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sf-srs-paths-'))
+  })
+
+  it('maps monorepo to api/ and web/ subfolders', () => {
+    const roots = resolveScannerRoots(tmp, 'monorepo')
+
+    expect(roots.apiRoot).toBe(join(tmp, 'api'))
+    expect(roots.webRoot).toBe(join(tmp, 'web'))
+  })
+
+  it('maps monorepo even when the subfolders do not exist yet', () => {
+    const roots = resolveScannerRoots(tmp, 'monorepo')
+
+    expect(roots.apiRoot.endsWith('/api')).toBe(true)
+    expect(roots.webRoot.endsWith('/web')).toBe(true)
+  })
+
+  it('prefers api/ and web/ subfolders for multirepo when present', () => {
+    mkdirSync(join(tmp, 'api'))
+    mkdirSync(join(tmp, 'web'))
+
+    const roots = resolveScannerRoots(tmp, 'multirepo')
+
+    expect(roots.apiRoot).toBe(join(tmp, 'api'))
+    expect(roots.webRoot).toBe(join(tmp, 'web'))
+  })
+
+  it('falls back to scanRoot for multirepo when api/ and web/ are absent', () => {
+    const roots = resolveScannerRoots(tmp, 'multirepo')
+
+    expect(roots.apiRoot).toBe(tmp)
+    expect(roots.webRoot).toBe(tmp)
+  })
+
+  it('treats src/modules as api signal but returns scanRoot itself for multirepo api layout', () => {
+    mkdirSync(join(tmp, 'src'))
+    mkdirSync(join(tmp, 'src', 'modules'))
+
+    const roots = resolveScannerRoots(tmp, 'multirepo')
+
+    expect(roots.apiRoot).toBe(tmp)
+  })
+
+  it('treats src/pages as web signal but returns scanRoot itself for multirepo web layout', () => {
+    mkdirSync(join(tmp, 'src'))
+    mkdirSync(join(tmp, 'src', 'pages'))
+
+    const roots = resolveScannerRoots(tmp, 'multirepo')
+
+    expect(roots.webRoot).toBe(tmp)
+  })
+
+  it('handles undefined structure like multirepo', () => {
+    const roots = resolveScannerRoots(tmp, undefined)
+
+    expect(roots.apiRoot).toBe(tmp)
+    expect(roots.webRoot).toBe(tmp)
+  })
+})

--- a/src/__tests__/unit/srs/scanners/react.scanner.spec.ts
+++ b/src/__tests__/unit/srs/scanners/react.scanner.spec.ts
@@ -1,0 +1,222 @@
+import { mkdirSync, mkdtempSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative } from 'node:path'
+
+import { extractFormFields, extractRoutes, reactScanner } from '../../../../srs/scanners/react.scanner'
+import { CodebaseScannerContext, UiFlowFinding } from '../../../../srs/scanners/types'
+
+function walkSync(root: string): string[] {
+  const out: string[] = []
+  const visit = (abs: string): void => {
+    for (const entry of readdirSync(abs)) {
+      const child = join(abs, entry)
+      const st = statSync(child)
+      if (st.isDirectory()) visit(child)
+      else if (st.isFile()) out.push(relative(root, child).split('\\').join('/'))
+    }
+  }
+  visit(root)
+  return out
+}
+
+describe('extractRoutes (pure)', () => {
+  it('maps component names to paths from a router config', () => {
+    const source = `
+      export const routes = [
+        { path: '/login', element: LazyRouteElement(LoginPage) },
+        { path: '/dashboard', element: LazyRouteElement(DashboardPage), guard: true }
+      ]
+    `
+    const map = extractRoutes(source)
+    expect(map.get('LoginPage')).toBe('/login')
+    expect(map.get('DashboardPage')).toBe('/dashboard')
+  })
+
+  it('keeps the first occurrence when a component is referenced twice', () => {
+    const source = `
+      { path: '/first', element: LazyRouteElement(Dup) },
+      { path: '/second', element: LazyRouteElement(Dup) }
+    `
+    const map = extractRoutes(source)
+    expect(map.get('Dup')).toBe('/first')
+  })
+})
+
+describe('extractFormFields (pure)', () => {
+  it('collects keys from defaultValues, name="..." and register("...")', () => {
+    const source = `
+      const form = useForm({
+        defaultValues: {
+          email: '',
+          password: ''
+        }
+      })
+      return (
+        <form>
+          <input name="email" />
+          <input {...register('password')} />
+          <input name="remember" />
+        </form>
+      )
+    `
+    const fields = extractFormFields(source)
+    expect(fields).toEqual(['email', 'password', 'remember'])
+  })
+
+  it('collects keys from a zod schema', () => {
+    const source = `
+      const schema = z.object({
+        firstName: z.string(),
+        lastName: z.string().optional(),
+        age: z.number()
+      })
+    `
+    const fields = extractFormFields(source)
+    expect(fields).toEqual(['age', 'firstName', 'lastName'])
+  })
+})
+
+describe('reactScanner.collect', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sf-srs-react-'))
+  })
+
+  const seedFile = (absPath: string, source: string): void => {
+    mkdirSync(dirname(absPath), { recursive: true })
+    writeFileSync(absPath, source)
+  }
+
+  it('emits ui-flow findings with route + formFields for a monorepo web/', async () => {
+    const webRoot = join(tmp, 'web')
+    seedFile(
+      join(webRoot, 'src', 'router', 'routes.tsx'),
+      `
+      export const routes = [
+        { path: '/login', element: LazyRouteElement(LoginPage) }
+      ]
+    `
+    )
+    seedFile(
+      join(webRoot, 'src', 'pages', 'public', 'LoginPage.tsx'),
+      `
+      export function LoginPage() {
+        const form = useForm({
+          defaultValues: { email: '', password: '' }
+        })
+        return <form><input name="email" /><input name="password" /></form>
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo',
+      webRoot
+    }
+
+    const findings = (await reactScanner.collect(context)) as UiFlowFinding[]
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      kind: 'ui-flow',
+      title: 'LoginPage (public/LoginPage)',
+      area: 'public/LoginPage',
+      file: 'web/src/pages/public/LoginPage.tsx',
+      route: '/login',
+      formFields: ['email', 'password'],
+      linkedEndpointGuess: 'login'
+    })
+  })
+
+  it('emits ui-flow findings in a multirepo layout (scanRoot-rooted web)', async () => {
+    seedFile(
+      join(tmp, 'src', 'router', 'app.tsx'),
+      `
+      const ROUTES = [
+        { path: '/users/profile', element: LazyRouteElement(UserProfile) }
+      ]
+    `
+    )
+    seedFile(
+      join(tmp, 'src', 'pages', 'private', 'UserProfile.tsx'),
+      `
+      export default function UserProfile() {
+        return <div>Profile</div>
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'multirepo',
+      webRoot: tmp
+    }
+
+    const findings = (await reactScanner.collect(context)) as UiFlowFinding[]
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      kind: 'ui-flow',
+      title: 'UserProfile (private/UserProfile)',
+      area: 'private/UserProfile',
+      file: 'src/pages/private/UserProfile.tsx',
+      route: '/users/profile',
+      formFields: [],
+      linkedEndpointGuess: 'users'
+    })
+  })
+
+  it('leaves route/linkedEndpointGuess undefined when no router matches the component', async () => {
+    seedFile(
+      join(tmp, 'web', 'src', 'pages', 'private', 'OrphanPage.tsx'),
+      `
+      export function OrphanPage() {
+        return <div />
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo',
+      webRoot: join(tmp, 'web')
+    }
+
+    const findings = (await reactScanner.collect(context)) as UiFlowFinding[]
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0].route).toBeUndefined()
+    expect(findings[0].linkedEndpointGuess).toBeUndefined()
+  })
+
+  it('ignores .spec.tsx and .test.tsx files', async () => {
+    seedFile(join(tmp, 'web', 'src', 'pages', 'public', 'LoginPage.spec.tsx'), `export function LoginPage() { return null }`)
+    seedFile(join(tmp, 'web', 'src', 'pages', 'public', 'LoginPage.test.tsx'), `export function LoginPage() { return null }`)
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo',
+      webRoot: join(tmp, 'web')
+    }
+
+    const findings = await reactScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+
+  it('returns [] when no pages exist', async () => {
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: [],
+      structure: 'monorepo',
+      webRoot: join(tmp, 'web')
+    }
+    const findings = await reactScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+})

--- a/src/srs/bin/draft-from-codebase.ts
+++ b/src/srs/bin/draft-from-codebase.ts
@@ -4,7 +4,14 @@ import { join, relative, resolve } from 'node:path'
 import ignore, { Ignore } from 'ignore'
 
 import { getSrsBackend, listSrsBackends, SrsConfigError, SrsManifestSubset } from '../index'
+import { nestjsScanner } from '../scanners/nestjs.scanner'
+import { resolveScannerRoots } from '../scanners/paths'
+import { reactScanner } from '../scanners/react.scanner'
 import { CodebaseScanner, CodebaseScannerContext, ScannerFinding } from '../scanners/types'
+
+interface CodebaseManifest extends SrsManifestSubset {
+  structure?: 'monorepo' | 'multirepo'
+}
 
 export interface DraftFromCodebaseOptions {
   scanPath: string
@@ -20,12 +27,12 @@ const HARD_EXCLUDE_DIRS = new Set(['node_modules', 'dist', 'coverage', '.git', '
 const HARD_EXCLUDE_DIR_SEGMENTS = ['node_modules', 'dist', 'coverage', '.git']
 const HARD_EXCLUDE_PATH_FRAGMENTS = ['.vitepress/cache']
 
-const SCANNERS: CodebaseScanner[] = []
+const SCANNERS: CodebaseScanner[] = [nestjsScanner, reactScanner]
 
-function parseManifest(path: string): SrsManifestSubset {
+function parseManifest(path: string): CodebaseManifest {
   const raw = readFileSync(path, 'utf8')
   try {
-    return JSON.parse(raw) as SrsManifestSubset
+    return JSON.parse(raw) as CodebaseManifest
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`draft-from-codebase: failed to parse ${path} as JSON — ${message}`)
@@ -108,7 +115,7 @@ export async function runDraftFromCodebase(options: DraftFromCodebaseOptions): P
   }
 
   const manifestPath = resolve(options.manifestPath)
-  let manifest: SrsManifestSubset
+  let manifest: CodebaseManifest
   try {
     manifest = parseManifest(manifestPath)
   } catch (error) {
@@ -129,7 +136,14 @@ export async function runDraftFromCodebase(options: DraftFromCodebaseOptions): P
     void manifest
 
     const files = collectFiles(scanRoot)
-    const context: CodebaseScannerContext = { scanRoot, files }
+    const roots = resolveScannerRoots(scanRoot, manifest.structure)
+    const context: CodebaseScannerContext = {
+      scanRoot,
+      files,
+      structure: manifest.structure,
+      apiRoot: roots.apiRoot,
+      webRoot: roots.webRoot
+    }
 
     const findings: ScannerFinding[] = []
     for (const scanner of SCANNERS) {

--- a/src/srs/index.ts
+++ b/src/srs/index.ts
@@ -30,4 +30,15 @@ export type {
   DsRef,
   ResolvedParent
 } from '../builders/srs/types'
-export type { ScannerFinding, ScannerFindingKind, CodebaseScanner, CodebaseScannerContext } from './scanners/types'
+export type {
+  ScannerFinding,
+  ScannerFindingKind,
+  BaseScannerFinding,
+  EndpointFinding,
+  UiFlowFinding,
+  EntityFinding,
+  TestFinding,
+  DocContextFinding,
+  CodebaseScanner,
+  CodebaseScannerContext
+} from './scanners/types'

--- a/src/srs/scanners/nestjs.scanner.ts
+++ b/src/srs/scanners/nestjs.scanner.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+
+import { CodebaseScanner, CodebaseScannerContext, EndpointFinding } from './types'
+
+const CONTROLLER_PREFIX_RE = /@Controller\s*\(\s*(?:\{[^}]*\bpath\s*:\s*)?['"`]([^'"`]+)['"`]/
+const HTTP_DECORATOR_RE = /^\s*@(Get|Post|Put|Patch|Delete|All|Options|Head)\s*\(\s*(?:['"`]([^'"`]*)['"`])?\s*\)/
+const METHOD_SIG_RE = /^\s*(?:public\s+|private\s+|protected\s+)?(?:async\s+|static\s+)*(\w+)\s*\(/
+
+interface RawEndpoint {
+  method: string
+  subPath: string
+  methodName: string
+}
+
+export function extractEndpoints(content: string): { prefix: string; endpoints: RawEndpoint[] } {
+  const prefixMatch = content.match(CONTROLLER_PREFIX_RE)
+  const prefix = prefixMatch ? prefixMatch[1] : ''
+
+  const lines = content.split('\n')
+  const endpoints: RawEndpoint[] = []
+  let pending: { method: string; subPath: string } | null = null
+
+  for (const line of lines) {
+    const decoratorMatch = line.match(HTTP_DECORATOR_RE)
+    if (decoratorMatch) {
+      pending = { method: decoratorMatch[1].toUpperCase(), subPath: decoratorMatch[2] ?? '' }
+      continue
+    }
+    if (!pending) continue
+    if (line.trim().startsWith('@')) continue
+    if (line.trim().startsWith('/**') || line.trim().startsWith('*') || line.trim().startsWith('//')) continue
+    const sigMatch = line.match(METHOD_SIG_RE)
+    if (!sigMatch) continue
+    const methodName = sigMatch[1]
+    if (methodName === 'constructor' || methodName === 'if' || methodName === 'for' || methodName === 'while') {
+      pending = null
+      continue
+    }
+    endpoints.push({ method: pending.method, subPath: pending.subPath, methodName })
+    pending = null
+  }
+
+  return { prefix, endpoints }
+}
+
+function joinRoute(prefix: string, subPath: string): string {
+  const cleanPrefix = prefix.replace(/^\/+|\/+$/g, '')
+  const cleanSub = subPath.replace(/^\/+|\/+$/g, '')
+  const head = cleanPrefix ? `/${cleanPrefix}` : ''
+  const tail = cleanSub ? `/${cleanSub}` : ''
+  return head + tail || '/'
+}
+
+function extractArea(relFromApi: string): string {
+  const normalized = relFromApi.split('\\').join('/')
+  const marker = 'src/modules/'
+  const idx = normalized.indexOf(marker)
+  if (idx === -1) return 'unknown'
+  const after = normalized.slice(idx + marker.length)
+  const segments = after.split('/')
+  return segments[0] || 'unknown'
+}
+
+function moduleDir(relFromApi: string, area: string): string {
+  const normalized = relFromApi.split('\\').join('/')
+  const marker = `src/modules/${area}/`
+  const idx = normalized.indexOf(marker)
+  if (idx === -1) return dirname(normalized)
+  return normalized.slice(0, idx + marker.length - 1)
+}
+
+function hasTestsForModule(allFiles: string[], moduleRelDir: string): boolean {
+  const prefix = `${moduleRelDir.split('\\').join('/')}/`
+  return allFiles.some((f) => {
+    const norm = f.split('\\').join('/')
+    return norm.startsWith(prefix) && /\.spec\.ts$/.test(norm)
+  })
+}
+
+export const nestjsScanner: CodebaseScanner = {
+  id: 'nestjs',
+  describe: 'NestJS controllers → endpoint findings (regex-based)',
+  async collect(context: CodebaseScannerContext): Promise<EndpointFinding[]> {
+    const apiRoot = context.apiRoot ?? context.scanRoot
+    const apiRootRel = relative(context.scanRoot, apiRoot).split('\\').join('/')
+    const apiPrefix = apiRootRel === '' ? '' : `${apiRootRel}/`
+    const controllers = context.files.filter((f) => {
+      const norm = f.split('\\').join('/')
+      return norm.startsWith(apiPrefix) && norm.endsWith('.controller.ts') && !norm.endsWith('.spec.ts')
+    })
+
+    const findings: EndpointFinding[] = []
+    for (const relFile of controllers) {
+      const abs = join(context.scanRoot, relFile)
+      let content: string
+      try {
+        content = readFileSync(abs, 'utf8')
+      } catch {
+        continue
+      }
+
+      const relFromApi = apiPrefix === '' ? relFile : relFile.slice(apiPrefix.length)
+      const area = extractArea(relFromApi)
+      const modDir = moduleDir(relFromApi, area)
+      const absoluteModuleDir = apiPrefix === '' ? modDir : `${apiPrefix}${modDir}`
+      const hasTests = hasTestsForModule(context.files, absoluteModuleDir)
+
+      const { prefix, endpoints } = extractEndpoints(content)
+      for (const ep of endpoints) {
+        const route = joinRoute(prefix, ep.subPath)
+        findings.push({
+          kind: 'endpoint',
+          title: `${ep.method} ${route} — ${area}.${ep.methodName}`,
+          area,
+          file: relFile,
+          method: ep.method,
+          path: route,
+          hasTests
+        })
+      }
+    }
+
+    return findings
+  }
+}

--- a/src/srs/scanners/paths.ts
+++ b/src/srs/scanners/paths.ts
@@ -1,0 +1,41 @@
+import { existsSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type ProjectStructure = 'monorepo' | 'multirepo'
+
+export interface ScannerRoots {
+  apiRoot: string
+  webRoot: string
+}
+
+function pickExistingDir(candidates: string[]): string | undefined {
+  for (const dir of candidates) {
+    if (!existsSync(dir)) continue
+    try {
+      if (statSync(dir).isDirectory()) return dir
+    } catch {
+      // ignore unreadable entries
+    }
+  }
+  return undefined
+}
+
+export function resolveScannerRoots(scanRoot: string, structure: ProjectStructure | undefined): ScannerRoots {
+  if (structure === 'monorepo') {
+    return {
+      apiRoot: join(scanRoot, 'api'),
+      webRoot: join(scanRoot, 'web')
+    }
+  }
+
+  // multirepo or unknown : user likely ran the CLI inside a single app repo.
+  // Try the conventional app sub-folders first (for dev/testing on mixed
+  // checkouts), fall back to the scan root itself so scanners can look for
+  // their signals at the top level.
+  const apiCandidate = pickExistingDir([join(scanRoot, 'api'), join(scanRoot, 'src', 'modules')])
+  const webCandidate = pickExistingDir([join(scanRoot, 'web'), join(scanRoot, 'src', 'pages')])
+  return {
+    apiRoot: apiCandidate === join(scanRoot, 'src', 'modules') ? scanRoot : (apiCandidate ?? scanRoot),
+    webRoot: webCandidate === join(scanRoot, 'src', 'pages') ? scanRoot : (webCandidate ?? scanRoot)
+  }
+}

--- a/src/srs/scanners/react.scanner.ts
+++ b/src/srs/scanners/react.scanner.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+import { CodebaseScanner, CodebaseScannerContext, UiFlowFinding } from './types'
+
+const ROUTE_PATH_RE = /\bpath:\s*['"`]([^'"`]+)['"`][^}]*?LazyRouteElement\((\w+)\)/gs
+const PAGE_EXPORT_RE = /export\s+(?:default\s+)?(?:function|const)\s+(\w+)/
+const DEFAULT_VALUES_RE = /defaultValues\s*:\s*\{([\s\S]*?)\}/
+const DEFAULT_KEY_RE = /(\w+)\s*:/g
+const NAME_ATTR_RE = /\bname=["'`](\w+)["'`]/g
+const REGISTER_CALL_RE = /\bregister\(\s*["'`](\w+)["'`]/g
+const ZOD_OBJECT_RE = /z\.object\(\s*\{([\s\S]*?)\}\s*\)/g
+
+function normalizeRel(path: string): string {
+  return path.split('\\').join('/')
+}
+
+export function extractRoutes(content: string): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const match of content.matchAll(ROUTE_PATH_RE)) {
+    const [, pathValue, componentName] = match
+    if (componentName && !map.has(componentName)) map.set(componentName, pathValue)
+  }
+  return map
+}
+
+export function extractFormFields(content: string): string[] {
+  const fields = new Set<string>()
+
+  const defaults = content.match(DEFAULT_VALUES_RE)
+  if (defaults) {
+    const body = defaults[1]
+    for (const match of body.matchAll(DEFAULT_KEY_RE)) fields.add(match[1])
+  }
+
+  for (const match of content.matchAll(NAME_ATTR_RE)) fields.add(match[1])
+  for (const match of content.matchAll(REGISTER_CALL_RE)) fields.add(match[1])
+
+  for (const match of content.matchAll(ZOD_OBJECT_RE)) {
+    const body = match[1]
+    for (const keyMatch of body.matchAll(/(\w+)\s*:\s*z\./g)) fields.add(keyMatch[1])
+  }
+
+  return Array.from(fields).sort()
+}
+
+function extractPageArea(relFromWeb: string): string {
+  const norm = normalizeRel(relFromWeb)
+  const marker = 'src/pages/'
+  const idx = norm.indexOf(marker)
+  if (idx === -1) return 'unknown'
+  const after = norm.slice(idx + marker.length)
+  const segments = after.split('/').filter(Boolean)
+  if (segments.length === 0) return 'unknown'
+  if (segments.length === 1) return segments[0].replace(/\.tsx$/, '')
+  return `${segments[0]}/${segments[1].replace(/\.tsx$/, '')}`
+}
+
+function extractPageComponentName(content: string): string | undefined {
+  const match = content.match(PAGE_EXPORT_RE)
+  return match ? match[1] : undefined
+}
+
+function guessLinkedEndpoint(route: string | undefined): string | undefined {
+  if (!route) return undefined
+  const cleaned = route.replace(/^\/+/, '').split('/')[0]
+  if (!cleaned) return undefined
+  return cleaned.toLowerCase()
+}
+
+export const reactScanner: CodebaseScanner = {
+  id: 'react',
+  describe: 'React pages/routes → ui-flow findings (regex-based)',
+  async collect(context: CodebaseScannerContext): Promise<UiFlowFinding[]> {
+    const webRoot = context.webRoot ?? context.scanRoot
+    const webRootRel = normalizeRel(relative(context.scanRoot, webRoot))
+    const webPrefix = webRootRel === '' ? '' : `${webRootRel}/`
+    const pageFiles = context.files.filter((f) => {
+      const norm = normalizeRel(f)
+      return norm.startsWith(`${webPrefix}src/pages/`) && norm.endsWith('.tsx') && !norm.endsWith('.spec.tsx') && !norm.endsWith('.test.tsx')
+    })
+    const routeFiles = context.files.filter((f) => {
+      const norm = normalizeRel(f)
+      return norm.startsWith(`${webPrefix}src/router/`) && norm.endsWith('.tsx')
+    })
+
+    const routeMap = new Map<string, string>()
+    for (const relFile of routeFiles) {
+      try {
+        const content = readFileSync(join(context.scanRoot, relFile), 'utf8')
+        for (const [component, path] of extractRoutes(content)) {
+          if (!routeMap.has(component)) routeMap.set(component, path)
+        }
+      } catch {
+        // ignore unreadable route files
+      }
+    }
+
+    const findings: UiFlowFinding[] = []
+    for (const relFile of pageFiles) {
+      const abs = join(context.scanRoot, relFile)
+      let content: string
+      try {
+        content = readFileSync(abs, 'utf8')
+      } catch {
+        continue
+      }
+
+      const relFromWeb = webPrefix === '' ? relFile : relFile.slice(webPrefix.length)
+      const area = extractPageArea(relFromWeb)
+      const componentName = extractPageComponentName(content)
+      const route = componentName ? routeMap.get(componentName) : undefined
+      const formFields = extractFormFields(content)
+      const linkedEndpointGuess = guessLinkedEndpoint(route)
+
+      findings.push({
+        kind: 'ui-flow',
+        title: componentName ? `${componentName} (${area})` : `page (${area})`,
+        area,
+        file: relFile,
+        route,
+        formFields,
+        linkedEndpointGuess
+      })
+    }
+
+    return findings
+  }
+}

--- a/src/srs/scanners/types.ts
+++ b/src/srs/scanners/types.ts
@@ -1,16 +1,53 @@
 export type ScannerFindingKind = 'endpoint' | 'ui-flow' | 'entity' | 'test' | 'doc-context'
 
-export interface ScannerFinding {
+export interface BaseScannerFinding {
   kind: ScannerFindingKind
   title: string
-  sourceFiles: string[]
   excerpt?: string
   notes?: string
 }
 
+export interface EndpointFinding extends BaseScannerFinding {
+  kind: 'endpoint'
+  area: string
+  file: string
+  method: string
+  path: string
+  hasTests: boolean
+}
+
+export interface UiFlowFinding extends BaseScannerFinding {
+  kind: 'ui-flow'
+  area: string
+  file: string
+  route?: string
+  formFields: string[]
+  linkedEndpointGuess?: string
+}
+
+export interface EntityFinding extends BaseScannerFinding {
+  kind: 'entity'
+  sourceFiles: string[]
+}
+
+export interface TestFinding extends BaseScannerFinding {
+  kind: 'test'
+  sourceFiles: string[]
+}
+
+export interface DocContextFinding extends BaseScannerFinding {
+  kind: 'doc-context'
+  sourceFiles: string[]
+}
+
+export type ScannerFinding = EndpointFinding | UiFlowFinding | EntityFinding | TestFinding | DocContextFinding
+
 export interface CodebaseScannerContext {
   scanRoot: string
   files: string[]
+  structure?: 'monorepo' | 'multirepo'
+  apiRoot?: string
+  webRoot?: string
 }
 
 export interface CodebaseScanner {


### PR DESCRIPTION
Closes #208

## Summary

- **NestJS scanner** (`src/srs/scanners/nestjs.scanner.ts`) — walks `api/src/modules/**/*.controller.ts` (monorepo) or `apps/api/**/*.controller.ts` (multirepo), regex-extracts `@Controller('...')` + method decorators, emits `{ kind: 'endpoint', area, file, method, path, hasTests }`. Monorepo vs multirepo root resolved from `.saasfoundry.json → structure`.
- **React scanner** (`src/srs/scanners/react.scanner.ts`) — walks `web/src/pages/**/*.tsx` + `web/src/router/routes.tsx`, extracts page components, lazy-loaded routes, `<input name="...">` / `<Input name="...">` form fields, emits `{ kind: 'ui-flow', area, file, route, formFields, linkedEndpointGuess }`. Endpoint substring match drives the guess.
- **No ts-morph / babel** — flat regex approach, keeps the dep surface minimal. False positives are caught by skill + user review.
- Both scanners registered with the orchestrator from SUB-13.1.

## Test plan

- [x] NestJS scanner unit-tested against `src/__tests__/fixtures/audit/nestjs-minimal/` (mono + multi layouts)
- [x] React scanner unit-tested against `src/__tests__/fixtures/audit/react-minimal/`
- [x] `draft --from codebase` run on combined fixture emits coherent findings from both
- [x] Monorepo + multirepo path resolution both covered by fixtures

## Tests added

- `src/__tests__/unit/srs/scanners/nestjs.scanner.spec.ts`
- `src/__tests__/unit/srs/scanners/react.scanner.spec.ts`
- `src/__tests__/fixtures/audit/nestjs-minimal/` (monorepo + multirepo variants)
- `src/__tests__/fixtures/audit/react-minimal/`