### PR TITLE
feat(#232): render TC section + align NFR — fix #223 residuals

### DIFF
--- a/.claude/skills/sf-srs/templates/pages/README.md
+++ b/.claude/skills/sf-srs/templates/pages/README.md
@@ -34,12 +34,13 @@ type PageBlock =
 
 Produced by `renderEpicPage(spec)` in this order (DIAMONFORGE-style):
 
-1. `Traceability` (H2) + plain-text code block (ASCII tree `UR → FR → DS → TC`) + explanatory paragraph
-2. `Requirement Types` (H2) + definitions table `Prefix | Type | Description | Example` with one row per UR/FR/DS/NFR
+1. `Traceability` (H2) + plain-text code block (ASCII tree `UR → FR → { DS, TC, NFR }`) + explanatory paragraph
+2. `Requirement Types` (H2) + definitions table `Prefix | Type | Description | Example` with one row per UR/FR/DS/TC/NFR
 3. `User Requirements (UR)` (H2) + table `ID | Requirement | Priority | Related FR`, with group-header rows when items carry a `group`
 4. `Functional Requirements (FR)` (H2) + table `ID | Requirement | Priority | Related UR | Related DS`, grouped
 5. `Design Specifications (DS)` (H2) + table `ID | Specification | Related FR`, grouped
-6. `Non-Functional Requirements (NFR)` (H2) + table `ID | Requirement | Target | Priority | Related FR`, grouped
+6. `Test Cases (TC)` (H2) + table `ID | Title | Steps | Expected Result | Related FR`
+7. `Non-Functional Requirements (NFR)` (H2) + table `ID | Requirement | Target | Priority | Related FR`, grouped
 
 Empty sections emit a placeholder paragraph (e.g. `No user requirements yet.`) instead of the table. Missing optional fields render as the em-dash cell `—`. Group headers appear as a single-cell row
 carrying the group id followed by empty cells matching the table arity.
@@ -48,10 +49,10 @@ carrying the group id followed by empty cells matching the table arity.
 
 Produced by `renderFrPage(spec)` in this order (DIAMONFORGE-style):
 
-1. `Summary` (H2) + table `ID | Requirement | Priority | Related UR | Related DS` — one row per FR item on the page
+1. `Summary` (H2) + table `ID | Requirement | Priority | Related UR | Related DS | Related TC` — one row per FR item on the page
 2. Divider
-3. Per FR item: `{FR-id} — {title}` (H2) + vertical detail table `Field | Value` with canonical rows (in order): `ID`, `Title`, `Endpoint`, `Priority`, `Related UR`, `Related DS`, `Description`,
-   `Request Body`, `Acceptance Criteria`, `Validation Rules`, `Security Rationale`
+3. Per FR item: `{FR-id} — {title}` (H2) + vertical detail table `Field | Value` with canonical rows (in order): `ID`, `Title`, `Endpoint`, `Priority`, `Related UR`, `Related DS`, `Related TC`,
+   `Description`, `Request Body`, `Acceptance Criteria`, `Validation Rules`, `Security Rationale`
 4. Divider **between** items (not after the last item)
 
 List-typed fields (`acceptanceCriteria`, `validationRules`) render as newline-joined `• item` entries within a single cell — Notion preserves newlines in table cells. Missing optional fields render as

--- a/scaffolds/skills-templates/sf-srs/templates/pages/README.md
+++ b/scaffolds/skills-templates/sf-srs/templates/pages/README.md
@@ -34,12 +34,13 @@ type PageBlock =
 
 Produced by `renderEpicPage(spec)` in this order (DIAMONFORGE-style):
 
-1. `Traceability` (H2) + plain-text code block (ASCII tree `UR → FR → DS → TC`) + explanatory paragraph
-2. `Requirement Types` (H2) + definitions table `Prefix | Type | Description | Example` with one row per UR/FR/DS/NFR
+1. `Traceability` (H2) + plain-text code block (ASCII tree `UR → FR → { DS, TC, NFR }`) + explanatory paragraph
+2. `Requirement Types` (H2) + definitions table `Prefix | Type | Description | Example` with one row per UR/FR/DS/TC/NFR
 3. `User Requirements (UR)` (H2) + table `ID | Requirement | Priority | Related FR`, with group-header rows when items carry a `group`
 4. `Functional Requirements (FR)` (H2) + table `ID | Requirement | Priority | Related UR | Related DS`, grouped
 5. `Design Specifications (DS)` (H2) + table `ID | Specification | Related FR`, grouped
-6. `Non-Functional Requirements (NFR)` (H2) + table `ID | Requirement | Target | Priority | Related FR`, grouped
+6. `Test Cases (TC)` (H2) + table `ID | Title | Steps | Expected Result | Related FR`
+7. `Non-Functional Requirements (NFR)` (H2) + table `ID | Requirement | Target | Priority | Related FR`, grouped
 
 Empty sections emit a placeholder paragraph (e.g. `No user requirements yet.`) instead of the table. Missing optional fields render as the em-dash cell `—`. Group headers appear as a single-cell row
 carrying the group id followed by empty cells matching the table arity.
@@ -48,10 +49,10 @@ carrying the group id followed by empty cells matching the table arity.
 
 Produced by `renderFrPage(spec)` in this order (DIAMONFORGE-style):
 
-1. `Summary` (H2) + table `ID | Requirement | Priority | Related UR | Related DS` — one row per FR item on the page
+1. `Summary` (H2) + table `ID | Requirement | Priority | Related UR | Related DS | Related TC` — one row per FR item on the page
 2. Divider
-3. Per FR item: `{FR-id} — {title}` (H2) + vertical detail table `Field | Value` with canonical rows (in order): `ID`, `Title`, `Endpoint`, `Priority`, `Related UR`, `Related DS`, `Description`,
-   `Request Body`, `Acceptance Criteria`, `Validation Rules`, `Security Rationale`
+3. Per FR item: `{FR-id} — {title}` (H2) + vertical detail table `Field | Value` with canonical rows (in order): `ID`, `Title`, `Endpoint`, `Priority`, `Related UR`, `Related DS`, `Related TC`,
+   `Description`, `Request Body`, `Acceptance Criteria`, `Validation Rules`, `Security Rationale`
 4. Divider **between** items (not after the last item)
 
 List-typed fields (`acceptanceCriteria`, `validationRules`) render as newline-joined `• item` entries within a single cell — Notion preserves newlines in table cells. Missing optional fields render as

--- a/src/__tests__/integration/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/integration/tools/notion/srs.adapter.spec.ts
@@ -50,6 +50,7 @@ describeIntegration('NotionSrsAdapter (integration, sandbox)', () => {
         }
       ],
       dsItems: [{ id: 'DS-1', title: 'Use Notion REST API', frRefs: ['FR-1'], group: 'Adapter smoke' }],
+      tcItems: [{ id: 'TC-1', title: 'Adapter round-trip', steps: ['create epic', 'fetch page'], expectedResult: 'fetched content matches spec', frRefs: ['FR-1'] }],
       nfrItems: [{ id: 'NFR-1', title: 'Round-trip latency', target: 'create+fetch ≤ 10s in CI', priority: 'P2', frRefs: ['FR-1'] }]
     }
   })
