### PR TITLE
[Parent #173] SUB-13.3: sf srs audit — Prisma + tests + docs scanners (DS/TC + context)

### DIFF
--- a/src/__tests__/unit/srs/draft-from-codebase.spec.ts
+++ b/src/__tests__/unit/srs/draft-from-codebase.spec.ts
@@ -231,4 +231,77 @@ describe('runDraftFromCodebase', () => {
       area: 'auth'
     })
   })
+
+  it('runs the full 5-scanner pipeline end-to-end for a monorepo', async () => {
+    const stdout: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk))
+      return true
+    })
+    // NestJS controller + spec (endpoint + test)
+    mkdirSync(join(tmp, 'api', 'src', 'modules', 'users'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'api', 'src', 'modules', 'users', 'users.controller.ts'),
+      `
+      @Controller('users')
+      export class UsersController {
+        @Get()
+        list() {}
+      }
+    `
+    )
+    writeFileSync(
+      join(tmp, 'api', 'src', 'modules', 'users', 'users.service.spec.ts'),
+      `
+      describe('UsersService', () => {
+        it('lists users', () => {})
+      })
+    `
+    )
+    // Prisma schema (entity)
+    mkdirSync(join(tmp, 'api', 'prisma', 'schema'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'api', 'prisma', 'schema', 'users.prisma'),
+      `
+      model User {
+        id    String @id
+        email String
+      }
+    `
+    )
+    // React page + router (ui-flow)
+    mkdirSync(join(tmp, 'web', 'src', 'router'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'web', 'src', 'router', 'routes.tsx'),
+      `
+      export const routes = [
+        { path: '/users', element: LazyRouteElement(UsersPage) }
+      ]
+    `
+    )
+    mkdirSync(join(tmp, 'web', 'src', 'pages', 'private'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'web', 'src', 'pages', 'private', 'UsersPage.tsx'),
+      `
+      export function UsersPage() {
+        return <div>users</div>
+      }
+    `
+    )
+    // Docs (doc-context)
+    writeFileSync(
+      join(tmp, 'README.md'),
+      `# Project
+A SaaS platform for users and their accounts.
+`
+    )
+    const manifestPath = writeManifest({ structure: 'monorepo', tools: { srs: { backend: 'notion' } } })
+
+    const code = await runDraftFromCodebase({ scanPath: tmp, manifestPath })
+
+    expect(code).toBe(0)
+    const body = JSON.parse(stdout.join(''))
+    const kinds = body.findings.map((f: { kind: string }) => f.kind)
+    expect(new Set(kinds)).toEqual(new Set(['endpoint', 'ui-flow', 'entity', 'test', 'doc-context']))
+  })
 })

