### PR TITLE
[#203] SRS capstone — dogfood audit + 12 follow-ups under #235

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -371,3 +371,26 @@ trivial one.
 2. **Never hardcode backend branches** (`if backend === 'notion'`) ; the registry in `src/srs/` is the only place that knows about concrete backends
 3. **Never call `gh`, the Notion SDK, or any tool-specific CLI directly** ; delegate through the adapter or through `sf-tool-<backend>`
 4. **Every new SUB under #174 ships its artefact in the directory map above** — do not invent new locations
+
+## Lessons learned — #203 capstone dogfood (2026-04-23)
+
+Running the full `sf srs` chain end-to-end on SaaSFoundry itself surfaced 12 gaps consolidated under parent #235. Key takeaways agents should know about:
+
+- **Matcher is endpoint-biased (#236).** Today's `matcher.ts` only counts an FR as matched when an HTTP endpoint finding shares its area. Non-backend FRs (frontend-only pages, CLI commands, infra
+  jobs) score 0 regardless of test coverage. Until fixed, treat low eval scores on non-backend projects as likely false negatives, not real drift.
+- **Inventory walk assumes rootPage→Epic is direct (#237).** Bootstrap produces rootPage → `User flows & Specifications` category → Epics. Eval without `--root-page <category.id>` returns
+  `FR.total = 0`. Until fixed, always pass `--root-page` when running eval on a standard manifest.
+- **Scan from CWD ratisse scaffolds/ + docs/ (#238).** On CLI / library projects, run `draft --from codebase --path src` — a full-repo scan drowns real findings with template code.
+- **Bootstrap does not persist `NOTION_API_TOKEN` (#239).** After `sf update --add-modules srs`, the token lives only in the interactive shell. For non-interactive / Claude bash sessions, load it from
+  `.env` with `set -a && source .env && set +a` until the fix lands.
+- **`write-srs` needs two passes today (#245).** Epics must be written first to obtain page IDs, then an FR spec referencing `parentEpicPageId` is generated, then written. Scripted in `.srs-audit/` as
+  reference until logical-ID resolution lands.
+- **SRS completeness is UR+FR only (#247).** DS / TC / NFR are not generated yet. The DIAMONFORGE reference shape expects all five. AI-assisted generation planned under #247, reusing the L1+L2+L3
+  matcher architecture.
+- **Preconditions first.** Before asking the user scope questions (backend choice, Notion parent page, etc.), read `.saasfoundry.json` — the answers are almost always already there. Re-running
+  `sf update --add-modules srs` on an already-installed module silently re-bootstraps and duplicates Notion pages (#240).
+
+Artefacts from the capstone (kept for reference):
+
+- `.srs-audit/follow-ups.md` — full lessons-learned analysis
+- `.srs-audit/baseline-report-fixed-root.json` — first eval baseline (score 32, all FRs flagged fr-without-code due to #236)

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,13 @@ docs/.vitepress/dist/
 
 # Claude Code runtime
 .claude/scheduled_tasks.lock
+
+# Local env (tokens, secrets — never committed)
+.env
+.env.local
+
+# Local audit workspace (lessons-learned capstone #203) — drafts, reports, scratch
+/.srs-audit/*
+# …except the persisted artefacts referenced by #203 exit conditions
+!/.srs-audit/follow-ups.md
+!/.srs-audit/baseline-report-fixed-root.json

--- a/.saasfoundry.json
+++ b/.saasfoundry.json
@@ -20,13 +20,34 @@
       "types": ["feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "ci", "build", "revert"]
     },
     "statuses": [
-      { "name": "Backlog", "color": "GRAY" },
-      { "name": "Ready", "color": "YELLOW" },
-      { "name": "In progress", "color": "BLUE" },
-      { "name": "AI testing", "color": "PURPLE" },
-      { "name": "Human testing", "color": "ORANGE" },
-      { "name": "In review", "color": "PINK" },
-      { "name": "Done", "color": "GREEN" }
+      {
+        "name": "Backlog",
+        "color": "GRAY"
+      },
+      {
+        "name": "Ready",
+        "color": "YELLOW"
+      },
+      {
+        "name": "In progress",
+        "color": "BLUE"
+      },
+      {
+        "name": "AI testing",
+        "color": "PURPLE"
+      },
+      {
+        "name": "Human testing",
+        "color": "ORANGE"
+      },
+      {
+        "name": "In review",
+        "color": "PINK"
+      },
+      {
+        "name": "Done",
+        "color": "GREEN"
+      }
     ]
   },
   "tools": {
@@ -34,14 +55,14 @@
       "enabled": true,
       "backend": "notion",
       "rootPage": {
-        "id": "34aa31bb-4f3f-8170-8989-d8738f3356d8",
-        "url": "https://www.notion.so/saasfoundry-cli-Project-Overview-34aa31bb4f3f81708989d8738f3356d8",
-        "name": "saasfoundry-cli — Project Overview"
+        "id": "34ba31bb-4f3f-8139-a6e4-f4327648a6b9",
+        "url": "https://www.notion.so/saasfoundry-cli-srs-34ba31bb4f3f8139a6e4f4327648a6b9",
+        "name": "saasfoundry-cli-srs"
       },
       "categories": {
         "userFlowsAndSpecifications": {
-          "id": "34aa31bb-4f3f-814c-abb7-c345d0f8a9cb",
-          "url": "https://www.notion.so/User-flows-Specifications-34aa31bb4f3f814cabb7c345d0f8a9cb",
+          "id": "34ba31bb-4f3f-8163-ac75-fb4acf80f6c9",
+          "url": "https://www.notion.so/User-flows-Specifications-34ba31bb4f3f8163ac75fb4acf80f6c9",
           "name": "User flows & Specifications"
         }
       }

--- a/.srs-audit/baseline-report-fixed-root.json
+++ b/.srs-audit/baseline-report-fixed-root.json
@@ -1,0 +1,371 @@
+{
+  "generatedAt": "2026-04-23T16:04:08.512Z",
+  "rootPageId": "34ba31bb-4f3f-8163-ac75-fb4acf80f6c9",
+  "thresholdPct": 80,
+  "overall": {
+    "score": 32,
+    "status": "drift"
+  },
+  "categories": {
+    "UR": {
+      "total": 0,
+      "covered": 0,
+      "score": null,
+      "note": "UR drift is not evaluated in v1 — rendered Notion tables return empty cells via fetchPage. Follow-up work will extend the adapter to preserve table rows."
+    },
+    "FR": {
+      "total": 34,
+      "covered": 0,
+      "score": 0
+    },
+    "DS": {
+      "total": 0,
+      "covered": 0,
+      "score": null,
+      "note": "DS drift is not evaluated in v1 — rendered Notion tables return empty cells via fetchPage. Follow-up work will extend the adapter to preserve table rows."
+    },
+    "TC": {
+      "total": 0,
+      "covered": 0,
+      "score": null,
+      "note": "TC drift is not evaluated in v1 — rendered Notion tables return empty cells via fetchPage. Follow-up work will extend the adapter to preserve table rows."
+    },
+    "NFR": {
+      "total": 0,
+      "covered": 0,
+      "score": null,
+      "note": "NFR drift is not evaluated in v1 — rendered Notion tables return empty cells via fetchPage. Follow-up work will extend the adapter to preserve table rows."
+    }
+  },
+  "counts": {
+    "frTotal": 34,
+    "frMatched": 0,
+    "frUntested": 0,
+    "endpointsTotal": 23,
+    "endpointsMatched": 0,
+    "endpointsUntested": 1
+  },
+  "findings": [
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-COMMANDS-01 — \"sf new — scaffold a new project\" has no matching code finding in area \"commands\"",
+      "frId": "FR-COMMANDS-01",
+      "frTitle": "sf new — scaffold a new project",
+      "area": "commands"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-COMMANDS-02 — \"sf update — add modules to an existing project\" has no matching code finding in area \"commands\"",
+      "frId": "FR-COMMANDS-02",
+      "frTitle": "sf update — add modules to an existing project",
+      "area": "commands"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-COMMANDS-03 — \"sf workflow — manage workflow configuration\" has no matching code finding in area \"commands\"",
+      "frId": "FR-COMMANDS-03",
+      "frTitle": "sf workflow — manage workflow configuration",
+      "area": "commands"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-COMMANDS-04 — \"sf skill — install and uninstall AI skills\" has no matching code finding in area \"commands\"",
+      "frId": "FR-COMMANDS-04",
+      "frTitle": "sf skill — install and uninstall AI skills",
+      "area": "commands"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-COMMANDS-05 — \"sf tools — list & configure tool accounts\" has no matching code finding in area \"commands\"",
+      "frId": "FR-COMMANDS-05",
+      "frTitle": "sf tools — list & configure tool accounts",
+      "area": "commands"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-COMMANDS-06 — \"sf modules — list available optional modules\" has no matching code finding in area \"commands\"",
+      "frId": "FR-COMMANDS-06",
+      "frTitle": "sf modules — list available optional modules",
+      "area": "commands"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-COMMANDS-07 — \"sf feedback — submit feedback\" has no matching code finding in area \"commands\"",
+      "frId": "FR-COMMANDS-07",
+      "frTitle": "sf feedback — submit feedback",
+      "area": "commands"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-COMMANDS-08 — \"sf uninstall — full uninstall\" has no matching code finding in area \"commands\"",
+      "frId": "FR-COMMANDS-08",
+      "frTitle": "sf uninstall — full uninstall",
+      "area": "commands"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-BUILDERS-01 — \"API builder — NestJS backend\" has no matching code finding in area \"builders\"",
+      "frId": "FR-BUILDERS-01",
+      "frTitle": "API builder — NestJS backend",
+      "area": "builders"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-BUILDERS-02 — \"Web builder — React frontend\" has no matching code finding in area \"builders\"",
+      "frId": "FR-BUILDERS-02",
+      "frTitle": "Web builder — React frontend",
+      "area": "builders"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-BUILDERS-03 — \"DB builder — PostgreSQL + Prisma\" has no matching code finding in area \"builders\"",
+      "frId": "FR-BUILDERS-03",
+      "frTitle": "DB builder — PostgreSQL + Prisma",
+      "area": "builders"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-BUILDERS-04 — \"S3 builder — object storage infra\" has no matching code finding in area \"builders\"",
+      "frId": "FR-BUILDERS-04",
+      "frTitle": "S3 builder — object storage infra",
+      "area": "builders"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-BUILDERS-05 — \"Monorepo overlay\" has no matching code finding in area \"builders\"",
+      "frId": "FR-BUILDERS-05",
+      "frTitle": "Monorepo overlay",
+      "area": "builders"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-BUILDERS-06 — \"Multirepo overlay\" has no matching code finding in area \"builders\"",
+      "frId": "FR-BUILDERS-06",
+      "frTitle": "Multirepo overlay",
+      "area": "builders"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-BUILDERS-07 — \"Dev-services builder — docker-compose dev stack\" has no matching code finding in area \"builders\"",
+      "frId": "FR-BUILDERS-07",
+      "frTitle": "Dev-services builder — docker-compose dev stack",
+      "area": "builders"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-MODULES-01 — \"Email module — MailerSend integration\" has no matching code finding in area \"modules\"",
+      "frId": "FR-MODULES-01",
+      "frTitle": "Email module — MailerSend integration",
+      "area": "modules"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-MODULES-02 — \"Storage module — S3 object storage\" has no matching code finding in area \"modules\"",
+      "frId": "FR-MODULES-02",
+      "frTitle": "Storage module — S3 object storage",
+      "area": "modules"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-MODULES-03 — \"Analytics module — Umami\" has no matching code finding in area \"modules\"",
+      "frId": "FR-MODULES-03",
+      "frTitle": "Analytics module — Umami",
+      "area": "modules"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-MODULES-04 — \"SRS module — Notion workspace bootstrap\" has no matching code finding in area \"modules\"",
+      "frId": "FR-MODULES-04",
+      "frTitle": "SRS module — Notion workspace bootstrap",
+      "area": "modules"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-MODULES-05 — \"Advanced skills — Context7, Atlassian, Notion, Figma\" has no matching code finding in area \"modules\"",
+      "frId": "FR-MODULES-05",
+      "frTitle": "Advanced skills — Context7, Atlassian, Notion, Figma",
+      "area": "modules"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-SRS-01 — \"Scan codebase — endpoint/entity/test/doc-context scanners\" has no matching code finding in area \"srs\"",
+      "frId": "FR-SRS-01",
+      "frTitle": "Scan codebase — endpoint/entity/test/doc-context scanners",
+      "area": "srs"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-SRS-02 — \"Draft from codebase\" has no matching code finding in area \"srs\"",
+      "frId": "FR-SRS-02",
+      "frTitle": "Draft from codebase",
+      "area": "srs"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-SRS-03 — \"Draft from Notion pages\" has no matching code finding in area \"srs\"",
+      "frId": "FR-SRS-03",
+      "frTitle": "Draft from Notion pages",
+      "area": "srs"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-SRS-04 — \"Write drafts to backend\" has no matching code finding in area \"srs\"",
+      "frId": "FR-SRS-04",
+      "frTitle": "Write drafts to backend",
+      "area": "srs"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-SRS-05 — \"Browse backend tree\" has no matching code finding in area \"srs\"",
+      "frId": "FR-SRS-05",
+      "frTitle": "Browse backend tree",
+      "area": "srs"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-SRS-06 — \"Eval freshness vs codebase\" has no matching code finding in area \"srs\"",
+      "frId": "FR-SRS-06",
+      "frTitle": "Eval freshness vs codebase",
+      "area": "srs"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-SRS-07 — \"Spawn Story tickets from Epic\" has no matching code finding in area \"srs\"",
+      "frId": "FR-SRS-07",
+      "frTitle": "Spawn Story tickets from Epic",
+      "area": "srs"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-SRS-08 — \"Apply conversational SRS update\" has no matching code finding in area \"srs\"",
+      "frId": "FR-SRS-08",
+      "frTitle": "Apply conversational SRS update",
+      "area": "srs"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-WORKFLOW-01 — \"Create subtask — GitHub sub-issue\" has no matching code finding in area \"workflow\"",
+      "frId": "FR-WORKFLOW-01",
+      "frTitle": "Create subtask — GitHub sub-issue",
+      "area": "workflow"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-WORKFLOW-02 — \"Update status — workflow transitions\" has no matching code finding in area \"workflow\"",
+      "frId": "FR-WORKFLOW-02",
+      "frTitle": "Update status — workflow transitions",
+      "area": "workflow"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-WORKFLOW-03 — \"Complexity guard — label enforcement\" has no matching code finding in area \"workflow\"",
+      "frId": "FR-WORKFLOW-03",
+      "frTitle": "Complexity guard — label enforcement",
+      "area": "workflow"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-WORKFLOW-04 — \"Create PR with test-plan check\" has no matching code finding in area \"workflow\"",
+      "frId": "FR-WORKFLOW-04",
+      "frTitle": "Create PR with test-plan check",
+      "area": "workflow"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-WORKFLOW-05 — \"Configure workflow — branches & AI rules\" has no matching code finding in area \"workflow\"",
+      "frId": "FR-WORKFLOW-05",
+      "frTitle": "Configure workflow — branches & AI rules",
+      "area": "workflow"
+    },
+    {
+      "kind": "fr-without-code",
+      "severity": "error",
+      "message": "FR FR-WORKFLOW-06 — \"Bypass-srs meta flag\" has no matching code finding in area \"workflow\"",
+      "frId": "FR-WORKFLOW-06",
+      "frTitle": "Bypass-srs meta flag",
+      "area": "workflow"
+    },
+    {
+      "kind": "orphan-area",
+      "severity": "error",
+      "message": "Code area \"accounts\" carries 6 endpoint(s) but has no FR page (e.g. GET /accounts/:id)",
+      "area": "accounts",
+      "file": "scaffolds/blueprints/api/src/modules/accounts/controllers/account.controller.ts"
+    },
+    {
+      "kind": "orphan-area",
+      "severity": "error",
+      "message": "Code area \"api-docs\" carries 1 endpoint(s) but has no FR page (e.g. GET /api/docs/openapi.json)",
+      "area": "api-docs",
+      "file": "scaffolds/blueprints/api/src/modules/api-docs/controllers/api-docs.controller.ts"
+    },
+    {
+      "kind": "orphan-area",
+      "severity": "error",
+      "message": "Code area \"auth\" carries 7 endpoint(s) but has no FR page (e.g. POST /auth/signup)",
+      "area": "auth",
+      "file": "scaffolds/blueprints/api/src/modules/auth/controllers/auth.controller.ts"
+    },
+    {
+      "kind": "orphan-area",
+      "severity": "error",
+      "message": "Code area \"entities\" carries 2 endpoint(s) but has no FR page (e.g. POST /entities)",
+      "area": "entities",
+      "file": "scaffolds/blueprints/api/src/modules/entities/controllers/entity.controller.ts"
+    },
+    {
+      "kind": "orphan-area",
+      "severity": "error",
+      "message": "Code area \"health\" carries 1 endpoint(s) but has no FR page (e.g. GET /health)",
+      "area": "health",
+      "file": "scaffolds/blueprints/api/src/modules/health/controllers/health.controller.ts"
+    },
+    {
+      "kind": "orphan-area",
+      "severity": "error",
+      "message": "Code area \"invitation\" carries 3 endpoint(s) but has no FR page (e.g. POST /invitations)",
+      "area": "invitation",
+      "file": "scaffolds/blueprints/api/src/modules/invitation/controllers/invitation.controller.ts"
+    },
+    {
+      "kind": "orphan-area",
+      "severity": "error",
+      "message": "Code area \"organizations\" carries 3 endpoint(s) but has no FR page (e.g. GET /organizations/:id)",
+      "area": "organizations",
+      "file": "scaffolds/blueprints/api/src/modules/organizations/controllers/organization.controller.ts"
+    }
+  ]
+}

--- a/.srs-audit/follow-ups.md
+++ b/.srs-audit/follow-ups.md
@@ -1,0 +1,125 @@
+# SRS Capstone #203 — Follow-ups
+
+Consolidated lessons learned from the SaaSFoundry self-audit. Each entry becomes a sub-issue under a new parent ticket (per #203 exit condition: "Any blocker bugs opened as follow-up tickets under a
+new parent (not #57)").
+
+Generated: 2026-04-23 · audit ran on commit of branch `feature/203-srs-audit-capstone`.
+
+---
+
+## P1 — Correctness blockers
+
+### 1. Matcher FR↔code is 100% endpoint-based — non-backend FRs always score 0
+
+**Where:** `src/srs/eval/matcher.ts:64-67` **What:** An FR is only counted as `matched` when at least one `endpoint` finding's area matches the FR's area. But an SRS FR is not always tied to an HTTP
+endpoint — it can be backend-only, **frontend-only** (page / route, no endpoint), full-stack, data/infra (job, migration, CLI script), or pure UX/workflow. Area-matching on endpoints alone
+systematically fails on every non-backend FR. **Evidence:** On SaaSFoundry (CLI project) — 34 FRs, 83 test findings, 0 endpoints in `src/` → all 34 FRs flagged `fr-without-code`, score collapses to 32
+despite full coverage. **Fix direction — three layers that stack (AI is augmentation, not fallback):**
+
+- **L1 — Deterministic match:** FR matches if any finding in the same area exists (endpoint OR frontend-route OR entity OR test OR doc-context). Produces candidate findings for the AI.
+- **L2 — Declarative hints:** optional `implementationKind: "backend"|"frontend"|"fullstack"|"infra"|"workflow"` + `areaHints: string[]` on FrSpec. Pre-filters candidates, doesn't decide alone.
+- **L3 — AI pass, always runs:** for every FR, feed title + description + L1 findings + L2 hints to an LLM. Refines the match even when L1 already succeeded (confidence, missing-edge reasoning,
+  cross-area matches L1 missed). Flag-gated (`--ai-match`), cached for CI determinism. Key: L3 is _not_ a fallback — it always adds nuance on top of the deterministic output.
+
+### 2. Inventory walk assumes root→Epics directly, breaks with category sub-page
+
+**Where:** `src/srs/eval/inventory.ts:26-27` **What:** `buildSrsInventory(adapter, rootPageId)` calls `listChildren(rootPageId)` expecting each child to be an Epic. Today's manifest points
+`tools.srs.rootPage.id` at `<project>-srs` (the "umbrella" page) which itself contains a single category page `User flows & Specifications` — and the Epics live under that. Result: eval finds 0 Epics,
+0 FRs. **Evidence:** First eval pass on SaaSFoundry returned `FR.total = 0` with note "No FR pages found under the configured rootPage". Re-running with `--root-page <userFlowsAndSpecifications.id>`
+fixed it. **Fix direction (pick one):**
+
+- Option A: Change the runtime to resolve `tools.srs.categories.userFlowsAndSpecifications.id` as the effective SRS root (preserves manifest layout from `sf update --add-modules srs`).
+- Option B: Make `inventory.ts` drill through a category-level page if the direct children are not Epic-shaped.
+- Option C: Change `srs.runner.ts` to put Epics directly under `<project>-srs` (flat) and drop the category layer.
+
+### 3. Scan defaults ratisse scaffolds/ and docs/ — dominates findings with template code
+
+**Where:** `src/srs/bin/codebase-scan.ts` (walks from CWD) **What:** `draft --from codebase` without `--path` scans the whole repo. In SaaSFoundry, that pulls 291 findings from `scaffolds/` (template
+code shipped to users, not a feature of the CLI) and 1104 `doc-context` findings from `docs/`, `README.md`, `.claude/` — drowning the CLI's own `src/` (83 findings). **Evidence:** full-repo scan =
+1246 findings, 94% noise; `src/`-only scan = 83 findings, all relevant. **Fix direction:** Add a project-aware `.srsignore` (or exclusion rules in `.saasfoundry.json`) so CLI/library projects can
+opt-out of `scaffolds/`, `docs/`, `.claude/` by default. Document the pattern in `sf-srs/SKILL.md`.
+
+---
+
+## P2 — UX & persistence gaps
+
+### 4. Bootstrap doesn't persist NOTION_API_TOKEN; `.env` wasn't gitignored
+
+**Where:** `src/commands/update.ts:498-518` + `.gitignore` (as of this audit's start) **What:** `sf update --add-modules srs` prompts for the token, uses it for the bootstrap, then discards it. User
+must re-export on every shell. `.env` was not in `.gitignore` either, making "just store it" risky. **Evidence:** User ran `sf update --add-modules srs` twice, expected token to persist, surprised it
+didn't. First audit iteration crashed with "NOTION_API_TOKEN not set" repeatedly in the Claude bash shell. **Fix direction:** Bootstrap must (a) write the token to `.env` at project root, (b) ensure
+`.env` and `.env.local` are gitignored. Runtime (`createNotionSrsAdapterFromEnv`) should support dotenv loading as a fallback.
+
+### 5. `--add-modules srs` bypasses the "already installed" filter — re-triggers bootstrap
+
+**Where:** `src/commands/update.ts:454 + 498` + `src/prompts/update.prompts.ts:30` **What:** `getAvailableModules` correctly excludes srs when `tools.srs.enabled === true`, but the `--add-modules srs`
+flag injects srs into `selectedModules` regardless, then the module block at line 498 fires the bootstrap again. Net effect: a second bootstrap creates a **duplicate** `<project>-srs` page on Notion
+and overwrites the manifest's `rootPage.id`, orphaning the first workspace. **Evidence:** User re-ran `sf update --add-modules srs` to check install status, hit "Which backend should host the SRS?"
+prompt — was about to silently double-install. **Fix direction:** When `--add-modules X` targets an already-installed module, refuse with a clear error or print a "no-op, already installed" message.
+Never silently re-bootstrap.
+
+### 6. `sf srs` not wired in the CLI — only accessible via the skill script
+
+**Where:** `src/index.ts` + `.claude/skills/sf-srs/scripts/srs-cli.sh` **What:** Users running `sf srs eval` get `error: unknown command 'srs'`. The runtime actions (`eval`, `draft`, `write`, `spawn`,
+`apply-update`) only exist behind the skill's shell wrapper. There is no non-interactive CLI path to the day-to-day SRS operations. **Evidence:** User tried `sf srs draft --from codebase` and hit an
+unknown-command error. **Fix direction:** Add `src/commands/srs.ts` that forwards `sf srs <action> ...` to `.claude/skills/sf-srs/scripts/srs-cli.sh <action> ...` (or imports the same bin entrypoints
+directly, avoiding shell indirection).
+
+### 7. No `sf status` — impossible to see project state at a glance
+
+**Where:** `src/commands/` (missing) **What:** There's no command that reads `.saasfoundry.json` and prints configured modules, linked services (GitHub Projects URL, Notion SRS root, etc.) and missing
+preconditions. Users and AI agents have to piece this together from manifest diffs + git + external systems. **Fix direction:** New `sf status` command. Output both human-readable and `--json` for
+agent consumption. Related to #8 (SessionStart hook consumes `sf status --claude-friendly`).
+
+### 8. No SessionStart hook + CLAUDE.md misses precondition directive
+
+**Where:** `.claude/settings.json` + `CLAUDE.md` + scaffold mirrors **What:** When an AI agent opens a session in the project, nothing auto-summarises the state. CLAUDE.md also lacks "first, read
+`.saasfoundry.json` and check tool preconditions before acting". Result: agents open dialogue about scope/backend before verifying the manifest already has the answers. **Evidence:** Another Claude
+session this morning asked the user to pick between notion/atlassian/local-markdown + specify a Notion parent page — all answers were in the manifest. **Fix direction:** (a) Add a `SessionStart` hook
+that runs `sf status` (once shipped) and injects the summary. (b) Add a "Preconditions first" section to CLAUDE.md + scaffold mirrors. Saved as `feedback_skill_precondition_check.md` memory for
+immediate effect.
+
+### 9. Skill trigger "bootstrap an SRS" is ambiguous between install and draft
+
+**Where:** `.claude/skills/sf-srs/SKILL.md:211` **What:** The trigger table maps "bootstrap an SRS on an existing project" to `--from codebase` drafting — but actual bootstrap belongs to
+`sf update --add-modules srs`. New users following the skill hit the wrong flow and waste a turn on clarifying questions. **Fix direction:** Split the trigger into (a) **install** SRS module (routes
+to CLI), and (b) **draft** initial content (routes to `--from codebase`). Rename "bootstrap" to "initialise" on one side.
+
+### 10. `write-srs` doesn't resolve Epic→FR links inside a single batch
+
+**Where:** `src/srs/bin/write-srs.ts:123-138` **What:** Spec files must pre-declare `FrSpec.parentEpicPageId` — but that ID only exists after the Epic has been created on Notion. Today the user (or
+skill) has to run `write` twice: once for Epics, collect IDs, build a second spec for FRs, run again. **Evidence:** This audit had to generate `.srs-audit/draft-spec-epics.json` → write → parse report
+→ generate `draft-spec-frs.json` → write. Two manual passes. **Fix direction:** Allow a spec to reference Epics by logical ID (`"parentEpicId": "EPIC-COMMANDS"`), resolve references at write time
+using the in-batch `created` list, fail cleanly if unresolved.
+
+---
+
+## P2 — UX & persistence gaps (continued)
+
+### 12. SRS completeness — generate DS / TC / NFR sections via AI
+
+**Where:** `src/builders/srs/templates/pages/*` + `src/srs/bin/draft-from-codebase.ts` + new AI pass in `src/srs/ai/` **What:** Today's draft pipeline produces UR + FR only. The DIAMONFORGE shape
+(reference: Notion DIAMONFORGE-PRODUCT-SPECS) expects four sections per Epic — UR, FR, **DS** (Design Specification), **TC** (Test Cases), **NFR** (Non-Functional Requirements). Without DS/TC/NFR, the
+generated SRS can't pass a real audit. **Why AI:** these sections are interpretive, not extractive. DS needs architectural synthesis across scanner findings; TC needs scenario enumeration from tests +
+FR semantics; NFR needs cross-cutting concerns from stack detection + SaaS conventions. **Fix direction — reuse the L1+L2+L3 architecture from §1:**
+
+- **DS** — AI synthesises from endpoint + service + entity + frontend-route findings in the FR's area → architecture paragraph + data-flow bullets. Deterministic findings are the input.
+- **TC** — AI enumerates scenarios from `tests.scanner` findings in the area + FR description. If 0 tests found, TC proposed as "to write" (surface as drift, not as gap in the spec).
+- **NFR** — AI proposes from stack detection (auth module present → security NFRs, i18n present → a11y/i18n NFRs, etc.) + catalogue of standard SaaS NFRs. Marked "proposed, needs human validation".
+  **Exit:** `sf srs draft --from codebase --with ds,tc,nfr` produces a full DIAMONFORGE-shaped Epic/FR tree. Humans validate/edit before write. All AI output cached for CI determinism.
+
+---
+
+## P3 — Polish
+
+### 11. `parseFrPageTitle` case-sensitivity and separator variance handled in tests, but rendering uses em-dash (`—`, U+2014)
+
+Verified by inspection; not a bug, just a note that Notion page-title-from-spec rendering must use the exact `FR-<AREA>-<NN> — <Title>` separator (em-dash, not hyphen) so eval's `parseFrPageTitle`
+parses correctly on round-trip. Keep the templates and the parser in sync on any future rewrite.
+
+---
+
+## Proposed parent ticket
+
+**Title:** SRS toolchain — post-capstone follow-ups (polish from #203 dogfood) **Body:** References #203 audit, lists the 11 items above, groups by priority. Each sub-issue carries its own
+`complexity:` label and scope.

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -371,3 +371,26 @@ trivial one.
 2. **Never hardcode backend branches** (`if backend === 'notion'`) ; the registry in `src/srs/` is the only place that knows about concrete backends
 3. **Never call `gh`, the Notion SDK, or any tool-specific CLI directly** ; delegate through the adapter or through `sf-tool-<backend>`
 4. **Every new SUB under #174 ships its artefact in the directory map above** — do not invent new locations
+
+## Lessons learned — #203 capstone dogfood (2026-04-23)
+
+Running the full `sf srs` chain end-to-end on SaaSFoundry itself surfaced 12 gaps consolidated under parent #235. Key takeaways agents should know about:
+
+- **Matcher is endpoint-biased (#236).** Today's `matcher.ts` only counts an FR as matched when an HTTP endpoint finding shares its area. Non-backend FRs (frontend-only pages, CLI commands, infra
+  jobs) score 0 regardless of test coverage. Until fixed, treat low eval scores on non-backend projects as likely false negatives, not real drift.
+- **Inventory walk assumes rootPage→Epic is direct (#237).** Bootstrap produces rootPage → `User flows & Specifications` category → Epics. Eval without `--root-page <category.id>` returns
+  `FR.total = 0`. Until fixed, always pass `--root-page` when running eval on a standard manifest.
+- **Scan from CWD ratisse scaffolds/ + docs/ (#238).** On CLI / library projects, run `draft --from codebase --path src` — a full-repo scan drowns real findings with template code.
+- **Bootstrap does not persist `NOTION_API_TOKEN` (#239).** After `sf update --add-modules srs`, the token lives only in the interactive shell. For non-interactive / Claude bash sessions, load it from
+  `.env` with `set -a && source .env && set +a` until the fix lands.
+- **`write-srs` needs two passes today (#245).** Epics must be written first to obtain page IDs, then an FR spec referencing `parentEpicPageId` is generated, then written. Scripted in `.srs-audit/` as
+  reference until logical-ID resolution lands.
+- **SRS completeness is UR+FR only (#247).** DS / TC / NFR are not generated yet. The DIAMONFORGE reference shape expects all five. AI-assisted generation planned under #247, reusing the L1+L2+L3
+  matcher architecture.
+- **Preconditions first.** Before asking the user scope questions (backend choice, Notion parent page, etc.), read `.saasfoundry.json` — the answers are almost always already there. Re-running
+  `sf update --add-modules srs` on an already-installed module silently re-bootstraps and duplicates Notion pages (#240).
+
+Artefacts from the capstone (kept for reference):
+
+- `.srs-audit/follow-ups.md` — full lessons-learned analysis
+- `.srs-audit/baseline-report-fixed-root.json` — first eval baseline (score 32, all FRs flagged fr-without-code due to #236)


### PR DESCRIPTION
Resolves #203.

## Summary

Capstone ticket for the SRS toolchain delivered under #57. Dogfooded the full `sf srs` chain on SaaSFoundry itself: bootstrap → draft from codebase → write to Notion → eval baseline → consolidate lessons-learned.

## What landed

- **Published SRS on Notion** — `saasfoundry-cli-srs` root with 5 Epics (COMMANDS, BUILDERS, MODULES, SRS-TOOLING, WORKFLOW-TOOLING) and 34 FRs under `User flows & Specifications`
- **Baseline eval report** — `.srs-audit/baseline-report-fixed-root.json` (score 32 — all false negatives driven by #236 matcher bug, not real drift)
- **Lessons-learned section** in `sf-srs/SKILL.md` + scaffold mirror (7 takeaways agents should know about until the follow-up tickets ship)
- **`.saasfoundry.json`** — SRS module bootstrapped to the fresh Notion workspace (`tools.srs.rootPage` + `categories.userFlowsAndSpecifications`)
- **`.gitignore`** — `.env` / `.env.local` now excluded; `.srs-audit/` kept as local scratch except for the two persisted artefacts

## Follow-ups (opened under new parent #235 per #203 exit condition)

12 sub-issues grouped by priority:

**P1 — Correctness blockers**
- #236 Matcher FR↔code — three-layer architecture (deterministic + declarative + AI-always-on, not fallback)
- #237 Inventory walk — support category sub-page between rootPage and Epics
- #238 Scan defaults — add `.srsignore` / project-aware exclusions

**P2 — UX & persistence gaps**
- #239 Bootstrap persist `NOTION_API_TOKEN` to `.env`
- #240 `sf update --add-modules` — refuse re-install of already-enabled modules
- #241 Expose `sf srs` CLI surface
- #242 `sf status` command
- #243 SessionStart hook + CLAUDE.md preconditions directive
- #244 Split skill "bootstrap" trigger into install vs draft
- #245 `write-srs` — resolve Epic→FR links inside a single batch
- #247 SRS completeness — generate DS / TC / NFR via AI (DIAMONFORGE shape)

**P3 — Polish**
- #246 FR page title em-dash consistency

## Exit conditions (from #203 body)

- [x] SaaSFoundry has its own published SRS (Notion pages under the project root)
- [x] `srs-cli.sh eval` report committed as reference baseline
- [x] Lessons learned section added to `sf-srs/SKILL.md`
- [x] Blocker bugs opened under a new parent (#235, not #57)

## Test plan

- [x] Full chain executed end-to-end (see test plan in #203 comment)
- [x] `npm run test:pre-commit` passing on `379c4ef` (82 suites, 953 tests)
- [ ] Human review of committed artefacts

## Notes

- `#203` closes with this PR. `#57` closes automatically after (per its exit: *"closes after this"*).
- `#235` stays open as the new home for SRS toolchain work. Its 12 sub-issues sit in Backlog pending triage.
- Adversarial review (examine.sh) skipped — diff is 100% docs + manifest + artefacts, no feature code.