@@ -84,13 +85,21 @@ describeIntegration('NotionSrsAdapter (integration, sandbox)', () => {
     expect(raw.title).toBe(epicSpec.title)
     expect(raw.blocks.length).toBeGreaterThan(0)
 
-    // Structural assertions on the rendered DIAMONFORGE shape (table count, NFR section, headings)
+    // Structural assertions on the rendered DIAMONFORGE shape (table count, TC + NFR sections, headings)
     const tables = raw.blocks.filter((b) => b.kind === 'table')
-    // 5 tables: Requirement Types + UR + FR + DS + NFR
-    expect(tables).toHaveLength(5)
+    // 6 tables: Requirement Types + UR + FR + DS + TC + NFR
+    expect(tables).toHaveLength(6)
     const headings = raw.blocks.filter((b) => b.kind === 'heading').map((b) => b.text)
     expect(headings).toEqual(
-      expect.arrayContaining(['Traceability', 'Requirement Types', 'User Requirements (UR)', 'Functional Requirements (FR)', 'Design Specifications (DS)', 'Non-Functional Requirements (NFR)'])
+      expect.arrayContaining([
+        'Traceability',
+        'Requirement Types',
+        'User Requirements (UR)',
+        'Functional Requirements (FR)',
+        'Design Specifications (DS)',
+        'Test Cases (TC)',
+        'Non-Functional Requirements (NFR)'
+      ])
     )
 
     const children = await adapter.listChildren(epic.id)

--- a/src/__tests__/unit/srs/templates/epic.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/epic.tpl.spec.ts
@@ -44,6 +44,7 @@ describe('renderEpicPage — DIAMONFORGE-style structure', () => {
         { id: 'DS-AUTH-01-01', title: 'bcrypt', frRefs: ['FR-AUTH-01-01'], group: 'DS-AUTH-01' },
         { id: 'DS-AUTH-03-01', title: 'JWT cookies', frRefs: ['FR-AUTH-02-01'], group: 'DS-AUTH-03' }
       ],
+      tcItems: [{ id: 'TC-AUTH-01-01', title: 'successful login', steps: ['submit valid credentials'], expectedResult: '200 OK + cookie set', frRefs: ['FR-AUTH-02-01'] }],
       nfrItems: [{ id: 'NFR-AUTH-01-01', title: 'login speed', target: '≤ 1s p95', priority: 'P1', frRefs: ['FR-AUTH-02-01'], group: 'NFR-AUTH-01' }]
     }
 
@@ -62,18 +63,20 @@ describe('renderEpicPage — DIAMONFORGE-style structure', () => {
       'table',
       'heading:2', // DS
       'table',
+      'heading:2', // TC
+      'table',
       'heading:2', // NFR
       'table'
     ])
   })
 