--- a/src/__tests__/unit/srs/scanners/docs.scanner.spec.ts
+++ b/src/__tests__/unit/srs/scanners/docs.scanner.spec.ts
@@ -1,0 +1,172 @@
+import { mkdirSync, mkdtempSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative } from 'node:path'
+
+import { docsScanner, extractHeadings, slugify } from '../../../../srs/scanners/docs.scanner'
+import { CodebaseScannerContext, DocContextFinding } from '../../../../srs/scanners/types'
+
+function walkSync(root: string): string[] {
+  const out: string[] = []
+  const visit = (abs: string): void => {
+    for (const entry of readdirSync(abs)) {
+      const child = join(abs, entry)
+      const st = statSync(child)
+      if (st.isDirectory()) visit(child)
+      else if (st.isFile()) out.push(relative(root, child).split('\\').join('/'))
+    }
+  }
+  visit(root)
+  return out
+}
+
+describe('slugify (pure)', () => {
+  it('lowercases and dashes a heading', () => {
+    expect(slugify('My First Heading')).toBe('my-first-heading')
+  })
+
+  it('caps the slug at 4 words', () => {
+    expect(slugify('One Two Three Four Five Six')).toBe('one-two-three-four')
+  })
+
+  it('strips punctuation', () => {
+    expect(slugify('Hello, World!')).toBe('hello-world')
+  })
+})
+
+describe('extractHeadings (pure)', () => {
+  it('extracts H1/H2/H3 headings and the first paragraph excerpt', () => {
+    const source = `# Top
+Intro paragraph line 1.
+Intro paragraph line 2.
+
+Another paragraph.
+
+## Section A
+Details about A.
+
+### Sub section
+Deep detail.
+`
+    const out = extractHeadings(source)
+    expect(out).toEqual([
+      { level: 1, heading: 'Top', excerpt: 'Intro paragraph line 1. Intro paragraph line 2.' },
+      { level: 2, heading: 'Section A', excerpt: 'Details about A.' },
+      { level: 3, heading: 'Sub section', excerpt: 'Deep detail.' }
+    ])
+  })
+
+  it('ignores H4+ headings', () => {
+    const source = `#### too deep\ncontent`
+    expect(extractHeadings(source)).toEqual([])
+  })
+
+  it('strips YAML frontmatter', () => {
+    const source = `---
+title: hello
+---
+
+# Real Heading
+Body.
+`
+    const out = extractHeadings(source)
+    expect(out).toEqual([{ level: 1, heading: 'Real Heading', excerpt: 'Body.' }])
+  })
+
+  it('caps the excerpt to avoid runaway output', () => {
+    const big = 'x'.repeat(500)
+    const source = `# Cap\n${big}`
+    const out = extractHeadings(source)
+    expect(out[0].excerpt.length).toBeLessThanOrEqual(280)
+  })
+})
+
+describe('docsScanner.collect', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sf-srs-docs-'))
+  })
+
+  const seedFile = (absPath: string, source: string): void => {
+    mkdirSync(dirname(absPath), { recursive: true })
+    writeFileSync(absPath, source)
+  }
+
+  it('emits doc-context findings for README / CLAUDE / docs/**/*.md', async () => {
+    seedFile(
+      join(tmp, 'README.md'),
+      `# Project
+Quick overview paragraph.
+`
+    )
+    seedFile(
+      join(tmp, 'CLAUDE.md'),
+      `# AI rules
+Do X, not Y.
+`
+    )
+    seedFile(
+      join(tmp, 'docs', 'guide.md'),
+      `# Guide
+Guide intro.
+
+## Step one
+First step.
+`
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo'
+    }
+
+    const findings = (await docsScanner.collect(context)) as DocContextFinding[]
+
+    expect(findings).toHaveLength(4)
+    const byHeading = Object.fromEntries(findings.map((f) => [f.heading, f]))
+    expect(byHeading.Project.file).toBe('README.md')
+    expect(byHeading.Project.area).toBe('project')
+    expect(byHeading['AI rules'].file).toBe('CLAUDE.md')
+    expect(byHeading.Guide.file).toBe('docs/guide.md')
+    expect(byHeading['Step one'].headingLevel).toBe(2)
+  })
+
+  it('picks up nested README under api/ and web/', async () => {
+    seedFile(join(tmp, 'api', 'README.md'), `# API\nBackend overview.`)
+    seedFile(join(tmp, 'web', 'README.md'), `# Web\nFrontend overview.`)
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo'
+    }
+
+    const findings = (await docsScanner.collect(context)) as DocContextFinding[]
+
+    expect(findings.map((f) => f.file).sort()).toEqual(['api/README.md', 'web/README.md'])
+  })
+
+  it('ignores non-doc markdown files (e.g. in src/)', async () => {
+    seedFile(join(tmp, 'src', 'notes.md'), `# Notes\nSome notes.`)
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'multirepo'
+    }
+
+    const findings = await docsScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+
+  it('returns [] when no doc files exist', async () => {
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: [],
+      structure: 'monorepo'
+    }
+    const findings = await docsScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+})

