### PR TITLE
feat(#229): enforce complexity label on non-Backlog status transitions

### DIFF
--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -84,6 +84,9 @@ Developer always has final say.
 
 **`/workflow retag <ticket> <new-complexity>`** Changes ticket complexity level (bug | low | medium | complex). Adjusts remaining workflow steps to match new complexity.
 
+**Guard** — `update-status <ticket> <target>` is rejected for any target other than `Backlog` if the ticket has no `complexity: *` label. `detect-complexity` only suggests — you must call `retag` to
+persist. The guard fails open if label fetch errors (offline / auth issues). Escape hatch: `SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD=1` (rare).
+
 ### Workflow Phase Commands (Complexity-Adaptive)
 
 **`/workflow prepare <ticket> <complexity>`** Runs adaptive analyze + plan phase (Backlog → Ready).

--- a/.claude/skills/sf-workflow/statuses/1-backlog.md
+++ b/.claude/skills/sf-workflow/statuses/1-backlog.md
@@ -11,9 +11,9 @@
 
 ### 1. READ THE TICKET THOROUGHLY
 
-### 2. DETECT COMPLEXITY
+### 2. DETECT COMPLEXITY → THEN WRITE IT TO THE TICKET
 
-**Run complexity detection:**
+**Step 2a — Run complexity detection (suggestion only):**
 
 ```bash
 .claude/skills/sf-workflow/scripts/detect-complexity.sh {ticket-number}
@@ -34,6 +34,16 @@
 - 🔴 **complex** - Critical feature (full apex with review)
 
 **Developer ALWAYS has final say - ask for confirmation or adjustment.**
+
+**Step 2b — Persist the complexity label on the ticket:**
+
+```bash
+.claude/skills/sf-workflow/workflow-cli.sh retag {ticket-number} {level}
+# level: bug | low | medium | complex
+```
+
+⚠️ **This step is mandatory, not optional.** `detect-complexity.sh` only prints a suggestion; it does NOT write anything to the ticket. Without the `complexity: *` label, the ticket cannot leave
+Backlog — `update-status` is hard-gated on it (see errors to avoid below).
 
 ### 3. ANALYZE (adaptive based on complexity)
 
@@ -101,7 +111,7 @@
 
 ## Exit Conditions
 
-- Complexity tag is set
+- **Complexity label persisted on the ticket** (run `get-complexity {ticket}` and confirm it prints one of `bug|low|medium|complex`, not `(none)`)
 - Analysis complete (if required by complexity)
 - Plan approved (if required by complexity)
 - Developer validates that specs are complete
@@ -114,5 +124,5 @@
 
 ## Errors to Avoid
 
-❌ NEVER create a branch from Backlog ❌ NEVER start coding before Ready ❌ NEVER skip complexity detection ❌ NEVER skip analysis/planning if required by complexity ❌ NEVER move to Ready without
-developer validation
+❌ NEVER create a branch from Backlog ❌ NEVER start coding before Ready ❌ NEVER skip complexity detection ❌ NEVER leave Backlog without persisting the `complexity: *` label via `retag` (suggestion
+≠ label; `update-status` is hard-gated) ❌ NEVER skip analysis/planning if required by complexity ❌ NEVER move to Ready without developer validation

--- a/.claude/skills/sf-workflow/workflow-cli.sh
+++ b/.claude/skills/sf-workflow/workflow-cli.sh
@@ -187,6 +187,64 @@ check_srs_guard() {
   return 0
 }
 
+# ───────────────────────────────────────────────────────────────────────────
+# Complexity guard
+# ───────────────────────────────────────────────────────────────────────────
+#
+# Every ticket must carry a `complexity: <bug|low|medium|complex>` label before
+# it leaves Backlog. Without it, the adaptive workflow (analyze / plan / examine
+# depth) has nothing to key off and the board ends up full of untagged tickets
+# — the exact failure mode the developer flagged.
+#
+# The guard fires on any `update-status` whose target is NOT 'Backlog'. It
+# fails open on fetch errors (same philosophy as check_srs_guard) so an offline
+# gh or auth hiccup never wedges the workflow. Escape hatch:
+# SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD=1.
+
+is_backlog_target() {
+  local target=$1
+  local normalized
+  normalized=$(echo "$target" | tr '[:upper:]' '[:lower:]' | awk '{$1=$1;print}')
+  [[ "$normalized" == "backlog" ]]
+}
+
+get_ticket_complexity_label() {
+  # Prints the complexity level (bug|low|medium|complex) or empty if none.
+  # Returns 0 on clean fetch, 1 on fetch error.
+  local ticket=$1
+  local raw
+  raw=$(route_to_tool "$WORKFLOW_TOOL" get-labels "$ticket" 2>/dev/null) || return 1
+  echo "$raw" | grep -E '^complexity: ' | head -n1 | sed 's/^complexity: //'
+}
+
+check_complexity_guard() {
+  # Returns 0 if the caller may proceed, 1 if blocked (message already printed).
+  local ticket=$1
+  local target=$2
+
+  [[ "${SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD:-}" == "1" ]] && return 0
+  is_backlog_target "$target" && return 0   # moving back to Backlog is always allowed
+
+  local level
+  level=$(get_ticket_complexity_label "$ticket") || return 0   # fail-open on fetch error
+
+  if [[ -z "$level" ]]; then
+    echo -e "${RED}✗ Ticket #${ticket} has no complexity label — cannot transition to '${target}'.${NC}" >&2
+    echo "" >&2
+    echo "  Every ticket must be tagged with one of: bug | low | medium | complex" >&2
+    echo "  before it leaves Backlog. The adaptive workflow keys off this label." >&2
+    echo "" >&2
+    echo "  Fix:" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh detect-complexity ${ticket}" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh retag ${ticket} <level>" >&2
+    echo "" >&2
+    echo "  See .claude/skills/sf-workflow/complexity/README.md for level guidance." >&2
+    echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD=1" >&2
+    return 1
+  fi
+  return 0
+}
+
 # Function to show next status
 show_next_status() {
   local current_status=$1
@@ -333,6 +391,9 @@ case "$COMMAND" in
       exit 1
     fi
     if ! check_srs_guard "$TICKET" "$TARGET"; then
+      exit 2
+    fi
+    if ! check_complexity_guard "$TICKET" "$TARGET"; then
       exit 2
     fi
     route_to_tool "$WORKFLOW_TOOL" update-status "$@"

--- a/scaffolds/skills-templates/workflow/workflow-cli.sh
+++ b/scaffolds/skills-templates/workflow/workflow-cli.sh
@@ -187,6 +187,64 @@ check_srs_guard() {
   return 0
 }
 
+# ───────────────────────────────────────────────────────────────────────────
+# Complexity guard
+# ───────────────────────────────────────────────────────────────────────────
+#
+# Every ticket must carry a `complexity: <bug|low|medium|complex>` label before
+# it leaves Backlog. Without it, the adaptive workflow (analyze / plan / examine
+# depth) has nothing to key off and the board ends up full of untagged tickets
+# — the exact failure mode the developer flagged.
+#
+# The guard fires on any `update-status` whose target is NOT 'Backlog'. It
+# fails open on fetch errors (same philosophy as check_srs_guard) so an offline
+# gh or auth hiccup never wedges the workflow. Escape hatch:
+# SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD=1.
+
+is_backlog_target() {
+  local target=$1
+  local normalized
+  normalized=$(echo "$target" | tr '[:upper:]' '[:lower:]' | awk '{$1=$1;print}')
+  [[ "$normalized" == "backlog" ]]
+}
+
+get_ticket_complexity_label() {
+  # Prints the complexity level (bug|low|medium|complex) or empty if none.
+  # Returns 0 on clean fetch, 1 on fetch error.
+  local ticket=$1
+  local raw
+  raw=$(route_to_tool "$WORKFLOW_TOOL" get-labels "$ticket" 2>/dev/null) || return 1
+  echo "$raw" | grep -E '^complexity: ' | head -n1 | sed 's/^complexity: //'
+}
+
+check_complexity_guard() {
+  # Returns 0 if the caller may proceed, 1 if blocked (message already printed).
+  local ticket=$1
+  local target=$2
+
+  [[ "${SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD:-}" == "1" ]] && return 0
+  is_backlog_target "$target" && return 0   # moving back to Backlog is always allowed
+
+  local level
+  level=$(get_ticket_complexity_label "$ticket") || return 0   # fail-open on fetch error
+
+  if [[ -z "$level" ]]; then
+    echo -e "${RED}✗ Ticket #${ticket} has no complexity label — cannot transition to '${target}'.${NC}" >&2
+    echo "" >&2
+    echo "  Every ticket must be tagged with one of: bug | low | medium | complex" >&2
+    echo "  before it leaves Backlog. The adaptive workflow keys off this label." >&2
+    echo "" >&2
+    echo "  Fix:" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh detect-complexity ${ticket}" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh retag ${ticket} <level>" >&2
+    echo "" >&2
+    echo "  See .claude/skills/sf-workflow/complexity/README.md for level guidance." >&2
+    echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD=1" >&2
+    return 1
+  fi
+  return 0
+}
+
 # Function to show next status
 show_next_status() {
   local current_status=$1
@@ -333,6 +391,9 @@ case "$COMMAND" in
       exit 1
     fi
     if ! check_srs_guard "$TICKET" "$TARGET"; then
+      exit 2
+    fi
+    if ! check_complexity_guard "$TICKET" "$TARGET"; then
       exit 2
     fi
     route_to_tool "$WORKFLOW_TOOL" update-status "$@"

--- a/src/__tests__/unit/skill/workflow-cli.complexity-guard.spec.ts
+++ b/src/__tests__/unit/skill/workflow-cli.complexity-guard.spec.ts
@@ -1,0 +1,153 @@
+import { execFile } from 'child_process'
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { promisify } from 'util'
+
+const execFileP = promisify(execFile)
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const CLI = path.resolve(REPO_ROOT, '.claude/skills/sf-workflow/workflow-cli.sh')
+const BASH = '/bin/bash'
+
+async function buildSandbox(): Promise<{
+  dir: string
+  env: NodeJS.ProcessEnv
+  toolLogPath: string
+  cleanup: () => Promise<void>
+}> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sf-wfcli-cplx-'))
+  const toolDir = path.join(dir, '.claude/skills/sf-tool-github-projects')
+  const toolLogPath = path.join(dir, 'tool-calls.log')
+  await mkdir(toolDir, { recursive: true })
+
+  await writeFile(
+    path.join(dir, '.saasfoundry.json'),
+    JSON.stringify({
+      workflow: {
+        tool: 'github-projects',
+        projectUrl: 'https://github.com/orgs/FakeOrg/projects/42',
+        workingBranch: 'develop'
+      }
+    })
+  )
+
+  const toolShim = `#!/bin/bash
+printf '%s\\n' "$*" >> '${toolLogPath}'
+case "$1" in
+  get-labels)
+    if [ "\${FAKE_LABELS_ERROR:-}" = "1" ]; then
+      echo "fake-tool-cli: simulated get-labels failure" >&2
+      exit 1
+    fi
+    if [ -n "\${FAKE_LABELS:-}" ]; then
+      printf '%s\\n' "\${FAKE_LABELS}"
+    fi
+    ;;
+  update-status)
+    echo "✓ Ticket #$2 → $3"
+    ;;
+  *)
+    echo "fake-tool-cli: unhandled $*" >&2
+    exit 0
+    ;;
+esac
+`
+  const toolPath = path.join(toolDir, 'github-projects-cli.sh')
+  writeFileSync(toolPath, toolShim)
+  chmodSync(toolPath, 0o755)
+
+  const env: NodeJS.ProcessEnv = { ...process.env, PWD: dir }
+  return { dir, env, toolLogPath, cleanup: () => rm(dir, { recursive: true, force: true }) }
+}
+
+async function runCli(args: string[], sandbox: { dir: string; env: NodeJS.ProcessEnv }, envOverrides: NodeJS.ProcessEnv = {}): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await execFileP(BASH, [CLI, ...args], {
+      cwd: sandbox.dir,
+      env: { ...sandbox.env, ...envOverrides }
+    })
+    return { stdout, stderr, code: 0 }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; code?: number }
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: typeof e.code === 'number' ? e.code : 1 }
+  }
+}
+
+function readLog(logPath: string): string[] {
+  try {
+    return readFileSync(logPath, 'utf8').split('\n').filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+describe('sf-workflow CLI — complexity guard', () => {
+  let sandbox: Awaited<ReturnType<typeof buildSandbox>>
+
+  beforeEach(async () => {
+    sandbox = await buildSandbox()
+  })
+
+  afterEach(async () => {
+    await sandbox.cleanup()
+  })
+
+  it('blocks "Ready" when no complexity label is set', async () => {
+    const res = await runCli(['update-status', '42', 'Ready'], sandbox, { FAKE_LABELS: '' })
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain('no complexity label')
+    expect(res.stderr).toContain('bug | low | medium | complex')
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toEqual([])
+  })
+
+  it('blocks "In progress" when only a non-complexity label is set', async () => {
+    const res = await runCli(['update-status', '42', 'In progress'], sandbox, { FAKE_LABELS: 'bug' })
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain('no complexity label')
+  })
+
+  it.each(['AI testing', 'Human testing', 'In review', 'Done'])('blocks "%s" when no complexity label is set', async (target) => {
+    const res = await runCli(['update-status', '42', target], sandbox, { FAKE_LABELS: '' })
+    expect(res.code).toBe(2)
+  })
+
+  it('allows "Backlog" transitions even without a complexity label (moving back is always allowed)', async () => {
+    const res = await runCli(['update-status', '42', 'Backlog'], sandbox, { FAKE_LABELS: '' })
+    expect(res.code).toBe(0)
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toHaveLength(1)
+  })
+
+  it.each(['bug', 'low', 'medium', 'complex'])('allows "Ready" when complexity: %s is set', async (level) => {
+    const res = await runCli(['update-status', '42', 'Ready'], sandbox, { FAKE_LABELS: `complexity: ${level}` })
+    expect(res.code).toBe(0)
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toHaveLength(1)
+  })
+
+  it('bypasses the guard when SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD=1', async () => {
+    const res = await runCli(['update-status', '42', 'Ready'], sandbox, {
+      FAKE_LABELS: '',
+      SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD: '1'
+    })
+    expect(res.code).toBe(0)
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toHaveLength(1)
+  })
+
+  it('fails open when the tool CLI errors on get-labels (offline / auth issue)', async () => {
+    const res = await runCli(['update-status', '42', 'Ready'], sandbox, { FAKE_LABELS_ERROR: '1' })
+    expect(res.code).toBe(0)
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toHaveLength(1)
+  })
+
+  it('coexists with the SRS guard — SRS-labelled ticket with complexity still blocked on code-path targets', async () => {
+    const res = await runCli(['update-status', '42', 'AI testing'], sandbox, { FAKE_LABELS: 'srs:drafting\ncomplexity: low' })
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain('srs:drafting')
+  })
+})

--- a/src/__tests__/unit/skill/workflow-cli.srs-drafting.spec.ts
+++ b/src/__tests__/unit/skill/workflow-cli.srs-drafting.spec.ts
@@ -166,18 +166,18 @@ describe('sf-workflow CLI — SRS drafting lifecycle', () => {
     })
 
     it('allows "In progress" even when srs:drafting is set (drafting lifecycle entry)', async () => {
-      const res = await runCli(['update-status', '42', 'In progress'], sandbox, { FAKE_LABELS: 'srs:drafting' })
+      const res = await runCli(['update-status', '42', 'In progress'], sandbox, { FAKE_LABELS: 'srs:drafting\ncomplexity: low' })
       expect(res.code).toBe(0)
     })
 
     it('allows "Done" even when srs:drafting is set (drafting lifecycle exit)', async () => {
-      const res = await runCli(['update-status', '42', 'Done'], sandbox, { FAKE_LABELS: 'srs:drafting' })
+      const res = await runCli(['update-status', '42', 'Done'], sandbox, { FAKE_LABELS: 'srs:drafting\ncomplexity: low' })
       expect(res.code).toBe(0)
     })
 
     it('bypasses the guard when SF_WORKFLOW_BYPASS_SRS_GUARD=1', async () => {
       const res = await runCli(['update-status', '42', 'AI testing'], sandbox, {
-        FAKE_LABELS: 'srs:drafting',
+        FAKE_LABELS: 'srs:drafting\ncomplexity: low',
         SF_WORKFLOW_BYPASS_SRS_GUARD: '1'
       })
       expect(res.code).toBe(0)


### PR DESCRIPTION
## Summary

Adds a hard-gate in `workflow-cli.sh update-status` that blocks any transition out of Backlog when the ticket has no `complexity:*` label set.

Closes #229.

### Behavior
- Backlog target → always allowed
- Any other target + missing `complexity:*` label → blocked with clear error message
- Fetch error (offline / auth) → fails open (doesn't block)
- Escape hatch: `SF_WORKFLOW_BYPASS_COMPLEXITY_GUARD=1`
- Coexists with the existing SRS drafting guard (SRS wins on code-path targets)

### Changes
- `workflow-cli.sh` + scaffold template: guard logic
- `1-backlog.md`: detect / persist split; `retag` is now mandatory before leaving Backlog
- `SKILL.md`: documents the gate
- New test suite: `workflow-cli.complexity-guard.spec.ts`
- Existing `workflow-cli.srs-drafting.spec.ts`: add `complexity: low` to FAKE_LABELS so tests pass under the new gate

## Test plan

- [x] `npm run test:pre-commit` — 908 tests green (incl. new complexity-guard spec)
- [x] `npm run test:pre-push` — multirepo-minimal + monorepo-minimal docker scenarios green
- [x] Dogfood: #229 itself carries `complexity: low` and transitioned Backlog → Ready → In progress → AI testing → Human testing → In review under the new gate
- [x] SRS drafting guard untouched — coexistence verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)