-  it('renders the Requirement Types table with UR/FR/DS/NFR rows', () => {
+  it('renders the Requirement Types table with UR/FR/DS/TC/NFR rows', () => {
     const spec: EpicSpec = { title: 'E', parentPageId: 'p', urs: [], frs: [] }
     const page = renderEpicPage(spec)
     const reqTypes = findTableAfterHeading(page.blocks, 'Requirement Types')
     expect(reqTypes.header).toEqual(['Prefix', 'Type', 'Description', 'Example'])
     const prefixes = reqTypes.rows.map((r) => r[0])
-    expect(prefixes).toEqual(['UR', 'FR', 'DS', 'NFR'])
+    expect(prefixes).toEqual(['UR', 'FR', 'DS', 'TC', 'NFR'])
   })
 
   it('renders the UR table with group headers and Related FR derived from spec.frs', () => {
@@ -174,7 +177,28 @@ describe('renderEpicPage — DIAMONFORGE-style structure', () => {
     expect(findParagraphAfterHeading(page.blocks, 'User Requirements (UR)')).toBe('No user requirements yet.')
     expect(findParagraphAfterHeading(page.blocks, 'Functional Requirements (FR)')).toBe('No functional requirements yet.')
     expect(findParagraphAfterHeading(page.blocks, 'Design Specifications (DS)')).toBe('No design specifications yet.')
+    expect(findParagraphAfterHeading(page.blocks, 'Test Cases (TC)')).toBe('No test cases yet.')
     expect(findParagraphAfterHeading(page.blocks, 'Non-Functional Requirements (NFR)')).toBe('No non-functional requirements yet.')
+  })
+
+  it('renders the TC table with Steps + Expected Result + Related FR', () => {
+    const spec: EpicSpec = {
+      title: 'E',
+      parentPageId: 'p',
+      urs: [],
+      frs: [],
+      tcItems: [
+        { id: 'TC-X-01', title: 'happy path', steps: ['step a', 'step b'], expectedResult: '200 OK', frRefs: ['FR-X-01'] },
+        { id: 'TC-X-02', title: 'empty body' }
+      ]
+    }
+    const page = renderEpicPage(spec)
+    const tcTable = findTableAfterHeading(page.blocks, 'Test Cases (TC)')
+    expect(tcTable.header).toEqual(['ID', 'Title', 'Steps', 'Expected Result', 'Related FR'])
+    expect(tcTable.rows).toEqual([
+      ['TC-X-01', 'happy path', '• step a\n• step b', '200 OK', 'FR-X-01'],
+      ['TC-X-02', 'empty body', '—', '—', '—']
+    ])
   })
 
   it('emits the Traceability tree as a plain-text code block', () => {
@@ -189,6 +213,7 @@ describe('renderEpicPage — DIAMONFORGE-style structure', () => {
       expect(codeBlock.text).toContain('FR (Functional Requirement)')
       expect(codeBlock.text).toContain('DS (Design Specification)')
       expect(codeBlock.text).toContain('TC (Test Case)')
+      expect(codeBlock.text).toContain('NFR (Non-Functional Requirement)')
     }
   })
 

--- a/src/__tests__/unit/srs/templates/fr.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/fr.tpl.spec.ts
@@ -29,7 +29,7 @@ describe('renderFrPage — DIAMONFORGE-style structure', () => {
     expect(kinds).toEqual(['heading:2:Summary', 'table', 'divider', 'heading:2:FR-AUTH-01-01 — Sign in', 'table'])
   })
 
-  it('renders the Summary table with the 5 canonical columns', () => {
+  it('renders the Summary table with the 6 canonical columns', () => {
     const spec: FrSpec = {
       parentEpicPageId: 'epic',
       fr: {
@@ -37,16 +37,17 @@ describe('renderFrPage — DIAMONFORGE-style structure', () => {
         title: 'Sign in',
         priority: 'P1',
         urRefs: ['UR-AUTH-01-01'],
-        dsRefs: ['DS-AUTH-01-01', 'DS-AUTH-01-02']
+        dsRefs: ['DS-AUTH-01-01', 'DS-AUTH-01-02'],
+        tcRefs: ['TC-AUTH-01-01']
       }
     }
     const page = renderFrPage(spec)
     const summary = findTableAfterHeading(page.blocks, 'Summary')
-    expect(summary.header).toEqual(['ID', 'Requirement', 'Priority', 'Related UR', 'Related DS'])
-    expect(summary.rows).toEqual([['FR-AUTH-01-01', 'Sign in', 'P1', 'UR-AUTH-01-01', 'DS-AUTH-01-01, DS-AUTH-01-02']])
+    expect(summary.header).toEqual(['ID', 'Requirement', 'Priority', 'Related UR', 'Related DS', 'Related TC'])
+    expect(summary.rows).toEqual([['FR-AUTH-01-01', 'Sign in', 'P1', 'UR-AUTH-01-01', 'DS-AUTH-01-01, DS-AUTH-01-02', 'TC-AUTH-01-01']])
   })
 
-  it('renders a vertical detail table with all 11 canonical rows', () => {
+  it('renders a vertical detail table with all 12 canonical rows', () => {
     const spec: FrSpec = {
       parentEpicPageId: 'epic',
       fr: {
@@ -57,6 +58,7 @@ describe('renderFrPage — DIAMONFORGE-style structure', () => {
         priority: 'P1',
         urRefs: ['UR-AUTH-01-01'],
         dsRefs: ['DS-AUTH-01-01'],
+        tcRefs: ['TC-AUTH-01-01', 'TC-AUTH-01-02'],
         requestBody: '{ email, password }',
         acceptanceCriteria: ['returns 200 on success', 'returns 401 on invalid credentials'],
         validationRules: ['email required', 'password min 8 chars'],
@@ -73,6 +75,7 @@ describe('renderFrPage — DIAMONFORGE-style structure', () => {
       ['Priority', 'P1'],
       ['Related UR', 'UR-AUTH-01-01'],
       ['Related DS', 'DS-AUTH-01-01'],
+      ['Related TC', 'TC-AUTH-01-01, TC-AUTH-01-02'],
       ['Description', 'Authenticate user via email + password'],
       ['Request Body', '{ email, password }'],
       ['Acceptance Criteria', '• returns 200 on success\n• returns 401 on invalid credentials'],
@@ -85,7 +88,7 @@ describe('renderFrPage — DIAMONFORGE-style structure', () => {
     const spec: FrSpec = { parentEpicPageId: 'epic', fr: { id: 'FR-1', title: 'Minimal' } }
     const page = renderFrPage(spec)
     const summary = findTableAfterHeading(page.blocks, 'Summary')
-    expect(summary.rows).toEqual([['FR-1', 'Minimal', '—', '—', '—']])
+    expect(summary.rows).toEqual([['FR-1', 'Minimal', '—', '—', '—', '—']])
 
     const detail = findTableAfterHeading(page.blocks, 'FR-1 — Minimal')
     const cellFor = (label: string) => detail.rows.find((row) => row[0] === label)?.[1]
@@ -93,6 +96,7 @@ describe('renderFrPage — DIAMONFORGE-style structure', () => {
     expect(cellFor('Priority')).toBe('—')
     expect(cellFor('Related UR')).toBe('—')
     expect(cellFor('Related DS')).toBe('—')
+    expect(cellFor('Related TC')).toBe('—')
     expect(cellFor('Description')).toBe('—')
     expect(cellFor('Request Body')).toBe('—')
     expect(cellFor('Acceptance Criteria')).toBe('—')

--- a/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
@@ -312,7 +312,7 @@ describe('NotionSrsAdapter', () => {
       expect(types).toEqual(['heading_2', 'table', 'divider', 'heading_2', 'table'])
       const tables = call.children.filter((c): c is AnyBlock & { table: { table_width: number; has_column_header: boolean } } => c.type === 'table' && c.table !== undefined)
       expect(tables).toHaveLength(2)
-      expect(tables[0].table.table_width).toBe(5) // Summary: ID, Requirement, Priority, Related UR, Related DS
+      expect(tables[0].table.table_width).toBe(6) // Summary: ID, Requirement, Priority, Related UR, Related DS, Related TC
       expect(tables[0].table.has_column_header).toBe(true)
       expect(tables[1].table.table_width).toBe(2) // Detail: Field, Value
       expect(tables[1].table.has_column_header).toBe(true)
@@ -320,7 +320,7 @@ describe('NotionSrsAdapter', () => {
   })
 
   describe('createEpicPage — DIAMONFORGE structural shape', () => {
-    it('emits Traceability + Requirement Types + UR/FR/DS/NFR sections with grouped tables', async () => {
+    it('emits Traceability + Requirement Types + UR/FR/DS/TC/NFR sections with grouped tables', async () => {
       const richEpic: EpicSpec = {
         title: 'Auth epic',
         parentPageId: 'parent_xyz',
@@ -330,6 +330,7 @@ describe('NotionSrsAdapter', () => {
         ],
         frs: [{ id: 'FR-AUTH-01', title: 'Sign in endpoint', group: 'Sign-in flow', urRefs: ['UR-AUTH-01'] }],
         dsItems: [{ id: 'DS-AUTH-01', title: 'JWT cookie', group: 'Sign-in flow', frRefs: ['FR-AUTH-01'] }],
+        tcItems: [{ id: 'TC-AUTH-01', title: 'sign-in happy path', steps: ['submit valid creds'], expectedResult: '200 OK', frRefs: ['FR-AUTH-01'] }],
         nfrItems: [{ id: 'NFR-PERF-01', title: 'Login latency', target: 'p95 ≤ 1s', priority: 'P1', frRefs: ['FR-AUTH-01'] }]
       }
       const { client, calls } = buildMockClient()
@@ -344,15 +345,23 @@ describe('NotionSrsAdapter', () => {
       const call = calls.pagesCreateCalls[0] as unknown as { children: AnyBlock[] }
       const types = call.children.map((c) => c.type)
       // Notion page title is set as page property (not a child block);
-      // children start at heading_2 (Traceability) + code + paragraph + heading_2 (Requirement Types) + table + UR/FR/DS/NFR (H2 + table each)
+      // children start at heading_2 (Traceability) + code + paragraph + heading_2 (Requirement Types) + table + UR/FR/DS/TC/NFR (H2 + table each)
       expect(types[0]).toBe('heading_2')
       expect(types).toContain('code')
       const tables = call.children.filter((c) => c.type === 'table')
-      expect(tables).toHaveLength(5) // Requirement Types, UR, FR, DS, NFR
+      expect(tables).toHaveLength(6) // Requirement Types, UR, FR, DS, TC, NFR
 
       const headings = call.children.filter((c): c is AnyBlock & { heading_2: { rich_text: Array<{ text: { content: string } }> } } => c.type === 'heading_2' && c.heading_2 !== undefined)
       const headingTexts = headings.map((h) => h.heading_2.rich_text[0].text.content)
-      expect(headingTexts).toEqual(['Traceability', 'Requirement Types', 'User Requirements (UR)', 'Functional Requirements (FR)', 'Design Specifications (DS)', 'Non-Functional Requirements (NFR)'])
+      expect(headingTexts).toEqual([
+        'Traceability',
+        'Requirement Types',
+        'User Requirements (UR)',
+        'Functional Requirements (FR)',
+        'Design Specifications (DS)',
+        'Test Cases (TC)',
+        'Non-Functional Requirements (NFR)'
+      ])
     })
 
     it('renders empty placeholder paragraphs when sections have no items', async () => {
@@ -376,7 +385,7 @@ describe('NotionSrsAdapter', () => {
             c.type === 'paragraph' && c.paragraph !== undefined && c.paragraph.rich_text[0]?.text.content.startsWith('No ')
         )
         .map((c) => c.paragraph.rich_text[0].text.content)
-      expect(placeholderTexts).toEqual(['No user requirements yet.', 'No functional requirements yet.', 'No design specifications yet.', 'No non-functional requirements yet.'])
+      expect(placeholderTexts).toEqual(['No user requirements yet.', 'No functional requirements yet.', 'No design specifications yet.', 'No test cases yet.', 'No non-functional requirements yet.'])
     })
   })
 

--- a/src/builders/srs/templates/pages/epic.tpl.ts
+++ b/src/builders/srs/templates/pages/epic.tpl.ts
@@ -1,4 +1,4 @@
-import { DsItem, EpicSpec, FrItem, NfrItem, PageBlock, PageContent, Priority, UrItem } from '../../types'
+import { DsItem, EpicSpec, FrItem, NfrItem, PageBlock, PageContent, Priority, TcItem, UrItem } from '../../types'
 
 const EMPTY_CELL = '—'
 
@@ -14,13 +14,20 @@ const REQUIREMENT_TYPES_ROWS: string[][] = [
   ['UR', 'User Requirement', "High-level user need describing what the user wants to achieve. Written from the user's perspective.", '"The user must be able to log in to access the product"'],
   ['FR', 'Functional Requirement', 'What the system must do to fulfill user requirements. Describes system behavior.', '"The system displays a generic error message on login failure"'],
   ['DS', 'Design Specification', 'How the system implements the functional requirements. Technical implementation details.', '"JWT tokens stored in httpOnly cookies"'],
+  [
+    'TC',
+    'Test Case',
+    'Verifiable steps that prove a functional requirement is satisfied. Bridges spec and QA.',
+    '"Given valid credentials, when user submits login form, then 200 OK and JWT cookie set"'
+  ],
   ['NFR', 'Non-Functional Requirement', 'Quality attributes: performance, security, availability, scalability.', '"Login response time ≤ 1 second (p95)"']
 ]
 
 const TRACEABILITY_TREE = `UR (User Requirement)
   └── FR (Functional Requirement)
-        └── DS (Design Specification)
-              └── TC (Test Case)`
+        ├── DS (Design Specification)
+        ├── TC (Test Case)
+        └── NFR (Non-Functional Requirement)`
 
 const TRACEABILITY_NOTE = 'Each lower-level requirement traces back to a higher-level requirement, ensuring complete coverage and compliance traceability.'
 
@@ -61,6 +68,15 @@ function dsRow(ds: DsItem): string[] {
 
 function nfrRow(nfr: NfrItem): string[] {
   return [nfr.id, nfr.title, nfr.target ?? EMPTY_CELL, priorityCell(nfr.priority), refsCell(nfr.frRefs)]
+}
+
+function listCell(items?: string[]): string {
+  if (!items || items.length === 0) return EMPTY_CELL
+  return items.map((item) => `• ${item}`).join('\n')
+}
+
+function tcRow(tc: TcItem): string[] {
+  return [tc.id, tc.title, listCell(tc.steps), tc.expectedResult ?? EMPTY_CELL, refsCell(tc.frRefs)]
 }
 
 export function renderEpicPage(spec: EpicSpec): PageContent {
@@ -108,6 +124,18 @@ export function renderEpicPage(spec: EpicSpec): PageContent {
       kind: 'table',
       header: ['ID', 'Specification', 'Related FR'],
       rows: buildGroupedRows(dsItems, (ds) => ds.group, dsRow)
+    })
+  }
+
+  const tcItems = spec.tcItems ?? []
+  blocks.push({ kind: 'heading', level: 2, text: 'Test Cases (TC)' })
+  if (tcItems.length === 0) {
+    blocks.push({ kind: 'paragraph', text: 'No test cases yet.' })
+  } else {
+    blocks.push({
+      kind: 'table',
+      header: ['ID', 'Title', 'Steps', 'Expected Result', 'Related FR'],
+      rows: tcItems.map(tcRow)
     })
   }
 

--- a/src/builders/srs/templates/pages/fr.tpl.ts
+++ b/src/builders/srs/templates/pages/fr.tpl.ts
@@ -20,7 +20,7 @@ function listCell(items?: string[]): string {
 }
 
 function summaryRow(fr: FrItem): string[] {
-  return [fr.id, fr.title, priorityCell(fr.priority), refsCell(fr.urRefs), refsCell(fr.dsRefs)]
+  return [fr.id, fr.title, priorityCell(fr.priority), refsCell(fr.urRefs), refsCell(fr.dsRefs), refsCell(fr.tcRefs)]
 }
 
 function detailRows(fr: FrItem): string[][] {
@@ -31,6 +31,7 @@ function detailRows(fr: FrItem): string[][] {
     ['Priority', priorityCell(fr.priority)],
     ['Related UR', refsCell(fr.urRefs)],
     ['Related DS', refsCell(fr.dsRefs)],
+    ['Related TC', refsCell(fr.tcRefs)],
     ['Description', textCell(fr.description)],
     ['Request Body', textCell(fr.requestBody)],
     ['Acceptance Criteria', listCell(fr.acceptanceCriteria)],
@@ -46,7 +47,7 @@ export function renderFrPage(spec: FrSpec): PageContent {
   blocks.push({ kind: 'heading', level: 2, text: 'Summary' })
   blocks.push({
     kind: 'table',
-    header: ['ID', 'Requirement', 'Priority', 'Related UR', 'Related DS'],
+    header: ['ID', 'Requirement', 'Priority', 'Related UR', 'Related DS', 'Related TC'],
     rows: frs.map(summaryRow)
   })
 


### PR DESCRIPTION
## Summary

Closes the residual TC/NFR inconsistencies left by #223 in the epic & FR templates.

Closes #232.

### Changes
- `epic.tpl` — add TC row to Requirement Types; new Test Cases (TC) section rendering `spec.tcItems`; traceability tree includes NFR + TC alongside DS
- `fr.tpl` — Related TC column in Summary; Related TC row in per-item detail (11 → 12 rows)
- Unit & integration tests updated: 5 → 6 tables on Epic, 6 → 7 heading sections, Summary table_width 5 → 6
- `sf-srs/templates/pages/README.md` + scaffold mirror synced
- #187 (migrate) and #202 (eval) bodies refreshed to reference UR/FR/DS/TC/NFR and dependency on #223/#232

### Why
#223 added the NFR section but left `tcItems` as a dead data path (typed but never rendered) and the traceability tree mismatching the rendered sections. TC and NFR stay conceptually distinct (test cases vs quality attributes) — both are now rendered end-to-end.

## Test plan

- [x] `npm run test:pre-commit` — 921 tests green (incl. new TC assertions)
- [x] `npm run test:pre-push` — multirepo-minimal + monorepo-minimal docker scenarios green
- [x] `tcItems` round-trip through adapter + renderer verified by unit spec structural assertions
- [x] Empty-epic placeholder now emits "No test cases yet." (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)