--- a/src/__tests__/unit/srs/scanners/prisma.scanner.spec.ts
+++ b/src/__tests__/unit/srs/scanners/prisma.scanner.spec.ts
@@ -1,0 +1,216 @@
+import { mkdirSync, mkdtempSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative } from 'node:path'
+
+import { extractModels, modelToArea, parseFieldLine, prismaScanner } from '../../../../srs/scanners/prisma.scanner'
+import { CodebaseScannerContext, EntityFinding } from '../../../../srs/scanners/types'
+
+function walkSync(root: string): string[] {
+  const out: string[] = []
+  const visit = (abs: string): void => {
+    for (const entry of readdirSync(abs)) {
+      const child = join(abs, entry)
+      const st = statSync(child)
+      if (st.isDirectory()) visit(child)
+      else if (st.isFile()) out.push(relative(root, child).split('\\').join('/'))
+    }
+  }
+  visit(root)
+  return out
+}
+
+describe('parseFieldLine (pure)', () => {
+  it('parses a scalar field with id attribute', () => {
+    const parsed = parseFieldLine('  id String @id @default(cuid())')
+    expect(parsed).toEqual({
+      field: { name: 'id', type: 'String', isId: true },
+      relationTarget: undefined
+    })
+  })
+
+  it('flags optional scalar fields', () => {
+    const parsed = parseFieldLine('  description String? @db.VarChar(255)')
+    expect(parsed?.field).toEqual({ name: 'description', type: 'String', optional: true })
+  })
+
+  it('recognizes list relation fields', () => {
+    const parsed = parseFieldLine('  users UserRoleLink[]')
+    expect(parsed?.field).toEqual({ name: 'users', type: 'UserRoleLink[]' })
+    expect(parsed?.relationTarget).toBe('UserRoleLink')
+  })
+
+  it('recognizes explicit @relation', () => {
+    const parsed = parseFieldLine('  role Role @relation(fields: [roleId], references: [id])')
+    expect(parsed?.field).toEqual({ name: 'role', type: 'Role' })
+    expect(parsed?.relationTarget).toBe('Role')
+  })
+
+  it('skips directive lines, comments, and blanks', () => {
+    expect(parseFieldLine('')).toBeUndefined()
+    expect(parseFieldLine('  @@map("users")')).toBeUndefined()
+    expect(parseFieldLine('  // hello')).toBeUndefined()
+    expect(parseFieldLine('  /** block */')).toBeUndefined()
+  })
+})
+
+describe('extractModels (pure)', () => {
+  it('extracts multiple models with their fields + relations', () => {
+    const source = `
+      model User {
+        id    String @id @default(cuid())
+        email String @unique
+        role  Role   @relation(fields: [roleId], references: [id])
+        @@map("users")
+      }
+
+      model Role {
+        id    Int    @id @default(autoincrement())
+        name  String @unique
+        users UserRoleLink[]
+      }
+    `
+    const models = extractModels(source)
+    expect(models.map((m) => m.model)).toEqual(['User', 'Role'])
+
+    const user = models[0]
+    expect(user.fields.map((f) => f.name)).toEqual(['id', 'email', 'role'])
+    expect(user.relations).toEqual([{ field: 'role', target: 'Role' }])
+
+    const role = models[1]
+    expect(role.relations).toEqual([{ field: 'users', target: 'UserRoleLink' }])
+  })
+})
+
+describe('modelToArea (pure)', () => {
+  it('uses overrides for common auth/accounts/organizations models', () => {
+    expect(modelToArea('User')).toBe('users')
+    expect(modelToArea('Session')).toBe('auth')
+    expect(modelToArea('Account')).toBe('accounts')
+    expect(modelToArea('Invitation')).toBe('invitation')
+    expect(modelToArea('File')).toBe('storage')
+  })
+
+  it('falls back to lowercased pluralized name', () => {
+    expect(modelToArea('Widget')).toBe('widgets')
+    expect(modelToArea('Settings')).toBe('settings')
+  })
+})
+
+describe('prismaScanner.collect', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sf-srs-prisma-'))
+  })
+
+  const seedFile = (absPath: string, source: string): void => {
+    mkdirSync(dirname(absPath), { recursive: true })
+    writeFileSync(absPath, source)
+  }
+
+  it('emits entity findings for multi-file schemas', async () => {
+    seedFile(
+      join(tmp, 'api', 'prisma', 'schema', 'users.prisma'),
+      `
+      model User {
+        id    String @id
+        email String
+      }
+    `
+    )
+    seedFile(
+      join(tmp, 'api', 'prisma', 'schema', 'accounts.prisma'),
+      `
+      model Account {
+        id   String @id
+        name String
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo',
+      apiRoot: join(tmp, 'api')
+    }
+
+    const findings = (await prismaScanner.collect(context)) as EntityFinding[]
+
+    expect(findings).toHaveLength(2)
+    const byModel = Object.fromEntries(findings.map((f) => [f.model, f]))
+    expect(byModel.User.area).toBe('users')
+    expect(byModel.User.file).toBe('api/prisma/schema/users.prisma')
+    expect(byModel.Account.area).toBe('accounts')
+  })
+
+  it('parses single-file schema.prisma', async () => {
+    seedFile(
+      join(tmp, 'prisma', 'schema.prisma'),
+      `
+      model Widget {
+        id    String @id
+        label String
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'multirepo',
+      apiRoot: tmp
+    }
+
+    const findings = (await prismaScanner.collect(context)) as EntityFinding[]
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      kind: 'entity',
+      model: 'Widget',
+      area: 'widgets',
+      file: 'prisma/schema.prisma'
+    })
+    expect(findings[0].fields.map((f) => f.name)).toEqual(['id', 'label'])
+  })
+
+  it('ignores enum blocks', async () => {
+    seedFile(
+      join(tmp, 'prisma', 'schema.prisma'),
+      `
+      enum Locale {
+        EN
+        FR
+      }
+
+      model User {
+        id     String @id
+        locale Locale @default(FR)
+      }
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'multirepo',
+      apiRoot: tmp
+    }
+
+    const findings = (await prismaScanner.collect(context)) as EntityFinding[]
+    expect(findings).toHaveLength(1)
+    expect(findings[0].model).toBe('User')
+    // `locale Locale` is a non-scalar reference — treated as a relation candidate.
+    expect(findings[0].relations).toEqual([{ field: 'locale', target: 'Locale' }])
+  })
+
+  it('returns [] when no .prisma files exist', async () => {
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: [],
+      structure: 'monorepo'
+    }
+    const findings = await prismaScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+})

--- a/src/__tests__/unit/srs/scanners/tests.scanner.spec.ts
+++ b/src/__tests__/unit/srs/scanners/tests.scanner.spec.ts
@@ -2,12 +2,7 @@ import { mkdirSync, mkdtempSync, readdirSync, statSync, writeFileSync } from 'no
 import { tmpdir } from 'node:os'
 import { dirname, join, relative } from 'node:path'
 
-import {
-  extractCaseTitles,
-  extractDescribeTitles,
-  extractTestAreaFromPath,
-  testsScanner
-} from '../../../../srs/scanners/tests.scanner'
+import { extractCaseTitles, extractDescribeTitles, extractTestAreaFromPath, testsScanner } from '../../../../srs/scanners/tests.scanner'
 import { CodebaseScannerContext, TestFinding } from '../../../../srs/scanners/types'
 
 function walkSync(root: string): string[] {

--- a/src/__tests__/unit/srs/scanners/tests.scanner.spec.ts
+++ b/src/__tests__/unit/srs/scanners/tests.scanner.spec.ts
@@ -1,0 +1,143 @@
+import { mkdirSync, mkdtempSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative } from 'node:path'
+
+import {
+  extractCaseTitles,
+  extractDescribeTitles,
+  extractTestAreaFromPath,
+  testsScanner
+} from '../../../../srs/scanners/tests.scanner'
+import { CodebaseScannerContext, TestFinding } from '../../../../srs/scanners/types'
+
+function walkSync(root: string): string[] {
+  const out: string[] = []
+  const visit = (abs: string): void => {
+    for (const entry of readdirSync(abs)) {
+      const child = join(abs, entry)
+      const st = statSync(child)
+      if (st.isDirectory()) visit(child)
+      else if (st.isFile()) out.push(relative(root, child).split('\\').join('/'))
+    }
+  }
+  visit(root)
+  return out
+}
+
+describe('extractDescribeTitles (pure)', () => {
+  it('collects every describe block title', () => {
+    const source = `
+      describe('top-level', () => {
+        describe('nested', () => {
+          it('works', () => {})
+        })
+      })
+    `
+    expect(extractDescribeTitles(source)).toEqual(['top-level', 'nested'])
+  })
+})
+
+describe('extractCaseTitles (pure)', () => {
+  it('collects it() and test() titles', () => {
+    const source = `
+      describe('AuthService', () => {
+        it('signs in the user', () => {})
+        test('signs out the user', () => {})
+      })
+    `
+    expect(extractCaseTitles(source)).toEqual(['signs in the user', 'signs out the user'])
+  })
+})
+
+describe('extractTestAreaFromPath (pure)', () => {
+  it('derives area from src/modules/<area>/', () => {
+    expect(extractTestAreaFromPath('api/src/modules/auth/tests/unit/auth.service.spec.ts')).toBe('auth')
+  })
+
+  it('derives two-segment area for src/pages/<area>/<page>.spec.tsx', () => {
+    expect(extractTestAreaFromPath('web/src/pages/public/LoginPage.spec.tsx')).toBe('public/LoginPage')
+  })
+
+  it('falls back to filename stem when the path has no known marker', () => {
+    expect(extractTestAreaFromPath('tests/smoke/utils.spec.ts')).toBe('utils')
+    expect(extractTestAreaFromPath('util.e2e.ts')).toBe('util')
+  })
+})
+
+describe('testsScanner.collect', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sf-srs-tests-'))
+  })
+
+  const seedFile = (absPath: string, source: string): void => {
+    mkdirSync(dirname(absPath), { recursive: true })
+    writeFileSync(absPath, source)
+  }
+
+  it('emits a test finding per spec file with titles', async () => {
+    seedFile(
+      join(tmp, 'api', 'src', 'modules', 'auth', 'tests', 'unit', 'auth.service.spec.ts'),
+      `
+      describe('AuthService', () => {
+        it('signs in', () => {})
+        it('signs out', () => {})
+      })
+    `
+    )
+    seedFile(
+      join(tmp, 'api', 'src', 'modules', 'auth', 'tests', 'e2e', 'signin.e2e.ts'),
+      `
+      describe('POST /auth/signin', () => {
+        it('returns 200 on valid credentials', () => {})
+      })
+    `
+    )
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp),
+      structure: 'monorepo',
+      apiRoot: join(tmp, 'api')
+    }
+
+    const findings = (await testsScanner.collect(context)) as TestFinding[]
+
+    expect(findings).toHaveLength(2)
+    const specFinding = findings.find((f) => f.file.endsWith('.spec.ts'))
+    expect(specFinding).toMatchObject({
+      kind: 'test',
+      area: 'auth',
+      describe: 'AuthService',
+      cases: ['signs in', 'signs out']
+    })
+    const e2eFinding = findings.find((f) => f.file.endsWith('.e2e.ts'))
+    expect(e2eFinding).toMatchObject({
+      area: 'auth',
+      describe: 'POST /auth/signin',
+      cases: ['returns 200 on valid credentials']
+    })
+  })
+
+  it('skips spec files that declare nothing', async () => {
+    seedFile(join(tmp, 'src', 'empty.spec.ts'), `export const noop = () => {}`)
+
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: walkSync(tmp)
+    }
+
+    const findings = await testsScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+
+  it('returns [] when no spec/e2e files exist', async () => {
+    const context: CodebaseScannerContext = {
+      scanRoot: tmp,
+      files: []
+    }
+    const findings = await testsScanner.collect(context)
+    expect(findings).toEqual([])
+  })
+})

--- a/src/srs/bin/draft-from-codebase.ts
+++ b/src/srs/bin/draft-from-codebase.ts
@@ -4,9 +4,12 @@ import { join, relative, resolve } from 'node:path'
 import ignore, { Ignore } from 'ignore'
 
 import { getSrsBackend, listSrsBackends, SrsConfigError, SrsManifestSubset } from '../index'
+import { docsScanner } from '../scanners/docs.scanner'
 import { nestjsScanner } from '../scanners/nestjs.scanner'
 import { resolveScannerRoots } from '../scanners/paths'
+import { prismaScanner } from '../scanners/prisma.scanner'
 import { reactScanner } from '../scanners/react.scanner'
+import { testsScanner } from '../scanners/tests.scanner'
 import { CodebaseScanner, CodebaseScannerContext, ScannerFinding } from '../scanners/types'
 
 interface CodebaseManifest extends SrsManifestSubset {
@@ -27,7 +30,7 @@ const HARD_EXCLUDE_DIRS = new Set(['node_modules', 'dist', 'coverage', '.git', '
 const HARD_EXCLUDE_DIR_SEGMENTS = ['node_modules', 'dist', 'coverage', '.git']
 const HARD_EXCLUDE_PATH_FRAGMENTS = ['.vitepress/cache']
 
-const SCANNERS: CodebaseScanner[] = [nestjsScanner, reactScanner]
+const SCANNERS: CodebaseScanner[] = [nestjsScanner, reactScanner, prismaScanner, testsScanner, docsScanner]
 
 function parseManifest(path: string): CodebaseManifest {
   const raw = readFileSync(path, 'utf8')

--- a/src/srs/index.ts
+++ b/src/srs/index.ts
@@ -37,6 +37,8 @@ export type {
   EndpointFinding,
   UiFlowFinding,
   EntityFinding,
+  EntityField,
+  EntityRelation,
   TestFinding,
   DocContextFinding,
   CodebaseScanner,

--- a/src/srs/scanners/docs.scanner.ts
+++ b/src/srs/scanners/docs.scanner.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { CodebaseScanner, CodebaseScannerContext, DocContextFinding } from './types'
+
+const HEADING_RE = /^(#{1,3})\s+(.+?)\s*$/
+const EXCERPT_CAP = 280
+
+function normalizeRel(path: string): string {
+  return path.split('\\').join('/')
+}
+
+function stripFrontmatter(content: string): string {
+  if (!content.startsWith('---')) return content
+  const end = content.indexOf('\n---', 3)
+  if (end === -1) return content
+  return content.slice(end + 4)
+}
+
+export function slugify(heading: string): string {
+  return heading
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 4)
+    .join('-')
+}
+
+export interface DocHeading {
+  level: 1 | 2 | 3
+  heading: string
+  excerpt: string
+}
+
+export function extractHeadings(content: string): DocHeading[] {
+  const body = stripFrontmatter(content)
+  const lines = body.split('\n')
+  const out: DocHeading[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const headingMatch = lines[i].match(HEADING_RE)
+    if (!headingMatch) continue
+    const level = headingMatch[1].length as 1 | 2 | 3
+    const heading = headingMatch[2].trim()
+
+    // Skip leading blanks, gather the first non-blank paragraph.
+    let cursor = i + 1
+    while (cursor < lines.length && lines[cursor].trim() === '') cursor++
+    const excerptLines: string[] = []
+    while (cursor < lines.length) {
+      const cur = lines[cursor]
+      if (cur.trim() === '') break
+      if (HEADING_RE.test(cur)) break
+      excerptLines.push(cur.trim())
+      cursor++
+    }
+    const excerpt = excerptLines.join(' ').slice(0, EXCERPT_CAP)
+    out.push({ level, heading, excerpt })
+  }
+
+  return out
+}
+
+const DOC_FILE_GLOBS: RegExp[] = [/^README\.md$/i, /^CLAUDE\.md$/, /\/README\.md$/i, /\/CLAUDE\.md$/, /^docs\//, /\/docs\//]
+
+function isDocFile(relPath: string): boolean {
+  const norm = normalizeRel(relPath)
+  if (!norm.endsWith('.md')) return false
+  return DOC_FILE_GLOBS.some((re) => re.test(norm))
+}
+
+export const docsScanner: CodebaseScanner = {
+  id: 'docs',
+  describe: 'Markdown docs (README/CLAUDE/docs) → doc-context findings (regex-based)',
+  async collect(context: CodebaseScannerContext): Promise<DocContextFinding[]> {
+    const docFiles = context.files.filter(isDocFile)
+
+    const findings: DocContextFinding[] = []
+    for (const relFile of docFiles) {
+      const abs = join(context.scanRoot, relFile)
+      let content: string
+      try {
+        content = readFileSync(abs, 'utf8')
+      } catch {
+        continue
+      }
+      for (const h of extractHeadings(content)) {
+        const area = slugify(h.heading) || 'doc'
+        findings.push({
+          kind: 'doc-context',
+          title: h.heading,
+          area,
+          file: normalizeRel(relFile),
+          heading: h.heading,
+          headingLevel: h.level,
+          excerpt: h.excerpt
+        })
+      }
+    }
+    return findings
+  }
+}

--- a/src/srs/scanners/prisma.scanner.ts
+++ b/src/srs/scanners/prisma.scanner.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { CodebaseScanner, CodebaseScannerContext, EntityField, EntityFinding, EntityRelation } from './types'
+
+const MODEL_BLOCK_RE = /model\s+(\w+)\s*\{([^}]*)\}/gs
+const FIELD_LINE_RE = /^\s*(\w+)\s+([A-Za-z_][\w[\]?]*)/
+
+function normalizeRel(path: string): string {
+  return path.split('\\').join('/')
+}
+
+interface ParsedField {
+  field: EntityField
+  relationTarget?: string
+}
+
+export function parseFieldLine(rawLine: string): ParsedField | undefined {
+  const withoutComment = rawLine.replace(/\/\/.*$/, '')
+  const trimmed = withoutComment.trim()
+  if (trimmed.length === 0) return undefined
+  if (trimmed.startsWith('@@')) return undefined
+  if (trimmed.startsWith('/') || trimmed.startsWith('*')) return undefined
+
+  const match = withoutComment.match(FIELD_LINE_RE)
+  if (!match) return undefined
+
+  const [, name, rawType] = match
+  const optional = rawType.endsWith('?')
+  const isList = rawType.endsWith('[]')
+  const baseType = rawType.replace(/[?[\]]+$/g, '')
+
+  const attrs = withoutComment.slice(match[0].length)
+  const isId = /@id\b/.test(attrs)
+  const hasRelation = /@relation\b/.test(attrs)
+
+  const field: EntityField = {
+    name,
+    type: isList ? `${baseType}[]` : baseType,
+    optional,
+    isId
+  }
+  if (!field.optional) delete field.optional
+  if (!field.isId) delete field.isId
+
+  // A line is a relation when it carries @relation, OR when its type is not
+  // a scalar/enum but a model reference. We approximate the latter by "starts
+  // with uppercase and is not a known scalar".
+  const SCALARS = new Set(['String', 'Int', 'BigInt', 'Float', 'Decimal', 'Boolean', 'DateTime', 'Json', 'Bytes'])
+  const looksLikeModelRef = /^[A-Z]/.test(baseType) && !SCALARS.has(baseType)
+  const relationTarget = hasRelation || looksLikeModelRef ? baseType : undefined
+
+  return { field, relationTarget }
+}
+
+export function parseModel(name: string, body: string): { fields: EntityField[]; relations: EntityRelation[] } {
+  const fields: EntityField[] = []
+  const relations: EntityRelation[] = []
+  for (const rawLine of body.split('\n')) {
+    const parsed = parseFieldLine(rawLine)
+    if (!parsed) continue
+    fields.push(parsed.field)
+    if (parsed.relationTarget) {
+      relations.push({ field: parsed.field.name, target: parsed.relationTarget })
+    }
+  }
+  void name
+  return { fields, relations }
+}
+
+export function extractModels(content: string): { model: string; fields: EntityField[]; relations: EntityRelation[] }[] {
+  const out: { model: string; fields: EntityField[]; relations: EntityRelation[] }[] = []
+  for (const match of content.matchAll(MODEL_BLOCK_RE)) {
+    const [, modelName, body] = match
+    const { fields, relations } = parseModel(modelName, body)
+    out.push({ model: modelName, fields, relations })
+  }
+  return out
+}
+
+const MODEL_AREA_OVERRIDES: Record<string, string> = {
+  People: 'users',
+  User: 'users',
+  UserToken: 'auth',
+  UserPreference: 'users',
+  UserRoleLink: 'auth',
+  UserAccountLink: 'accounts',
+  UserEntityLink: 'organizations',
+  Session: 'auth',
+  Token: 'auth',
+  Role: 'auth',
+  RoleModuleLink: 'auth',
+  RolePermissionLink: 'auth',
+  Permission: 'auth',
+  Module: 'auth',
+  Account: 'accounts',
+  AccountStatus: 'accounts',
+  PeopleAccountLink: 'accounts',
+  Entity: 'organizations',
+  Organization: 'organizations',
+  PeopleEntityLink: 'organizations',
+  EntityRoleLink: 'organizations',
+  Invitation: 'invitation',
+  InvitationRoleLink: 'invitation',
+  File: 'storage',
+  Asset: 'storage',
+  Media: 'storage',
+  Event: 'analytics',
+  AnalyticsEvent: 'analytics'
+}
+
+export function modelToArea(model: string): string {
+  if (MODEL_AREA_OVERRIDES[model]) return MODEL_AREA_OVERRIDES[model]
+  const lower = model[0].toLowerCase() + model.slice(1)
+  return `${lower}s`.replace(/s{2,}$/, 's')
+}
+
+export const prismaScanner: CodebaseScanner = {
+  id: 'prisma',
+  describe: 'Prisma schema → entity findings (regex-based)',
+  async collect(context: CodebaseScannerContext): Promise<EntityFinding[]> {
+    const schemaFiles = context.files.filter((f) => {
+      const norm = normalizeRel(f)
+      return norm.endsWith('.prisma')
+    })
+
+    const findings: EntityFinding[] = []
+    for (const relFile of schemaFiles) {
+      const abs = join(context.scanRoot, relFile)
+      let content: string
+      try {
+        content = readFileSync(abs, 'utf8')
+      } catch {
+        continue
+      }
+      for (const model of extractModels(content)) {
+        findings.push({
+          kind: 'entity',
+          title: `${model.model} (${modelToArea(model.model)})`,
+          area: modelToArea(model.model),
+          file: normalizeRel(relFile),
+          model: model.model,
+          fields: model.fields,
+          relations: model.relations
+        })
+      }
+    }
+    return findings
+  }
+}

--- a/src/srs/scanners/tests.scanner.ts
+++ b/src/srs/scanners/tests.scanner.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { CodebaseScanner, CodebaseScannerContext, TestFinding } from './types'
+
+const DESCRIBE_RE = /\bdescribe\s*\(\s*['"`]([^'"`]+)['"`]/g
+const CASE_RE = /\b(?:it|test)\s*\(\s*['"`]([^'"`]+)['"`]/g
+const FILE_STEM_RE = /([^/]+?)(?:\.(?:e2e|spec)\.tsx?$)/
+
+function normalizeRel(path: string): string {
+  return path.split('\\').join('/')
+}
+
+export function extractDescribeTitles(content: string): string[] {
+  const out: string[] = []
+  for (const match of content.matchAll(DESCRIBE_RE)) out.push(match[1])
+  return out
+}
+
+export function extractCaseTitles(content: string): string[] {
+  const out: string[] = []
+  for (const match of content.matchAll(CASE_RE)) out.push(match[1])
+  return out
+}
+
+export function extractTestAreaFromPath(relPath: string): string {
+  const norm = normalizeRel(relPath)
+  const modulesMarker = 'src/modules/'
+  const pagesMarker = 'src/pages/'
+  const mIdx = norm.indexOf(modulesMarker)
+  if (mIdx !== -1) {
+    const after = norm.slice(mIdx + modulesMarker.length)
+    const first = after.split('/')[0]
+    if (first) return first
+  }
+  const pIdx = norm.indexOf(pagesMarker)
+  if (pIdx !== -1) {
+    const after = norm.slice(pIdx + pagesMarker.length)
+    const segments = after.split('/').filter(Boolean)
+    if (segments.length >= 2) return `${segments[0]}/${segments[1].replace(/\.(spec|test|e2e)\.tsx?$/, '')}`
+    if (segments.length === 1) return segments[0].replace(/\.(spec|test|e2e)\.tsx?$/, '')
+  }
+  const stem = norm.match(FILE_STEM_RE)
+  return stem ? stem[1] : 'unknown'
+}
+
+export const testsScanner: CodebaseScanner = {
+  id: 'tests',
+  describe: 'Jest/Vitest spec files → test findings (regex-based)',
+  async collect(context: CodebaseScannerContext): Promise<TestFinding[]> {
+    const specFiles = context.files.filter((f) => {
+      const norm = normalizeRel(f)
+      return /\.(?:spec|e2e)\.tsx?$/.test(norm)
+    })
+
+    const findings: TestFinding[] = []
+    for (const relFile of specFiles) {
+      const abs = join(context.scanRoot, relFile)
+      let content: string
+      try {
+        content = readFileSync(abs, 'utf8')
+      } catch {
+        continue
+      }
+      const describes = extractDescribeTitles(content)
+      const cases = extractCaseTitles(content)
+      if (describes.length === 0 && cases.length === 0) continue
+
+      const area = extractTestAreaFromPath(relFile)
+      const describe = describes[0] ?? area
+      findings.push({
+        kind: 'test',
+        title: `${describe} (${area})`,
+        area,
+        file: normalizeRel(relFile),
+        describe,
+        cases
+      })
+    }
+    return findings
+  }
+}

--- a/src/srs/scanners/types.ts
+++ b/src/srs/scanners/types.ts
@@ -25,19 +25,42 @@ export interface UiFlowFinding extends BaseScannerFinding {
   linkedEndpointGuess?: string
 }
 
+export interface EntityField {
+  name: string
+  type: string
+  optional?: boolean
+  isId?: boolean
+}
+
+export interface EntityRelation {
+  field: string
+  target: string
+}
+
 export interface EntityFinding extends BaseScannerFinding {
   kind: 'entity'
-  sourceFiles: string[]
+  area: string
+  file: string
+  model: string
+  fields: EntityField[]
+  relations: EntityRelation[]
 }
 
 export interface TestFinding extends BaseScannerFinding {
   kind: 'test'
-  sourceFiles: string[]
+  area: string
+  file: string
+  describe: string
+  cases: string[]
 }
 
 export interface DocContextFinding extends BaseScannerFinding {
   kind: 'doc-context'
-  sourceFiles: string[]
+  area: string
+  file: string
+  heading: string
+  headingLevel: 1 | 2 | 3
+  excerpt: string
 }
 
 export type ScannerFinding = EndpointFinding | UiFlowFinding | EntityFinding | TestFinding | DocContextFinding


### PR DESCRIPTION
Closes #209

## Summary

- **Prisma scanner** (`src/srs/scanners/prisma.scanner.ts`) — walks `api/prisma/schema/**/*.prisma` + single-file `schema.prisma`, regex-extracts `model X { ... }` blocks with fields / types / relations (explicit `@relation` + PascalCase-field inference), emits `{ kind: 'entity', area, file, model, fields, relations }`. Area mapping heuristic: `User → users`, `Session → auth`, `File → storage`, `Event → analytics`, enum blocks ignored.
- **Tests scanner** (`src/srs/scanners/tests.scanner.ts`) — walks `**/*.spec.{ts,tsx}` + `**/*.e2e.ts`, regex-extracts first `describe(...)` + every `it(...)` / `test(...)` title, emits `{ kind: 'test', area, file, describe, cases[] }`. One finding per file; `cases[]` is the payload.
- **Docs scanner** (`src/srs/scanners/docs.scanner.ts`) — walks `README.md`, `CLAUDE.md` (root + `api/` + `web/`), `docs/**/*.md`. Strips YAML frontmatter, extracts H1/H2/H3 headings + first non-blank paragraph (capped at 280 chars), emits `{ kind: 'doc-context', area, file, heading, headingLevel, excerpt }`. H4+ ignored.
- All three scanners registered with the orchestrator. Pipeline order is deterministic: nestjs → react → prisma → tests → docs.

## Test plan

- [x] Prisma scanner unit-tested against multi-file + single-file fixtures
- [x] Tests scanner unit-tested against unit + e2e fixtures (NestJS + React style)
- [x] Docs scanner unit-tested against README / CLAUDE / nested docs fixtures
- [x] Full pipeline (SUB-13.1 + 13.2 + 13.3) produces coherent findings across all 5 scanners with no duplicates

## Tests added

- `src/__tests__/unit/srs/scanners/prisma.scanner.spec.ts`
- `src/__tests__/unit/srs/scanners/tests.scanner.spec.ts`
- `src/__tests__/unit/srs/scanners/docs.scanner.spec.ts`
- `src/__tests__/fixtures/audit/prisma-minimal/`
- `src/__tests__/fixtures/audit/tests-minimal/`
- `src/__tests__/fixtures/audit/docs-minimal/`