### PR TITLE
feat(#223): Epic & FR templates refonte — match design spec

### DIFF
--- a/.claude/skills/sf-srs/templates/pages/README.md
+++ b/.claude/skills/sf-srs/templates/pages/README.md
@@ -32,27 +32,32 @@ type PageBlock =
 
 ## Epic page sections
 
-Produced by `renderEpicPage(spec)` in this order:
+Produced by `renderEpicPage(spec)` in this order (DIAMONFORGE-style):
 
-1. `Overview` (H1) + business value paragraph
-2. `Scope` (H2) + scope paragraph (omitted when absent)
-3. Divider
-4. `Requirement Types` (H2) + table `[UR, FR, DS, TC]` with counts
-5. `Traceability` (H2) + table `[FR, UR refs, DS refs, TC refs]`
-6. Divider
-7. `User Requirements (UR)` (H2) + bulleted list
-8. Divider
-9. `Functional Requirements (FR)` (H2) + per-FR detail blocks (H3 + description + acceptance criteria list + refs paragraph)
+1. `Traceability` (H2) + plain-text code block (ASCII tree `UR → FR → DS → TC`) + explanatory paragraph
+2. `Requirement Types` (H2) + definitions table `Prefix | Type | Description | Example` with one row per UR/FR/DS/NFR
+3. `User Requirements (UR)` (H2) + table `ID | Requirement | Priority | Related FR`, with group-header rows when items carry a `group`
+4. `Functional Requirements (FR)` (H2) + table `ID | Requirement | Priority | Related UR | Related DS`, grouped
+5. `Design Specifications (DS)` (H2) + table `ID | Specification | Related FR`, grouped
+6. `Non-Functional Requirements (NFR)` (H2) + table `ID | Requirement | Target | Priority | Related FR`, grouped
+
+Empty sections emit a placeholder paragraph (e.g. `No user requirements yet.`) instead of the table. Missing optional fields render as the em-dash cell `—`. Group headers appear as a single-cell row
+carrying the group id followed by empty cells matching the table arity.
 
 ## FR page sections
 
-Produced by `renderFrPage(spec)` in this order:
+Produced by `renderFrPage(spec)` in this order (DIAMONFORGE-style):
 
-1. `{FR-id} — {title}` (H1) + description paragraph
-2. `User Requirements` (H2) + bulleted list (placeholder when empty)
-3. `Acceptance Criteria` (H2) + bulleted list (placeholder when empty)
-4. `Design (DS)` (H2) + bulleted list (placeholder when empty)
-5. `Test Cases (TC)` (H2) + bulleted list (placeholder when empty)
+1. `Summary` (H2) + table `ID | Requirement | Priority | Related UR | Related DS` — one row per FR item on the page
+2. Divider
+3. Per FR item: `{FR-id} — {title}` (H2) + vertical detail table `Field | Value` with canonical rows (in order): `ID`, `Title`, `Endpoint`, `Priority`, `Related UR`, `Related DS`, `Description`,
+   `Request Body`, `Acceptance Criteria`, `Validation Rules`, `Security Rationale`
+4. Divider **between** items (not after the last item)
+
+List-typed fields (`acceptanceCriteria`, `validationRules`) render as newline-joined `• item` entries within a single cell — Notion preserves newlines in table cells. Missing optional fields render as
+`—`. The page title is `{FR-id} — {title}` of `spec.fr`.
+
+`FrSpec.fr` is currently singular (one FR per page); the template wraps it as `[spec.fr]` internally so a future type extension to multi-FR pages is a single-line change.
 
 ## Adding a new backend
 

--- a/scaffolds/skills-templates/sf-srs/templates/pages/README.md
+++ b/scaffolds/skills-templates/sf-srs/templates/pages/README.md
@@ -32,27 +32,32 @@ type PageBlock =
 
 ## Epic page sections
 
-Produced by `renderEpicPage(spec)` in this order:
+Produced by `renderEpicPage(spec)` in this order (DIAMONFORGE-style):
 
-1. `Overview` (H1) + business value paragraph
-2. `Scope` (H2) + scope paragraph (omitted when absent)
-3. Divider
-4. `Requirement Types` (H2) + table `[UR, FR, DS, TC]` with counts
-5. `Traceability` (H2) + table `[FR, UR refs, DS refs, TC refs]`
-6. Divider
-7. `User Requirements (UR)` (H2) + bulleted list
-8. Divider
-9. `Functional Requirements (FR)` (H2) + per-FR detail blocks (H3 + description + acceptance criteria list + refs paragraph)
+1. `Traceability` (H2) + plain-text code block (ASCII tree `UR → FR → DS → TC`) + explanatory paragraph
+2. `Requirement Types` (H2) + definitions table `Prefix | Type | Description | Example` with one row per UR/FR/DS/NFR
+3. `User Requirements (UR)` (H2) + table `ID | Requirement | Priority | Related FR`, with group-header rows when items carry a `group`
+4. `Functional Requirements (FR)` (H2) + table `ID | Requirement | Priority | Related UR | Related DS`, grouped
+5. `Design Specifications (DS)` (H2) + table `ID | Specification | Related FR`, grouped
+6. `Non-Functional Requirements (NFR)` (H2) + table `ID | Requirement | Target | Priority | Related FR`, grouped
+
+Empty sections emit a placeholder paragraph (e.g. `No user requirements yet.`) instead of the table. Missing optional fields render as the em-dash cell `—`. Group headers appear as a single-cell row
+carrying the group id followed by empty cells matching the table arity.
 
 ## FR page sections
 
-Produced by `renderFrPage(spec)` in this order:
+Produced by `renderFrPage(spec)` in this order (DIAMONFORGE-style):
 
-1. `{FR-id} — {title}` (H1) + description paragraph
-2. `User Requirements` (H2) + bulleted list (placeholder when empty)
-3. `Acceptance Criteria` (H2) + bulleted list (placeholder when empty)
-4. `Design (DS)` (H2) + bulleted list (placeholder when empty)
-5. `Test Cases (TC)` (H2) + bulleted list (placeholder when empty)
+1. `Summary` (H2) + table `ID | Requirement | Priority | Related UR | Related DS` — one row per FR item on the page
+2. Divider
+3. Per FR item: `{FR-id} — {title}` (H2) + vertical detail table `Field | Value` with canonical rows (in order): `ID`, `Title`, `Endpoint`, `Priority`, `Related UR`, `Related DS`, `Description`,
+   `Request Body`, `Acceptance Criteria`, `Validation Rules`, `Security Rationale`
+4. Divider **between** items (not after the last item)
+
+List-typed fields (`acceptanceCriteria`, `validationRules`) render as newline-joined `• item` entries within a single cell — Notion preserves newlines in table cells. Missing optional fields render as
+`—`. The page title is `{FR-id} — {title}` of `spec.fr`.
+
+`FrSpec.fr` is currently singular (one FR per page); the template wraps it as `[spec.fr]` internally so a future type extension to multi-FR pages is a single-line change.
 
 ## Adding a new backend
 

--- a/src/__tests__/integration/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/integration/tools/notion/srs.adapter.spec.ts
@@ -89,7 +89,9 @@ describeIntegration('NotionSrsAdapter (integration, sandbox)', () => {
     // 5 tables: Requirement Types + UR + FR + DS + NFR
     expect(tables).toHaveLength(5)
     const headings = raw.blocks.filter((b) => b.kind === 'heading').map((b) => b.text)
-    expect(headings).toEqual(expect.arrayContaining(['Traceability', 'Requirement Types', 'User Requirements (UR)', 'Functional Requirements (FR)', 'Design Specifications (DS)', 'Non-Functional Requirements (NFR)']))
+    expect(headings).toEqual(
+      expect.arrayContaining(['Traceability', 'Requirement Types', 'User Requirements (UR)', 'Functional Requirements (FR)', 'Design Specifications (DS)', 'Non-Functional Requirements (NFR)'])
+    )
 
     const children = await adapter.listChildren(epic.id)
     const childIds = children.map((c) => c.id)

--- a/src/__tests__/integration/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/integration/tools/notion/srs.adapter.spec.ts
@@ -38,16 +38,19 @@ describeIntegration('NotionSrsAdapter (integration, sandbox)', () => {
       parentPageId: sandboxParentPageId,
       businessValue: 'Automated sandbox run — safe to archive.',
       scope: 'Exercises create → fetch → list → update → archive path.',
-      urs: [{ id: 'UR-1', narrative: 'Adapter is callable against a live workspace.' }],
+      urs: [{ id: 'UR-1', narrative: 'Adapter is callable against a live workspace.', group: 'Adapter smoke' }],
       frs: [
         {
           id: 'FR-1',
           title: 'Live create + list',
           description: 'Confirms the Notion Create + Children Read flow.',
           acceptanceCriteria: ['FR page appears under the parent Epic.'],
-          urRefs: ['UR-1']
+          urRefs: ['UR-1'],
+          group: 'Adapter smoke'
         }
-      ]
+      ],
+      dsItems: [{ id: 'DS-1', title: 'Use Notion REST API', frRefs: ['FR-1'], group: 'Adapter smoke' }],
+      nfrItems: [{ id: 'NFR-1', title: 'Round-trip latency', target: 'create+fetch ≤ 10s in CI', priority: 'P2', frRefs: ['FR-1'] }]
     }
   })
 
@@ -81,9 +84,23 @@ describeIntegration('NotionSrsAdapter (integration, sandbox)', () => {
     expect(raw.title).toBe(epicSpec.title)
     expect(raw.blocks.length).toBeGreaterThan(0)
 
+    // Structural assertions on the rendered DIAMONFORGE shape (table count, NFR section, headings)
+    const tables = raw.blocks.filter((b) => b.kind === 'table')
+    // 5 tables: Requirement Types + UR + FR + DS + NFR
+    expect(tables).toHaveLength(5)
+    const headings = raw.blocks.filter((b) => b.kind === 'heading').map((b) => b.text)
+    expect(headings).toEqual(expect.arrayContaining(['Traceability', 'Requirement Types', 'User Requirements (UR)', 'Functional Requirements (FR)', 'Design Specifications (DS)', 'Non-Functional Requirements (NFR)']))
+
     const children = await adapter.listChildren(epic.id)
     const childIds = children.map((c) => c.id)
     expect(childIds).toContain(fr.id)
+
+    // FR page also rendered with the new shape: Summary + per-item detail (2 tables expected)
+    const frRaw = await adapter.fetchPage(fr.id)
+    const frTables = frRaw.blocks.filter((b) => b.kind === 'table')
+    expect(frTables).toHaveLength(2)
+    const frHeadings = frRaw.blocks.filter((b) => b.kind === 'heading').map((b) => b.text)
+    expect(frHeadings).toEqual(expect.arrayContaining(['Summary', 'FR-1 — Live create + list']))
 
     await adapter.updatePage(epic.id, {
       title: 'Integration test update',

--- a/src/__tests__/unit/runners/srs.runner.spec.ts
+++ b/src/__tests__/unit/runners/srs.runner.spec.ts
@@ -63,18 +63,18 @@ describe('bootstrapSrs', () => {
     expect(adapter.initCalls).toBe(1)
     expect(adapter.resolveCalls).toEqual(['https://notion.so/parent'])
     expect(adapter.createCalls).toEqual([
-      { parentPageId: 'resolved_parent_id', title: 'acme — Project Overview', hasContent: false },
-      { parentPageId: 'resolved_parent_id__acme_—_Project_Overview', title: 'User flows & Specifications', hasContent: false }
+      { parentPageId: 'resolved_parent_id', title: 'acme-srs', hasContent: false },
+      { parentPageId: 'resolved_parent_id__acme-srs', title: 'User flows & Specifications', hasContent: false }
     ])
 
     expect(result.rootPage).toEqual({
-      id: 'resolved_parent_id__acme_—_Project_Overview',
-      url: 'https://notion.so/resolved_parent_id__acme_—_Project_Overview',
-      name: 'acme — Project Overview'
+      id: 'resolved_parent_id__acme-srs',
+      url: 'https://notion.so/resolved_parent_id__acme-srs',
+      name: 'acme-srs'
     })
     expect(result.categoryPage).toEqual({
-      id: 'resolved_parent_id__acme_—_Project_Overview__User_flows_&_Specifications',
-      url: 'https://notion.so/resolved_parent_id__acme_—_Project_Overview__User_flows_&_Specifications',
+      id: 'resolved_parent_id__acme-srs__User_flows_&_Specifications',
+      url: 'https://notion.so/resolved_parent_id__acme-srs__User_flows_&_Specifications',
       name: 'User flows & Specifications'
     })
   })
@@ -88,7 +88,7 @@ describe('bootstrapSrs', () => {
 
     const [rootCall, categoryCall] = adapter.createCalls
     expect(rootCall.parentPageId).toBe('resolved_parent_id')
-    expect(categoryCall.parentPageId).toBe('id-demo — Project Overview')
+    expect(categoryCall.parentPageId).toBe('id-demo-srs')
   })
 
   it('propagates errors from resolveParent without calling createPage', async () => {

--- a/src/__tests__/unit/srs/templates/epic.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/epic.tpl.spec.ts
@@ -16,100 +16,195 @@ function findTableAfterHeading(blocks: PageBlock[], headingText: string): TableB
   throw new Error(`table after heading "${headingText}" not found`)
 }
 
-describe('renderEpicPage', () => {
-  it('emits the title and the full section scaffold for a rich EpicSpec', () => {
+function findParagraphAfterHeading(blocks: PageBlock[], headingText: string): string {
+  for (let i = 0; i < blocks.length - 1; i++) {
+    const current = blocks[i]
+    const next = blocks[i + 1]
+    if (current.kind === 'heading' && current.text === headingText && next.kind === 'paragraph') {
+      return next.text
+    }
+  }
+  throw new Error(`paragraph after heading "${headingText}" not found`)
+}
+
+describe('renderEpicPage — DIAMONFORGE-style structure', () => {
+  it('emits the spec-sections scaffold in order', () => {
     const spec: EpicSpec = {
-      title: 'User authentication',
-      parentPageId: 'parent',
-      businessValue: 'Users can sign in securely.',
-      scope: 'Email + password auth, no SSO.',
-      urs: [{ id: 'UR-1', narrative: 'sign in with email', businessValue: 'daily login' }],
-      frs: [
-        {
-          id: 'FR-1',
-          title: 'Login endpoint',
-          description: 'POST /auth/login',
-          acceptanceCriteria: ['returns 200 with valid creds', 'returns 401 with invalid creds'],
-          urRefs: ['UR-1'],
-          dsRefs: ['DS-1'],
-          tcRefs: ['TC-1']
-        }
+      title: 'Authentication',
+      parentPageId: 'p',
+      urs: [
+        { id: 'UR-AUTH-01-01', narrative: 'sign in', priority: 'P1', group: 'UR-AUTH-01' },
+        { id: 'UR-AUTH-02-01', narrative: 'reset password', priority: 'P1', group: 'UR-AUTH-02' }
       ],
-      dsItems: [{ id: 'DS-1', title: 'Login form' }],
-      tcItems: [{ id: 'TC-1', title: 'Happy path' }]
+      frs: [
+        { id: 'FR-AUTH-01-01', title: 'register', priority: 'P1', group: 'FR-AUTH-01', urRefs: ['UR-AUTH-01-01'], dsRefs: ['DS-AUTH-01'] },
+        { id: 'FR-AUTH-02-01', title: 'login', priority: 'P1', group: 'FR-AUTH-02', urRefs: ['UR-AUTH-01-01'], dsRefs: ['DS-AUTH-03'] }
+      ],
+      dsItems: [
+        { id: 'DS-AUTH-01-01', title: 'bcrypt', frRefs: ['FR-AUTH-01-01'], group: 'DS-AUTH-01' },
+        { id: 'DS-AUTH-03-01', title: 'JWT cookies', frRefs: ['FR-AUTH-02-01'], group: 'DS-AUTH-03' }
+      ],
+      nfrItems: [{ id: 'NFR-AUTH-01-01', title: 'login speed', target: '≤ 1s p95', priority: 'P1', frRefs: ['FR-AUTH-02-01'], group: 'NFR-AUTH-01' }]
     }
 
     const page = renderEpicPage(spec)
 
-    expect(page.title).toBe('User authentication')
+    expect(page.title).toBe('Authentication')
     expect(kinds(page)).toEqual([
-      'heading:1',
+      'heading:2', // Traceability
+      'code',
       'paragraph',
-      'heading:2',
-      'paragraph',
-      'divider',
-      'heading:2',
+      'heading:2', // Requirement Types
       'table',
-      'heading:2',
+      'heading:2', // UR
       'table',
-      'divider',
-      'heading:2',
-      'bulleted_list',
-      'divider',
-      'heading:2',
-      'heading:3',
-      'paragraph',
-      'paragraph',
-      'bulleted_list',
-      'paragraph'
+      'heading:2', // FR
+      'table',
+      'heading:2', // DS
+      'table',
+      'heading:2', // NFR
+      'table'
     ])
   })
 
-  it('renders the Requirement Types counts row from the spec', () => {
+  it('renders the Requirement Types table with UR/FR/DS/NFR rows', () => {
+    const spec: EpicSpec = { title: 'E', parentPageId: 'p', urs: [], frs: [] }
+    const page = renderEpicPage(spec)
+    const reqTypes = findTableAfterHeading(page.blocks, 'Requirement Types')
+    expect(reqTypes.header).toEqual(['Prefix', 'Type', 'Description', 'Example'])
+    const prefixes = reqTypes.rows.map((r) => r[0])
+    expect(prefixes).toEqual(['UR', 'FR', 'DS', 'NFR'])
+  })
+
+  it('renders the UR table with group headers and Related FR derived from spec.frs', () => {
     const spec: EpicSpec = {
-      title: 'Epic',
+      title: 'E',
       parentPageId: 'p',
-      urs: [{ id: 'UR-1', narrative: 'a' }],
-      frs: [
-        { id: 'FR-1', title: 'a' },
-        { id: 'FR-2', title: 'b' }
+      urs: [
+        { id: 'UR-X-01-01', narrative: 'a', priority: 'P1', group: 'UR-X-01' },
+        { id: 'UR-X-01-02', narrative: 'b', priority: 'P2', group: 'UR-X-01' },
+        { id: 'UR-X-02-01', narrative: 'c', priority: 'P1', group: 'UR-X-02' }
       ],
-      dsItems: [{ id: 'DS-1', title: 'x' }],
-      tcItems: []
+      frs: [
+        { id: 'FR-X-01', title: 'f1', urRefs: ['UR-X-01-01'] },
+        { id: 'FR-X-02', title: 'f2', urRefs: ['UR-X-01-01', 'UR-X-02-01'] }
+      ]
     }
-
     const page = renderEpicPage(spec)
-    const reqTypeTable = findTableAfterHeading(page.blocks, 'Requirement Types')
+    const urTable = findTableAfterHeading(page.blocks, 'User Requirements (UR)')
 
-    expect(reqTypeTable.header).toEqual(['UR', 'FR', 'DS', 'TC'])
-    expect(reqTypeTable.rows).toEqual([['1', '2', '1', '0']])
+    expect(urTable.header).toEqual(['ID', 'Requirement', 'Priority', 'Related FR'])
+    expect(urTable.rows).toEqual([
+      ['UR-X-01', '', '', ''], // group header
+      ['UR-X-01-01', 'a', 'P1', 'FR-X-01, FR-X-02'],
+      ['UR-X-01-02', 'b', 'P2', '—'],
+      ['UR-X-02', '', '', ''], // group header
+      ['UR-X-02-01', 'c', 'P1', 'FR-X-02']
+    ])
   })
 
-  it('degrades gracefully when URs/FRs are empty', () => {
-    const spec: EpicSpec = { title: 'Empty', parentPageId: 'p', urs: [], frs: [] }
-    const page = renderEpicPage(spec)
-    const paragraphs = page.blocks.filter((b) => b.kind === 'paragraph')
-    const texts = paragraphs.map((p) => ('text' in p ? p.text : ''))
-    expect(texts).toContain('No user requirements yet.')
-    expect(texts).toContain('No functional requirements yet.')
-  })
-
-  it('builds the Traceability table rows from FR refs (with em-dash for missing refs)', () => {
+  it('renders the FR table with group headers and related refs', () => {
     const spec: EpicSpec = {
       title: 'E',
       parentPageId: 'p',
       urs: [],
       frs: [
-        { id: 'FR-1', title: 'a', urRefs: ['UR-1'] },
-        { id: 'FR-2', title: 'b' }
+        { id: 'FR-X-01-01', title: 'a', priority: 'P1', group: 'FR-X-01', urRefs: ['UR-X-01-01'], dsRefs: ['DS-X-01'] },
+        { id: 'FR-X-02-01', title: 'b', group: 'FR-X-02' }
       ]
     }
     const page = renderEpicPage(spec)
-    const traceTable = findTableAfterHeading(page.blocks, 'Traceability')
-
-    expect(traceTable.rows).toEqual([
-      ['FR-1', 'UR-1', '—', '—'],
-      ['FR-2', '—', '—', '—']
+    const frTable = findTableAfterHeading(page.blocks, 'Functional Requirements (FR)')
+    expect(frTable.header).toEqual(['ID', 'Requirement', 'Priority', 'Related UR', 'Related DS'])
+    expect(frTable.rows).toEqual([
+      ['FR-X-01', '', '', '', ''],
+      ['FR-X-01-01', 'a', 'P1', 'UR-X-01-01', 'DS-X-01'],
+      ['FR-X-02', '', '', '', ''],
+      ['FR-X-02-01', 'b', '—', '—', '—']
     ])
+  })
+
+  it('renders the DS table with group headers', () => {
+    const spec: EpicSpec = {
+      title: 'E',
+      parentPageId: 'p',
+      urs: [],
+      frs: [],
+      dsItems: [
+        { id: 'DS-X-01-01', title: 'a', group: 'DS-X-01', frRefs: ['FR-X-01-01'] },
+        { id: 'DS-X-02-01', title: 'b', group: 'DS-X-02' }
+      ]
+    }
+    const page = renderEpicPage(spec)
+    const dsTable = findTableAfterHeading(page.blocks, 'Design Specifications (DS)')
+    expect(dsTable.header).toEqual(['ID', 'Specification', 'Related FR'])
+    expect(dsTable.rows).toEqual([
+      ['DS-X-01', '', ''],
+      ['DS-X-01-01', 'a', 'FR-X-01-01'],
+      ['DS-X-02', '', ''],
+      ['DS-X-02-01', 'b', '—']
+    ])
+  })
+
+  it('renders the NFR table with Target column and group headers', () => {
+    const spec: EpicSpec = {
+      title: 'E',
+      parentPageId: 'p',
+      urs: [],
+      frs: [],
+      nfrItems: [
+        { id: 'NFR-X-01-01', title: 'perf', target: '≤ 1s', priority: 'P1', group: 'NFR-X-01', frRefs: ['FR-X-01'] },
+        { id: 'NFR-X-02-01', title: 'sec', priority: 'P2', group: 'NFR-X-02' }
+      ]
+    }
+    const page = renderEpicPage(spec)
+    const nfrTable = findTableAfterHeading(page.blocks, 'Non-Functional Requirements (NFR)')
+    expect(nfrTable.header).toEqual(['ID', 'Requirement', 'Target', 'Priority', 'Related FR'])
+    expect(nfrTable.rows).toEqual([
+      ['NFR-X-01', '', '', '', ''],
+      ['NFR-X-01-01', 'perf', '≤ 1s', 'P1', 'FR-X-01'],
+      ['NFR-X-02', '', '', '', ''],
+      ['NFR-X-02-01', 'sec', '—', 'P2', '—']
+    ])
+  })
+
+  it('emits placeholder paragraphs for empty sections', () => {
+    const spec: EpicSpec = { title: 'Empty', parentPageId: 'p', urs: [], frs: [] }
+    const page = renderEpicPage(spec)
+    expect(findParagraphAfterHeading(page.blocks, 'User Requirements (UR)')).toBe('No user requirements yet.')
+    expect(findParagraphAfterHeading(page.blocks, 'Functional Requirements (FR)')).toBe('No functional requirements yet.')
+    expect(findParagraphAfterHeading(page.blocks, 'Design Specifications (DS)')).toBe('No design specifications yet.')
+    expect(findParagraphAfterHeading(page.blocks, 'Non-Functional Requirements (NFR)')).toBe('No non-functional requirements yet.')
+  })
+
+  it('emits the Traceability tree as a plain-text code block', () => {
+    const spec: EpicSpec = { title: 'E', parentPageId: 'p', urs: [], frs: [] }
+    const page = renderEpicPage(spec)
+    const traceIdx = page.blocks.findIndex((b) => b.kind === 'heading' && b.text === 'Traceability')
+    const codeBlock = page.blocks[traceIdx + 1]
+    expect(codeBlock.kind).toBe('code')
+    if (codeBlock.kind === 'code') {
+      expect(codeBlock.language).toBe('plain text')
+      expect(codeBlock.text).toContain('UR (User Requirement)')
+      expect(codeBlock.text).toContain('FR (Functional Requirement)')
+      expect(codeBlock.text).toContain('DS (Design Specification)')
+      expect(codeBlock.text).toContain('TC (Test Case)')
+    }
+  })
+
+  it('handles ungrouped items without emitting group header rows', () => {
+    const spec: EpicSpec = {
+      title: 'E',
+      parentPageId: 'p',
+      urs: [{ id: 'UR-1', narrative: 'a', priority: 'P1' }],
+      frs: [{ id: 'FR-1', title: 'b', priority: 'P1' }]
+    }
+    const page = renderEpicPage(spec)
+    const urTable = findTableAfterHeading(page.blocks, 'User Requirements (UR)')
+    const frTable = findTableAfterHeading(page.blocks, 'Functional Requirements (FR)')
+    expect(urTable.rows).toHaveLength(1)
+    expect(urTable.rows[0][0]).toBe('UR-1')
+    expect(frTable.rows).toHaveLength(1)
+    expect(frTable.rows[0][0]).toBe('FR-1')
   })
 })

--- a/src/__tests__/unit/srs/templates/fr.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/fr.tpl.spec.ts
@@ -1,48 +1,119 @@
 import { renderFrPage } from '../../../../builders/srs/templates/pages/fr.tpl'
-import { FrSpec } from '../../../../builders/srs/types'
+import { FrSpec, PageBlock, TableBlock } from '../../../../builders/srs/types'
 
-describe('renderFrPage', () => {
+function findTableAfterHeading(blocks: PageBlock[], headingText: string): TableBlock {
+  for (let i = 0; i < blocks.length - 1; i++) {
+    const current = blocks[i]
+    const next = blocks[i + 1]
+    if (current.kind === 'heading' && current.text === headingText && next.kind === 'table') {
+      return next
+    }
+  }
+  throw new Error(`table after heading "${headingText}" not found`)
+}
+
+describe('renderFrPage — DIAMONFORGE-style structure', () => {
   it('uses "ID — Title" as the page title', () => {
-    const spec: FrSpec = { parentEpicPageId: 'epic', fr: { id: 'FR-1', title: 'Login endpoint' } }
+    const spec: FrSpec = { parentEpicPageId: 'epic', fr: { id: 'FR-AUTH-01-01', title: 'Sign in' } }
     const page = renderFrPage(spec)
-    expect(page.title).toBe('FR-1 — Login endpoint')
+    expect(page.title).toBe('FR-AUTH-01-01 — Sign in')
   })
 
-  it('emits each section with its heading + placeholder paragraph when empty', () => {
-    const spec: FrSpec = { parentEpicPageId: 'epic', fr: { id: 'FR-1', title: 'empty FR' } }
+  it('emits Summary + divider + per-item detail in order', () => {
+    const spec: FrSpec = {
+      parentEpicPageId: 'epic',
+      fr: { id: 'FR-AUTH-01-01', title: 'Sign in' }
+    }
     const page = renderFrPage(spec)
-
-    const headings = page.blocks.filter((b) => b.kind === 'heading').map((b) => ('text' in b ? b.text : ''))
-    expect(headings).toEqual(['FR-1 — empty FR', 'User Requirements', 'Acceptance Criteria', 'Design (DS)', 'Test Cases (TC)'])
-
-    const placeholders = page.blocks.filter((b) => b.kind === 'paragraph').map((b) => ('text' in b ? b.text : ''))
-    expect(placeholders).toEqual(['No linked user requirements.', 'No acceptance criteria yet.', 'No design items yet.', 'No test cases yet.'])
+    const kinds = page.blocks.map((b) => (b.kind === 'heading' ? `heading:${b.level}:${b.text}` : b.kind))
+    expect(kinds).toEqual(['heading:2:Summary', 'table', 'divider', 'heading:2:FR-AUTH-01-01 — Sign in', 'table'])
   })
 
-  it('renders bulleted lists when sections have content', () => {
+  it('renders the Summary table with the 5 canonical columns', () => {
+    const spec: FrSpec = {
+      parentEpicPageId: 'epic',
+      fr: {
+        id: 'FR-AUTH-01-01',
+        title: 'Sign in',
+        priority: 'P1',
+        urRefs: ['UR-AUTH-01-01'],
+        dsRefs: ['DS-AUTH-01-01', 'DS-AUTH-01-02']
+      }
+    }
+    const page = renderFrPage(spec)
+    const summary = findTableAfterHeading(page.blocks, 'Summary')
+    expect(summary.header).toEqual(['ID', 'Requirement', 'Priority', 'Related UR', 'Related DS'])
+    expect(summary.rows).toEqual([['FR-AUTH-01-01', 'Sign in', 'P1', 'UR-AUTH-01-01', 'DS-AUTH-01-01, DS-AUTH-01-02']])
+  })
+
+  it('renders a vertical detail table with all 11 canonical rows', () => {
+    const spec: FrSpec = {
+      parentEpicPageId: 'epic',
+      fr: {
+        id: 'FR-AUTH-01-01',
+        title: 'Sign in',
+        description: 'Authenticate user via email + password',
+        endpoint: 'POST /auth/signin',
+        priority: 'P1',
+        urRefs: ['UR-AUTH-01-01'],
+        dsRefs: ['DS-AUTH-01-01'],
+        requestBody: '{ email, password }',
+        acceptanceCriteria: ['returns 200 on success', 'returns 401 on invalid credentials'],
+        validationRules: ['email required', 'password min 8 chars'],
+        securityRationale: 'Prevents user enumeration'
+      }
+    }
+    const page = renderFrPage(spec)
+    const detail = findTableAfterHeading(page.blocks, 'FR-AUTH-01-01 — Sign in')
+    expect(detail.header).toEqual(['Field', 'Value'])
+    expect(detail.rows).toEqual([
+      ['ID', 'FR-AUTH-01-01'],
+      ['Title', 'Sign in'],
+      ['Endpoint', 'POST /auth/signin'],
+      ['Priority', 'P1'],
+      ['Related UR', 'UR-AUTH-01-01'],
+      ['Related DS', 'DS-AUTH-01-01'],
+      ['Description', 'Authenticate user via email + password'],
+      ['Request Body', '{ email, password }'],
+      ['Acceptance Criteria', '• returns 200 on success\n• returns 401 on invalid credentials'],
+      ['Validation Rules', '• email required\n• password min 8 chars'],
+      ['Security Rationale', 'Prevents user enumeration']
+    ])
+  })
+
+  it('fills missing fields with the em-dash placeholder', () => {
+    const spec: FrSpec = { parentEpicPageId: 'epic', fr: { id: 'FR-1', title: 'Minimal' } }
+    const page = renderFrPage(spec)
+    const summary = findTableAfterHeading(page.blocks, 'Summary')
+    expect(summary.rows).toEqual([['FR-1', 'Minimal', '—', '—', '—']])
+
+    const detail = findTableAfterHeading(page.blocks, 'FR-1 — Minimal')
+    const cellFor = (label: string) => detail.rows.find((row) => row[0] === label)?.[1]
+    expect(cellFor('Endpoint')).toBe('—')
+    expect(cellFor('Priority')).toBe('—')
+    expect(cellFor('Related UR')).toBe('—')
+    expect(cellFor('Related DS')).toBe('—')
+    expect(cellFor('Description')).toBe('—')
+    expect(cellFor('Request Body')).toBe('—')
+    expect(cellFor('Acceptance Criteria')).toBe('—')
+    expect(cellFor('Validation Rules')).toBe('—')
+    expect(cellFor('Security Rationale')).toBe('—')
+  })
+
+  it('renders multi-line list cells with bullet prefix and newlines', () => {
     const spec: FrSpec = {
       parentEpicPageId: 'epic',
       fr: {
         id: 'FR-1',
-        title: 'Login',
-        description: 'POST /auth/login',
-        acceptanceCriteria: ['returns 200', 'returns 401']
-      },
-      urs: [{ id: 'UR-1', narrative: 'sign in' }],
-      dsItems: [{ id: 'DS-1', title: 'Form' }],
-      tcItems: [{ id: 'TC-1', title: 'Happy path' }]
+        title: 'T',
+        acceptanceCriteria: ['a', 'b', 'c'],
+        validationRules: ['r1']
+      }
     }
-
     const page = renderFrPage(spec)
-
-    const lists = page.blocks.filter((b) => b.kind === 'bulleted_list')
-    expect(lists).toHaveLength(4)
-    expect(lists[0]).toMatchObject({ kind: 'bulleted_list', items: ['UR-1: sign in'] })
-    expect(lists[1]).toMatchObject({ kind: 'bulleted_list', items: ['returns 200', 'returns 401'] })
-    expect(lists[2]).toMatchObject({ kind: 'bulleted_list', items: ['DS-1: Form'] })
-    expect(lists[3]).toMatchObject({ kind: 'bulleted_list', items: ['TC-1: Happy path'] })
-
-    const descParagraphs = page.blocks.filter((b) => b.kind === 'paragraph').map((b) => ('text' in b ? b.text : ''))
-    expect(descParagraphs).toContain('POST /auth/login')
+    const detail = findTableAfterHeading(page.blocks, 'FR-1 — T')
+    const cellFor = (label: string) => detail.rows.find((row) => row[0] === label)?.[1]
+    expect(cellFor('Acceptance Criteria')).toBe('• a\n• b\n• c')
+    expect(cellFor('Validation Rules')).toBe('• r1')
   })
 })

--- a/src/__tests__/unit/srs/types.spec.ts
+++ b/src/__tests__/unit/srs/types.spec.ts
@@ -1,0 +1,92 @@
+import { DsItem, EpicSpec, FrItem, NfrItem, Priority, UrItem } from '../../../builders/srs/types'
+
+describe('SRS types (SUB-18.1 extensions)', () => {
+  it('accepts priority and group on UrItem', () => {
+    const ur: UrItem = {
+      id: 'UR-AUTH-01-01',
+      narrative: 'user can sign in',
+      priority: 'P1',
+      group: 'UR-AUTH-01'
+    }
+    expect(ur.priority).toBe('P1')
+    expect(ur.group).toBe('UR-AUTH-01')
+  })
+
+  it('accepts priority, group and detail fields on FrItem', () => {
+    const fr: FrItem = {
+      id: 'FR-AUTH-01-01',
+      title: 'Sign up endpoint',
+      priority: 'P1',
+      group: 'FR-AUTH-01',
+      endpoint: 'POST /auth/signup',
+      requestBody: '{ email, password, locale? }',
+      validationRules: ['Email required', 'Password min 8 chars'],
+      securityRationale: 'Prevents user enumeration',
+      urRefs: ['UR-AUTH-01-01'],
+      dsRefs: ['DS-AUTH-01-01']
+    }
+    expect(fr.priority).toBe('P1')
+    expect(fr.endpoint).toBe('POST /auth/signup')
+    expect(fr.validationRules).toHaveLength(2)
+  })
+
+  it('accepts group on DsItem', () => {
+    const ds: DsItem = { id: 'DS-AUTH-01-01', title: 'bcrypt hash', group: 'DS-AUTH-01' }
+    expect(ds.group).toBe('DS-AUTH-01')
+  })
+
+  it('constructs a NfrItem with target, priority, frRefs, group', () => {
+    const nfr: NfrItem = {
+      id: 'NFR-AUTH-01-01',
+      title: 'Login response time',
+      target: '≤ 1 second (p95)',
+      priority: 'P1',
+      frRefs: ['FR-AUTH-02-01'],
+      group: 'NFR-AUTH-01'
+    }
+    expect(nfr.target).toBe('≤ 1 second (p95)')
+    expect(nfr.priority).toBe('P1')
+  })
+
+  it('accepts nfrItems on EpicSpec', () => {
+    const epic: EpicSpec = {
+      title: 'Authentication',
+      parentPageId: 'parent',
+      urs: [],
+      frs: [],
+      nfrItems: [{ id: 'NFR-AUTH-01-01', title: 'perf', target: '≤ 1s', priority: 'P1' }]
+    }
+    expect(epic.nfrItems).toHaveLength(1)
+  })
+
+  it('rejects invalid Priority values at compile time (doc-test)', () => {
+    const valid: Priority[] = ['P1', 'P2', 'P3']
+    expect(valid).toHaveLength(3)
+    // @ts-expect-error — 'P4' is not a valid Priority
+    const invalid: Priority = 'P4'
+    expect(invalid).toBe('P4')
+  })
+
+  it('preserves all new fields through JSON round-trip', () => {
+    const epic: EpicSpec = {
+      title: 'Auth',
+      parentPageId: 'p',
+      urs: [{ id: 'UR-1', narrative: 'n', priority: 'P1', group: 'UR-AUTH-01' }],
+      frs: [
+        {
+          id: 'FR-1',
+          title: 't',
+          priority: 'P2',
+          group: 'FR-AUTH-01',
+          endpoint: 'GET /x',
+          requestBody: '{}',
+          validationRules: ['r1'],
+          securityRationale: 'sr'
+        }
+      ],
+      nfrItems: [{ id: 'NFR-1', title: 'n', target: 't', priority: 'P3' }]
+    }
+    const roundTripped = JSON.parse(JSON.stringify(epic)) as EpicSpec
+    expect(roundTripped).toEqual(epic)
+  })
+})

--- a/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
@@ -247,19 +247,13 @@ describe('NotionSrsAdapter', () => {
     })
 
     it('splits >100 children across one create + N appends (Notion caps at 100 per request)', async () => {
-      const urs = Array.from({ length: 40 }, (_, i) => ({ id: `UR-${i + 1}`, narrative: `narrative ${i + 1}` }))
-      const frs = Array.from({ length: 40 }, (_, i) => ({
-        id: `FR-${i + 1}`,
-        title: `fr ${i + 1}`,
-        description: `desc ${i + 1}`,
-        acceptanceCriteria: ['ac-1', 'ac-2'],
-        urRefs: [`UR-${i + 1}`]
-      }))
-      const bigEpic: EpicSpec = { ...sampleEpic, urs, frs }
+      // Uses createPage directly to drive the chunker with a controlled block count,
+      // independent of template shape (which collapses many items into few blocks via tables).
+      const manyBlocks = Array.from({ length: 150 }, (_, i) => ({ kind: 'paragraph' as const, text: `p-${i + 1}` }))
       const { client, calls } = buildMockClient()
       const adapter = new NotionSrsAdapter({ apiToken: 'tk', client })
 
-      await adapter.createEpicPage(bigEpic)
+      await adapter.createPage('parent_123', 'Big page', { blocks: manyBlocks })
 
       expect(calls.pagesCreateCalls).toHaveLength(1)
       const create = calls.pagesCreateCalls[0] as { children: unknown[] }
@@ -271,15 +265,7 @@ describe('NotionSrsAdapter', () => {
     })
 
     it('rolls back (archives) the created page when a follow-up append fails', async () => {
-      const urs = Array.from({ length: 40 }, (_, i) => ({ id: `UR-${i + 1}`, narrative: `narrative ${i + 1}` }))
-      const frs = Array.from({ length: 40 }, (_, i) => ({
-        id: `FR-${i + 1}`,
-        title: `fr ${i + 1}`,
-        description: `desc ${i + 1}`,
-        acceptanceCriteria: ['ac-1'],
-        urRefs: [`UR-${i + 1}`]
-      }))
-      const bigEpic: EpicSpec = { ...sampleEpic, urs, frs }
+      const manyBlocks = Array.from({ length: 150 }, (_, i) => ({ kind: 'paragraph' as const, text: `p-${i + 1}` }))
       const pagesUpdateCalls: unknown[] = []
       const { client } = buildMockClient({
         blocksAppendImpl: async () => {
@@ -293,7 +279,7 @@ describe('NotionSrsAdapter', () => {
       }
       const adapter = new NotionSrsAdapter({ apiToken: 'tk', client })
 
-      await expect(adapter.createEpicPage(bigEpic)).rejects.toThrow(/append failed/)
+      await expect(adapter.createPage('parent_123', 'Big page', { blocks: manyBlocks })).rejects.toThrow(/append failed/)
       expect(pagesUpdateCalls).toHaveLength(1)
       expect(pagesUpdateCalls[0]).toMatchObject({ page_id: 'page_new', archived: true })
     })

--- a/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
@@ -297,6 +297,91 @@ describe('NotionSrsAdapter', () => {
       expect(call.parent).toEqual({ page_id: 'epic_42' })
       expect(call.children.length).toBeGreaterThan(0)
     })
+
+    it('produces the DIAMONFORGE-shape children: Summary table + divider + per-item detail table', async () => {
+      const { client, calls } = buildMockClient()
+      const adapter = new NotionSrsAdapter({ apiToken: 'tk', client })
+
+      await adapter.createFrPage(sampleFr)
+
+      type AnyBlock = { type: string; table?: { table_width: number; has_column_header: boolean } }
+      const call = calls.pagesCreateCalls[0] as unknown as { children: AnyBlock[] }
+      const types = call.children.map((c) => c.type)
+      // Notion page title is set as page property (not a child block);
+      // children start at heading_2 (Summary), table, divider, heading_2 (id — title), table
+      expect(types).toEqual(['heading_2', 'table', 'divider', 'heading_2', 'table'])
+      const tables = call.children.filter((c): c is AnyBlock & { table: { table_width: number; has_column_header: boolean } } => c.type === 'table' && c.table !== undefined)
+      expect(tables).toHaveLength(2)
+      expect(tables[0].table.table_width).toBe(5) // Summary: ID, Requirement, Priority, Related UR, Related DS
+      expect(tables[0].table.has_column_header).toBe(true)
+      expect(tables[1].table.table_width).toBe(2) // Detail: Field, Value
+      expect(tables[1].table.has_column_header).toBe(true)
+    })
+  })
+
+  describe('createEpicPage — DIAMONFORGE structural shape', () => {
+    it('emits Traceability + Requirement Types + UR/FR/DS/NFR sections with grouped tables', async () => {
+      const richEpic: EpicSpec = {
+        title: 'Auth epic',
+        parentPageId: 'parent_xyz',
+        urs: [
+          { id: 'UR-AUTH-01', narrative: 'Sign-in', group: 'Sign-in flow' },
+          { id: 'UR-AUTH-02', narrative: 'Sign-out', group: 'Sign-out flow' }
+        ],
+        frs: [
+          { id: 'FR-AUTH-01', title: 'Sign in endpoint', group: 'Sign-in flow', urRefs: ['UR-AUTH-01'] }
+        ],
+        dsItems: [{ id: 'DS-AUTH-01', title: 'JWT cookie', group: 'Sign-in flow', frRefs: ['FR-AUTH-01'] }],
+        nfrItems: [{ id: 'NFR-PERF-01', title: 'Login latency', target: 'p95 ≤ 1s', priority: 'P1', frRefs: ['FR-AUTH-01'] }]
+      }
+      const { client, calls } = buildMockClient()
+      const adapter = new NotionSrsAdapter({ apiToken: 'tk', client })
+
+      await adapter.createEpicPage(richEpic)
+
+      type AnyBlock = {
+        type: string
+        heading_2?: { rich_text: Array<{ text: { content: string } }> }
+      }
+      const call = calls.pagesCreateCalls[0] as unknown as { children: AnyBlock[] }
+      const types = call.children.map((c) => c.type)
+      // Notion page title is set as page property (not a child block);
+      // children start at heading_2 (Traceability) + code + paragraph + heading_2 (Requirement Types) + table + UR/FR/DS/NFR (H2 + table each)
+      expect(types[0]).toBe('heading_2')
+      expect(types).toContain('code')
+      const tables = call.children.filter((c) => c.type === 'table')
+      expect(tables).toHaveLength(5) // Requirement Types, UR, FR, DS, NFR
+
+      const headings = call.children.filter((c): c is AnyBlock & { heading_2: { rich_text: Array<{ text: { content: string } }> } } => c.type === 'heading_2' && c.heading_2 !== undefined)
+      const headingTexts = headings.map((h) => h.heading_2.rich_text[0].text.content)
+      expect(headingTexts).toEqual(['Traceability', 'Requirement Types', 'User Requirements (UR)', 'Functional Requirements (FR)', 'Design Specifications (DS)', 'Non-Functional Requirements (NFR)'])
+    })
+
+    it('renders empty placeholder paragraphs when sections have no items', async () => {
+      const emptyEpic: EpicSpec = {
+        title: 'Empty epic',
+        parentPageId: 'p',
+        urs: [],
+        frs: []
+        // dsItems + nfrItems undefined → placeholder paragraphs expected
+      }
+      const { client, calls } = buildMockClient()
+      const adapter = new NotionSrsAdapter({ apiToken: 'tk', client })
+
+      await adapter.createEpicPage(emptyEpic)
+
+      type AnyBlock = { type: string; paragraph?: { rich_text: Array<{ text: { content: string } }> } }
+      const call = calls.pagesCreateCalls[0] as unknown as { children: AnyBlock[] }
+      const placeholderTexts = call.children
+        .filter((c): c is AnyBlock & { paragraph: { rich_text: Array<{ text: { content: string } }> } } => c.type === 'paragraph' && c.paragraph !== undefined && c.paragraph.rich_text[0]?.text.content.startsWith('No '))
+        .map((c) => c.paragraph.rich_text[0].text.content)
+      expect(placeholderTexts).toEqual([
+        'No user requirements yet.',
+        'No functional requirements yet.',
+        'No design specifications yet.',
+        'No non-functional requirements yet.'
+      ])
+    })
   })
 
   describe('fetchPage', () => {

--- a/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
@@ -328,9 +328,7 @@ describe('NotionSrsAdapter', () => {
           { id: 'UR-AUTH-01', narrative: 'Sign-in', group: 'Sign-in flow' },
           { id: 'UR-AUTH-02', narrative: 'Sign-out', group: 'Sign-out flow' }
         ],
-        frs: [
-          { id: 'FR-AUTH-01', title: 'Sign in endpoint', group: 'Sign-in flow', urRefs: ['UR-AUTH-01'] }
-        ],
+        frs: [{ id: 'FR-AUTH-01', title: 'Sign in endpoint', group: 'Sign-in flow', urRefs: ['UR-AUTH-01'] }],
         dsItems: [{ id: 'DS-AUTH-01', title: 'JWT cookie', group: 'Sign-in flow', frRefs: ['FR-AUTH-01'] }],
         nfrItems: [{ id: 'NFR-PERF-01', title: 'Login latency', target: 'p95 ≤ 1s', priority: 'P1', frRefs: ['FR-AUTH-01'] }]
       }
@@ -373,14 +371,12 @@ describe('NotionSrsAdapter', () => {
       type AnyBlock = { type: string; paragraph?: { rich_text: Array<{ text: { content: string } }> } }
       const call = calls.pagesCreateCalls[0] as unknown as { children: AnyBlock[] }
       const placeholderTexts = call.children
-        .filter((c): c is AnyBlock & { paragraph: { rich_text: Array<{ text: { content: string } }> } } => c.type === 'paragraph' && c.paragraph !== undefined && c.paragraph.rich_text[0]?.text.content.startsWith('No '))
+        .filter(
+          (c): c is AnyBlock & { paragraph: { rich_text: Array<{ text: { content: string } }> } } =>
+            c.type === 'paragraph' && c.paragraph !== undefined && c.paragraph.rich_text[0]?.text.content.startsWith('No ')
+        )
         .map((c) => c.paragraph.rich_text[0].text.content)
-      expect(placeholderTexts).toEqual([
-        'No user requirements yet.',
-        'No functional requirements yet.',
-        'No design specifications yet.',
-        'No non-functional requirements yet.'
-      ])
+      expect(placeholderTexts).toEqual(['No user requirements yet.', 'No functional requirements yet.', 'No design specifications yet.', 'No non-functional requirements yet.'])
     })
   })
 

--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -369,7 +369,7 @@ describe('utils', () => {
             rootPage: {
               id: 'abc-123',
               url: 'https://www.notion.so/SaaSFoundry-abc123',
-              name: 'SaaSFoundry — Project Overview'
+              name: 'srs-enabled-srs'
             },
             categories: {
               userFlowsAndSpecifications: {

--- a/src/builders/srs/templates/pages/epic.tpl.ts
+++ b/src/builders/srs/templates/pages/epic.tpl.ts
@@ -1,70 +1,126 @@
-import { EpicSpec, PageBlock, PageContent } from '../../types'
+import { DsItem, EpicSpec, FrItem, NfrItem, PageBlock, PageContent, Priority, UrItem } from '../../types'
+
+const EMPTY_CELL = '—'
 
 function refsCell(refs?: string[]): string {
-  return refs && refs.length > 0 ? refs.join(', ') : '—'
+  return refs && refs.length > 0 ? refs.join(', ') : EMPTY_CELL
+}
+
+function priorityCell(priority?: Priority): string {
+  return priority ?? EMPTY_CELL
+}
+
+const REQUIREMENT_TYPES_ROWS: string[][] = [
+  ['UR', 'User Requirement', "High-level user need describing what the user wants to achieve. Written from the user's perspective.", '"The user must be able to log in to access the product"'],
+  ['FR', 'Functional Requirement', 'What the system must do to fulfill user requirements. Describes system behavior.', '"The system displays a generic error message on login failure"'],
+  ['DS', 'Design Specification', 'How the system implements the functional requirements. Technical implementation details.', '"JWT tokens stored in httpOnly cookies"'],
+  ['NFR', 'Non-Functional Requirement', 'Quality attributes: performance, security, availability, scalability.', '"Login response time ≤ 1 second (p95)"']
+]
+
+const TRACEABILITY_TREE = `UR (User Requirement)
+  └── FR (Functional Requirement)
+        └── DS (Design Specification)
+              └── TC (Test Case)`
+
+const TRACEABILITY_NOTE = 'Each lower-level requirement traces back to a higher-level requirement, ensuring complete coverage and compliance traceability.'
+
+function groupHeaderRow(groupId: string, columnCount: number): string[] {
+  const row = [groupId]
+  while (row.length < columnCount) row.push('')
+  return row
+}
+
+function buildGroupedRows<T>(items: T[], getGroup: (item: T) => string | undefined, getRow: (item: T) => string[]): string[][] {
+  if (items.length === 0) return []
+  const columnCount = getRow(items[0]).length
+  const rows: string[][] = []
+  let lastGroup: string | undefined
+  for (const item of items) {
+    const group = getGroup(item)
+    if (group && group !== lastGroup) {
+      rows.push(groupHeaderRow(group, columnCount))
+    }
+    lastGroup = group
+    rows.push(getRow(item))
+  }
+  return rows
+}
+
+function urRow(ur: UrItem, allFrs: FrItem[]): string[] {
+  const relatedFrs = allFrs.filter((fr) => fr.urRefs?.includes(ur.id)).map((fr) => fr.id)
+  return [ur.id, ur.narrative, priorityCell(ur.priority), refsCell(relatedFrs.length > 0 ? relatedFrs : undefined)]
+}
+
+function frRow(fr: FrItem): string[] {
+  return [fr.id, fr.title, priorityCell(fr.priority), refsCell(fr.urRefs), refsCell(fr.dsRefs)]
+}
+
+function dsRow(ds: DsItem): string[] {
+  return [ds.id, ds.title, refsCell(ds.frRefs)]
+}
+
+function nfrRow(nfr: NfrItem): string[] {
+  return [nfr.id, nfr.title, nfr.target ?? EMPTY_CELL, priorityCell(nfr.priority), refsCell(nfr.frRefs)]
 }
 
 export function renderEpicPage(spec: EpicSpec): PageContent {
   const blocks: PageBlock[] = []
 
-  blocks.push({ kind: 'heading', level: 1, text: 'Overview' })
-  if (spec.businessValue) blocks.push({ kind: 'paragraph', text: spec.businessValue })
-
-  if (spec.scope) {
-    blocks.push({ kind: 'heading', level: 2, text: 'Scope' })
-    blocks.push({ kind: 'paragraph', text: spec.scope })
-  }
-
-  blocks.push({ kind: 'divider' })
-  blocks.push({ kind: 'heading', level: 2, text: 'Requirement Types' })
-  blocks.push({
-    kind: 'table',
-    header: ['UR', 'FR', 'DS', 'TC'],
-    rows: [[String(spec.urs.length), String(spec.frs.length), String(spec.dsItems?.length ?? 0), String(spec.tcItems?.length ?? 0)]]
-  })
-
   blocks.push({ kind: 'heading', level: 2, text: 'Traceability' })
-  if (spec.frs.length === 0) {
-    blocks.push({ kind: 'paragraph', text: 'No functional requirements yet.' })
-  } else {
-    blocks.push({
-      kind: 'table',
-      header: ['FR', 'UR refs', 'DS refs', 'TC refs'],
-      rows: spec.frs.map((fr) => [fr.id, refsCell(fr.urRefs), refsCell(fr.dsRefs), refsCell(fr.tcRefs)])
-    })
-  }
+  blocks.push({ kind: 'code', language: 'plain text', text: TRACEABILITY_TREE })
+  blocks.push({ kind: 'paragraph', text: TRACEABILITY_NOTE })
 
-  blocks.push({ kind: 'divider' })
+  blocks.push({ kind: 'heading', level: 2, text: 'Requirement Types' })
+  blocks.push({ kind: 'table', header: ['Prefix', 'Type', 'Description', 'Example'], rows: REQUIREMENT_TYPES_ROWS })
+
   blocks.push({ kind: 'heading', level: 2, text: 'User Requirements (UR)' })
   if (spec.urs.length === 0) {
     blocks.push({ kind: 'paragraph', text: 'No user requirements yet.' })
   } else {
     blocks.push({
-      kind: 'bulleted_list',
-      items: spec.urs.map((ur) => {
-        const suffix = ur.businessValue ? ` — ${ur.businessValue}` : ''
-        return `${ur.id}: ${ur.narrative}${suffix}`
-      })
+      kind: 'table',
+      header: ['ID', 'Requirement', 'Priority', 'Related FR'],
+      rows: buildGroupedRows(
+        spec.urs,
+        (ur) => ur.group,
+        (ur) => urRow(ur, spec.frs)
+      )
     })
   }
 
-  blocks.push({ kind: 'divider' })
   blocks.push({ kind: 'heading', level: 2, text: 'Functional Requirements (FR)' })
   if (spec.frs.length === 0) {
     blocks.push({ kind: 'paragraph', text: 'No functional requirements yet.' })
   } else {
-    for (const fr of spec.frs) {
-      blocks.push({ kind: 'heading', level: 3, text: `${fr.id} — ${fr.title}` })
-      if (fr.description) blocks.push({ kind: 'paragraph', text: fr.description })
-      if (fr.acceptanceCriteria && fr.acceptanceCriteria.length > 0) {
-        blocks.push({ kind: 'paragraph', text: 'Acceptance criteria:' })
-        blocks.push({ kind: 'bulleted_list', items: fr.acceptanceCriteria })
-      }
-      blocks.push({
-        kind: 'paragraph',
-        text: [`UR: ${refsCell(fr.urRefs)}`, `DS: ${refsCell(fr.dsRefs)}`, `TC: ${refsCell(fr.tcRefs)}`].join(' · ')
-      })
-    }
+    blocks.push({
+      kind: 'table',
+      header: ['ID', 'Requirement', 'Priority', 'Related UR', 'Related DS'],
+      rows: buildGroupedRows(spec.frs, (fr) => fr.group, frRow)
+    })
+  }
+
+  const dsItems = spec.dsItems ?? []
+  blocks.push({ kind: 'heading', level: 2, text: 'Design Specifications (DS)' })
+  if (dsItems.length === 0) {
+    blocks.push({ kind: 'paragraph', text: 'No design specifications yet.' })
+  } else {
+    blocks.push({
+      kind: 'table',
+      header: ['ID', 'Specification', 'Related FR'],
+      rows: buildGroupedRows(dsItems, (ds) => ds.group, dsRow)
+    })
+  }
+
+  const nfrItems = spec.nfrItems ?? []
+  blocks.push({ kind: 'heading', level: 2, text: 'Non-Functional Requirements (NFR)' })
+  if (nfrItems.length === 0) {
+    blocks.push({ kind: 'paragraph', text: 'No non-functional requirements yet.' })
+  } else {
+    blocks.push({
+      kind: 'table',
+      header: ['ID', 'Requirement', 'Target', 'Priority', 'Related FR'],
+      rows: buildGroupedRows(nfrItems, (nfr) => nfr.group, nfrRow)
+    })
   }
 
   return { title: spec.title, blocks }

--- a/src/builders/srs/templates/pages/fr.tpl.ts
+++ b/src/builders/srs/templates/pages/fr.tpl.ts
@@ -1,40 +1,62 @@
-import { FrSpec, PageBlock, PageContent } from '../../types'
+import { FrItem, FrSpec, PageBlock, PageContent, Priority } from '../../types'
+
+const EMPTY_CELL = '—'
+
+function refsCell(refs?: string[]): string {
+  return refs && refs.length > 0 ? refs.join(', ') : EMPTY_CELL
+}
+
+function priorityCell(priority?: Priority): string {
+  return priority ?? EMPTY_CELL
+}
+
+function textCell(value?: string): string {
+  return value && value.trim().length > 0 ? value : EMPTY_CELL
+}
+
+function listCell(items?: string[]): string {
+  if (!items || items.length === 0) return EMPTY_CELL
+  return items.map((item) => `• ${item}`).join('\n')
+}
+
+function summaryRow(fr: FrItem): string[] {
+  return [fr.id, fr.title, priorityCell(fr.priority), refsCell(fr.urRefs), refsCell(fr.dsRefs)]
+}
+
+function detailRows(fr: FrItem): string[][] {
+  return [
+    ['ID', fr.id],
+    ['Title', fr.title],
+    ['Endpoint', textCell(fr.endpoint)],
+    ['Priority', priorityCell(fr.priority)],
+    ['Related UR', refsCell(fr.urRefs)],
+    ['Related DS', refsCell(fr.dsRefs)],
+    ['Description', textCell(fr.description)],
+    ['Request Body', textCell(fr.requestBody)],
+    ['Acceptance Criteria', listCell(fr.acceptanceCriteria)],
+    ['Validation Rules', listCell(fr.validationRules)],
+    ['Security Rationale', textCell(fr.securityRationale)]
+  ]
+}
 
 export function renderFrPage(spec: FrSpec): PageContent {
-  const { fr } = spec
+  const frs: FrItem[] = [spec.fr]
   const blocks: PageBlock[] = []
 
-  blocks.push({ kind: 'heading', level: 1, text: `${fr.id} — ${fr.title}` })
-  if (fr.description) blocks.push({ kind: 'paragraph', text: fr.description })
+  blocks.push({ kind: 'heading', level: 2, text: 'Summary' })
+  blocks.push({
+    kind: 'table',
+    header: ['ID', 'Requirement', 'Priority', 'Related UR', 'Related DS'],
+    rows: frs.map(summaryRow)
+  })
 
-  blocks.push({ kind: 'heading', level: 2, text: 'User Requirements' })
-  if (!spec.urs || spec.urs.length === 0) {
-    blocks.push({ kind: 'paragraph', text: 'No linked user requirements.' })
-  } else {
-    blocks.push({ kind: 'bulleted_list', items: spec.urs.map((ur) => `${ur.id}: ${ur.narrative}`) })
-  }
+  blocks.push({ kind: 'divider' })
 
-  blocks.push({ kind: 'heading', level: 2, text: 'Acceptance Criteria' })
-  if (!fr.acceptanceCriteria || fr.acceptanceCriteria.length === 0) {
-    blocks.push({ kind: 'paragraph', text: 'No acceptance criteria yet.' })
-  } else {
-    blocks.push({ kind: 'bulleted_list', items: fr.acceptanceCriteria })
-  }
+  frs.forEach((fr, idx) => {
+    blocks.push({ kind: 'heading', level: 2, text: `${fr.id} — ${fr.title}` })
+    blocks.push({ kind: 'table', header: ['Field', 'Value'], rows: detailRows(fr) })
+    if (idx < frs.length - 1) blocks.push({ kind: 'divider' })
+  })
 
-  blocks.push({ kind: 'heading', level: 2, text: 'Design (DS)' })
-  if (!spec.dsItems || spec.dsItems.length === 0) {
-    blocks.push({ kind: 'paragraph', text: 'No design items yet.' })
-  } else {
-    blocks.push({ kind: 'bulleted_list', items: spec.dsItems.map((ds) => `${ds.id}: ${ds.title}`) })
-  }
-
-  blocks.push({ kind: 'heading', level: 2, text: 'Test Cases (TC)' })
-  if (!spec.tcItems || spec.tcItems.length === 0) {
-    blocks.push({ kind: 'paragraph', text: 'No test cases yet.' })
-  } else {
-    blocks.push({ kind: 'bulleted_list', items: spec.tcItems.map((tc) => `${tc.id}: ${tc.title}`) })
-  }
-
-  const title = `${fr.id} — ${fr.title}`
-  return { title, blocks }
+  return { title: `${spec.fr.id} — ${spec.fr.title}`, blocks }
 }

--- a/src/builders/srs/types.ts
+++ b/src/builders/srs/types.ts
@@ -4,10 +4,14 @@ export interface PageRef {
   title: string
 }
 
+export type Priority = 'P1' | 'P2' | 'P3'
+
 export interface UrItem {
   id: string
   narrative: string
   businessValue?: string
+  priority?: Priority
+  group?: string
 }
 
 export interface FrItem {
@@ -18,6 +22,12 @@ export interface FrItem {
   urRefs?: string[]
   dsRefs?: string[]
   tcRefs?: string[]
+  priority?: Priority
+  group?: string
+  endpoint?: string
+  requestBody?: string
+  validationRules?: string[]
+  securityRationale?: string
 }
 
 export interface DsItem {
@@ -25,6 +35,7 @@ export interface DsItem {
   title: string
   description?: string
   frRefs?: string[]
+  group?: string
 }
 
 export interface TcItem {
@@ -33,6 +44,15 @@ export interface TcItem {
   steps?: string[]
   expectedResult?: string
   frRefs?: string[]
+}
+
+export interface NfrItem {
+  id: string
+  title: string
+  target?: string
+  priority?: Priority
+  frRefs?: string[]
+  group?: string
 }
 
 export interface EpicSpec {
@@ -44,6 +64,7 @@ export interface EpicSpec {
   frs: FrItem[]
   dsItems?: DsItem[]
   tcItems?: TcItem[]
+  nfrItems?: NfrItem[]
 }
 
 export interface FrSpec {

--- a/src/runners/srs.runner.ts
+++ b/src/runners/srs.runner.ts
@@ -25,7 +25,7 @@ export async function bootstrapSrs(options: BootstrapSrsOptions): Promise<Bootst
   await adapter.init()
   const parent = await adapter.resolveParent(parentInput)
 
-  const rootTitle = `${projectName} — Project Overview`
+  const rootTitle = `${projectName}-srs`
   const rootRef = await adapter.createPage(parent.id, rootTitle)
   const rootPage: SrsPageRef = { id: rootRef.id, url: rootRef.url, name: rootTitle }
 


### PR DESCRIPTION
## Summary

Rewrites SRS Epic & FR page templates to match the design spec from #57 + DIAMONFORGE reference.

Closes #223 (parent SUB-18). Subtasks merged: #224 #225 #226 #227 #228.

### Changes
- **#224** — SRS types extended (`NfrItem`, `priority`, `group`, FR detail fields)
- **#225** — `epic.tpl` → DIAMONFORGE structure (Traceability + Requirement Types table + 4 grouped tables UR/FR/DS/NFR)
- **#226** — `fr.tpl` → Summary table (5 cols) + divider + per-item vertical detail (11 canonical rows)
- **#227** — rootPage naming convention → \`{projectName}-srs\`
- **#228** — adapter unit structural tests + integration coverage for the new shape

## Test plan

- [x] `npm run test:pre-commit` — 78 suites / 908 tests green
- [x] `npm run test:pre-push` — 2 docker scenarios green (multirepo-minimal + monorepo-minimal)
- [x] Unit: `srs.adapter.spec.ts` asserts 5 tables (epic) / 2 tables + Summary heading (FR)
- [x] Unit: `epic.tpl.spec.ts`, `fr.tpl.spec.ts` structural assertions
- [x] Unit: `runners/srs.runner.spec.ts` updated for `{projectName}-srs`
- [x] Integration (opt-in with creds): live Notion round-trip asserts 5 epic tables + 6 headings + 2 FR tables
- [x] Human-validated in sandbox workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)