### PR TITLE
feat(#236): three-layer matcher — deterministic + hints + AI review packet

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -94,15 +94,37 @@ silent drift that already happened).
 
 ### Heuristics (v1)
 
-| Finding kind      | Trigger                                                                                | Severity |
-| ----------------- | -------------------------------------------------------------------------------------- | -------- |
-| `fr-without-code` | FR page exists in the SRS but no scanner finding matches its area token                | error    |
-| `orphan-area`     | Scanner area carries endpoints but no FR page exists for it (e.g. new module, no spec) | error    |
-| `code-without-fr` | Individual endpoint not covered by an FR whose area already has other matches          | warn     |
-| `fr-untested`     | FR is mapped to endpoints, but no endpoint in that area carries `hasTests=true`        | warn     |
+| Finding kind      | Trigger                                                                                                                        | Severity |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `fr-without-code` | FR page exists but no scanner finding (endpoint / ui-flow / entity / test) matches its area token                              | error    |
+| `orphan-area`     | Scanner area carries implementation findings (endpoint / ui-flow / entity) but no FR page exists for it                        | error    |
+| `code-without-fr` | An implementation finding is outside the matched set but its area already carries other matches (or mismatches a hint filter)  | warn     |
+| `fr-untested`     | FR is mapped to code findings in its area but no test coverage is detected (no `endpoint.hasTests`, no test finding, no hints) | warn     |
 
 The overall score is the unweighted mean of FR coverage, endpoint coverage, and test coverage (each as a percentage). The per-category breakdown reports `FR` from the heuristics above.
 `UR / DS / TC / NFR` are emitted with `score: null` and a note — deeper drift on those categories requires the Notion adapter to preserve table-row cells on `fetchPage`, which is a follow-up SUB.
+
+### Three-layer matcher (L1 deterministic → L2 declarative → L3 AI review)
+
+The eval is AI-augmented by design: the CLI runs deterministic checks so the skill can spend agent tokens only on the semantic review that tooling cannot do. No LLM is ever invoked from the tool
+itself — cost for non-agent users stays at zero.
+
+- **L1 — deterministic script.** `eval-srs` matches every FR against all scanner findings whose `area` overlaps (not just endpoints). `ui-flow`, `entity`, and `test` findings now count alongside
+  `endpoint`, so frontend-only, data-only, and test-driven FRs are recognised without human intervention.
+- **L2 — declarative hints on the FR page.** FR authors can narrow the match with two optional fields on `SrsFrEntry` :
+  - `implementationKind: 'endpoint' | 'ui-flow' | 'entity' | 'mixed'` — filters impl findings to the declared kind (tests always count regardless).
+  - `areaHints: string[]` — additional area tokens to match (handy when the scanner area and the FR ID diverge, e.g. FR area `billing` ↔ code area `payments`). Inventory builders populate these when
+    the backend's page body carries them; today they are optional and unset.
+- **L3 — AI review packet.** Pass `--review-packet <path>` to `eval-srs` and the tool writes a structured JSON alongside the usual report :
+  ```bash
+  .claude/skills/sf-srs/scripts/srs-cli.sh eval --review-packet .srs-audit/review-packet.json
+  ```
+  The packet contains, per FR, its deterministic `status` (`matched` / `untested` / `unmatched`), the matched file list, and `promptHints` summarising the deterministic gaps. The skill feeds this
+  packet into its own context and proposes :
+  - matches the script missed (semantic mapping, e.g. an FR titled "Invoices" that should map to code area `billing`),
+  - reclassifications (FR that looks matched but actually covers a different behaviour),
+  - new UR / DS / TC / NFR items that the rendered report doesn't compute yet. The skill never edits the FR page silently — it uses the conversational eval hook (`apply-update`) to propose each change
+    with the user.
 
 ### Sample output (human)
 
@@ -376,8 +398,9 @@ trivial one.
 
 Running the full `sf srs` chain end-to-end on SaaSFoundry itself surfaced 12 gaps consolidated under parent #235. Key takeaways agents should know about:
 
-- **Matcher is endpoint-biased (#236).** Today's `matcher.ts` only counts an FR as matched when an HTTP endpoint finding shares its area. Non-backend FRs (frontend-only pages, CLI commands, infra
-  jobs) score 0 regardless of test coverage. Until fixed, treat low eval scores on non-backend projects as likely false negatives, not real drift.
+- **Matcher covers all finding kinds (#236 — landed).** `matcher.ts` now counts `endpoint`, `ui-flow`, `entity`, and `test` findings when scoring an FR. Frontend-only, data-only, and test-driven FRs
+  no longer score 0 purely because there is no endpoint. FR authors can further steer the match via `implementationKind` / `areaHints` (L2 hints) and the skill gets a `--review-packet` JSON for L3 AI
+  refinement. See "Three-layer matcher" above.
 - **Inventory walk assumes rootPage→Epic is direct (#237).** Bootstrap produces rootPage → `User flows & Specifications` category → Epics. Eval without `--root-page <category.id>` returns
   `FR.total = 0`. Until fixed, always pass `--root-page` when running eval on a standard manifest.
 - **Scan from CWD ratisse scaffolds/ + docs/ (#238).** On CLI / library projects, run `draft --from codebase --path src` — a full-repo scan drowns real findings with template code.

--- a/.srs-audit/follow-ups.md
+++ b/.srs-audit/follow-ups.md
@@ -9,17 +9,15 @@ Generated: 2026-04-23 · audit ran on commit of branch `feature/203-srs-audit-ca
 
 ## P1 — Correctness blockers
 
-### 1. Matcher FR↔code is 100% endpoint-based — non-backend FRs always score 0
+### 1. Matcher FR↔code is 100% endpoint-based — non-backend FRs always score 0 — **RESOLVED (#236, 2026-04-23)**
 
-**Where:** `src/srs/eval/matcher.ts:64-67` **What:** An FR is only counted as `matched` when at least one `endpoint` finding's area matches the FR's area. But an SRS FR is not always tied to an HTTP
-endpoint — it can be backend-only, **frontend-only** (page / route, no endpoint), full-stack, data/infra (job, migration, CLI script), or pure UX/workflow. Area-matching on endpoints alone
-systematically fails on every non-backend FR. **Evidence:** On SaaSFoundry (CLI project) — 34 FRs, 83 test findings, 0 endpoints in `src/` → all 34 FRs flagged `fr-without-code`, score collapses to 32
-despite full coverage. **Fix direction — three layers that stack (AI is augmentation, not fallback):**
+**Where:** `src/srs/eval/matcher.ts` **Status:** Landed on branch `feature/236-matcher-three-layers` across three commits.
 
-- **L1 — Deterministic match:** FR matches if any finding in the same area exists (endpoint OR frontend-route OR entity OR test OR doc-context). Produces candidate findings for the AI.
-- **L2 — Declarative hints:** optional `implementationKind: "backend"|"frontend"|"fullstack"|"infra"|"workflow"` + `areaHints: string[]` on FrSpec. Pre-filters candidates, doesn't decide alone.
-- **L3 — AI pass, always runs:** for every FR, feed title + description + L1 findings + L2 hints to an LLM. Refines the match even when L1 already succeeded (confidence, missing-edge reasoning,
-  cross-area matches L1 missed). Flag-gated (`--ai-match`), cached for CI determinism. Key: L3 is _not_ a fallback — it always adds nuance on top of the deterministic output.
+- **L1 — Deterministic match (landed):** FR matches if any finding (`endpoint` / `ui-flow` / `entity` / `test`) in the same area exists. `orphan-area` and `code-without-fr` now cover all impl kinds.
+- **L2 — Declarative hints (landed):** `SrsFrEntry.implementationKind` + `SrsFrEntry.areaHints` are honoured by the matcher when present. Inventory builders can populate them from page bodies (a
+  future adapter change will parse Notion code-blocks; the type plumbing is in place today).
+- **L3 — Review packet for AI refinement (landed):** `eval-srs --review-packet <path>` emits a deterministic JSON summary (per-FR status, per-finding mapping, `promptHints`) for the sf-srs skill to
+  refine with AI. The CLI never calls an LLM itself — cost stays zero for non-agent users.
 
 ### 2. Inventory walk assumes root→Epics directly, breaks with category sub-page
 

--- a/docs/srs/lifecycle.md
+++ b/docs/srs/lifecycle.md
@@ -120,7 +120,7 @@ All commands are driven from two wrappers :
 | `srs-cli.sh write --spec <path>`                       | Apply `DraftCandidate[]` to the backend (creates Epic + FR pages)               |
 | `srs-cli.sh spawn --ticket <parent> --epic <url>`      | Create one Story sub-issue per FR page                                          |
 | `srs-cli.sh apply-update < patch.json`                 | Conversational eval hook — append new UR / FR / DS / TC (ADD-only v1)           |
-| `srs-cli.sh eval` _(coming — SUB-16)_                  | Batch freshness score SRS vs. codebase                                          |
+| `srs-cli.sh eval [--review-packet <path>]`             | Batch freshness score SRS vs. codebase (L1 script + L2 hints + L3 AI packet)    |
 
 ::: warning `update-status` is gated on SRS tickets `workflow-cli.sh update-status <ticket> "AI testing|Human testing|In review"` is **rejected** when the ticket carries an `srs:*` label. SRS tickets
 have their own phases (`ai-draft`, `human-review`, `spawning`) — always use `transition-drafting` instead. The guard fails open if label fetch errors so networked teams aren't punished by

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -94,15 +94,37 @@ silent drift that already happened).
 
 ### Heuristics (v1)
 
-| Finding kind      | Trigger                                                                                | Severity |
-| ----------------- | -------------------------------------------------------------------------------------- | -------- |
-| `fr-without-code` | FR page exists in the SRS but no scanner finding matches its area token                | error    |
-| `orphan-area`     | Scanner area carries endpoints but no FR page exists for it (e.g. new module, no spec) | error    |
-| `code-without-fr` | Individual endpoint not covered by an FR whose area already has other matches          | warn     |
-| `fr-untested`     | FR is mapped to endpoints, but no endpoint in that area carries `hasTests=true`        | warn     |
+| Finding kind      | Trigger                                                                                                                        | Severity |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `fr-without-code` | FR page exists but no scanner finding (endpoint / ui-flow / entity / test) matches its area token                              | error    |
+| `orphan-area`     | Scanner area carries implementation findings (endpoint / ui-flow / entity) but no FR page exists for it                        | error    |
+| `code-without-fr` | An implementation finding is outside the matched set but its area already carries other matches (or mismatches a hint filter)  | warn     |
+| `fr-untested`     | FR is mapped to code findings in its area but no test coverage is detected (no `endpoint.hasTests`, no test finding, no hints) | warn     |
 
 The overall score is the unweighted mean of FR coverage, endpoint coverage, and test coverage (each as a percentage). The per-category breakdown reports `FR` from the heuristics above.
 `UR / DS / TC / NFR` are emitted with `score: null` and a note — deeper drift on those categories requires the Notion adapter to preserve table-row cells on `fetchPage`, which is a follow-up SUB.
+
+### Three-layer matcher (L1 deterministic → L2 declarative → L3 AI review)
+
+The eval is AI-augmented by design: the CLI runs deterministic checks so the skill can spend agent tokens only on the semantic review that tooling cannot do. No LLM is ever invoked from the tool
+itself — cost for non-agent users stays at zero.
+
+- **L1 — deterministic script.** `eval-srs` matches every FR against all scanner findings whose `area` overlaps (not just endpoints). `ui-flow`, `entity`, and `test` findings now count alongside
+  `endpoint`, so frontend-only, data-only, and test-driven FRs are recognised without human intervention.
+- **L2 — declarative hints on the FR page.** FR authors can narrow the match with two optional fields on `SrsFrEntry` :
+  - `implementationKind: 'endpoint' | 'ui-flow' | 'entity' | 'mixed'` — filters impl findings to the declared kind (tests always count regardless).
+  - `areaHints: string[]` — additional area tokens to match (handy when the scanner area and the FR ID diverge, e.g. FR area `billing` ↔ code area `payments`). Inventory builders populate these when
+    the backend's page body carries them; today they are optional and unset.
+- **L3 — AI review packet.** Pass `--review-packet <path>` to `eval-srs` and the tool writes a structured JSON alongside the usual report :
+  ```bash
+  .claude/skills/sf-srs/scripts/srs-cli.sh eval --review-packet .srs-audit/review-packet.json
+  ```
+  The packet contains, per FR, its deterministic `status` (`matched` / `untested` / `unmatched`), the matched file list, and `promptHints` summarising the deterministic gaps. The skill feeds this
+  packet into its own context and proposes :
+  - matches the script missed (semantic mapping, e.g. an FR titled "Invoices" that should map to code area `billing`),
+  - reclassifications (FR that looks matched but actually covers a different behaviour),
+  - new UR / DS / TC / NFR items that the rendered report doesn't compute yet. The skill never edits the FR page silently — it uses the conversational eval hook (`apply-update`) to propose each change
+    with the user.
 
 ### Sample output (human)
 
@@ -376,8 +398,9 @@ trivial one.
 
 Running the full `sf srs` chain end-to-end on SaaSFoundry itself surfaced 12 gaps consolidated under parent #235. Key takeaways agents should know about:
 
-- **Matcher is endpoint-biased (#236).** Today's `matcher.ts` only counts an FR as matched when an HTTP endpoint finding shares its area. Non-backend FRs (frontend-only pages, CLI commands, infra
-  jobs) score 0 regardless of test coverage. Until fixed, treat low eval scores on non-backend projects as likely false negatives, not real drift.
+- **Matcher covers all finding kinds (#236 — landed).** `matcher.ts` now counts `endpoint`, `ui-flow`, `entity`, and `test` findings when scoring an FR. Frontend-only, data-only, and test-driven FRs
+  no longer score 0 purely because there is no endpoint. FR authors can further steer the match via `implementationKind` / `areaHints` (L2 hints) and the skill gets a `--review-packet` JSON for L3 AI
+  refinement. See "Three-layer matcher" above.
 - **Inventory walk assumes rootPage→Epic is direct (#237).** Bootstrap produces rootPage → `User flows & Specifications` category → Epics. Eval without `--root-page <category.id>` returns
   `FR.total = 0`. Until fixed, always pass `--root-page` when running eval on a standard manifest.
 - **Scan from CWD ratisse scaffolds/ + docs/ (#238).** On CLI / library projects, run `draft --from codebase --path src` — a full-repo scan drowns real findings with template code.

--- a/src/__tests__/unit/srs/bin/eval-srs.spec.ts
+++ b/src/__tests__/unit/srs/bin/eval-srs.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -29,6 +29,13 @@ describe('parseArgs (eval-srs)', () => {
     expect(opts.scanPath).toBe('/p')
     expect(opts.rootPageId).toBe('rr')
     expect(opts.thresholdPct).toBe(70)
+  })
+
+  it('parses --review-packet in both forms', () => {
+    const space = parseArgs(['--review-packet', '/out/packet.json'])
+    expect(space.reviewPacketPath).toBe('/out/packet.json')
+    const eq = parseArgs(['--review-packet=/out/packet.json'])
+    expect(eq.reviewPacketPath).toBe('/out/packet.json')
   })
 })
 
@@ -125,6 +132,27 @@ describe('runEvalSrs (fixture mode)', () => {
     const code = await runEvalSrs({ scanPath: tmp, manifestPath, thresholdPct: 80, output: 'human' }, io)
     expect(code).toBe(2)
     expect(err.join('')).toMatch(/--root-page is required/)
+  })
+
+  it('writes a review packet when --review-packet is set', async () => {
+    const { inv, fnd, manifest } = writeFixture(
+      {
+        rootPageId: 'root',
+        epics: [{ pageId: 'e', title: 'E' }],
+        frs: [{ id: 'FR-AUTH-01', area: 'auth', title: 'Sign in', pageId: 'f', epicPageId: 'e', epicTitle: 'E' }],
+        unsupportedCategories: ['UR', 'DS', 'TC', 'NFR']
+      },
+      [{ kind: 'endpoint', area: 'auth', method: 'POST', path: '/signin', hasTests: true, file: 'auth/c.ts', title: 'POST /signin' }]
+    )
+
+    const packetPath = join(tmp, 'packet.json')
+    const code = await runEvalSrs({ scanPath: tmp, manifestPath: manifest, thresholdPct: 80, output: 'json', fixtureInventoryPath: inv, fixtureFindingsPath: fnd, reviewPacketPath: packetPath }, io)
+    expect(code).toBe(0)
+    expect(existsSync(packetPath)).toBe(true)
+    const packet = JSON.parse(readFileSync(packetPath, 'utf8'))
+    expect(packet.inventory.frCount).toBe(1)
+    expect(packet.frs[0].status).toBe('matched')
+    expect(Array.isArray(packet.promptHints)).toBe(true)
   })
 
   it('returns 3 when the backend is missing from the manifest', async () => {

--- a/src/__tests__/unit/srs/eval/matcher.spec.ts
+++ b/src/__tests__/unit/srs/eval/matcher.spec.ts
@@ -165,4 +165,30 @@ describe('matchSrsAgainstScanners', () => {
     expect(orphan).toBeDefined()
     expect(orphan?.message).toMatch(/entity/)
   })
+
+  it('honours areaHints when matching (FR area "billing" ↔ finding area "payments")', () => {
+    const invBase = inventory([{ id: 'FR-BILL-01', area: 'billing', title: 'Invoices' }])
+    const inv: SrsInventory = {
+      ...invBase,
+      frs: [{ ...invBase.frs[0], areaHints: ['payments'] }]
+    }
+    const findings: ScannerFinding[] = [endpoint('payments', 'GET', '/charges', true)]
+    const report = matchSrsAgainstScanners(inv, findings)
+    expect(report.counts.frMatched).toBe(1)
+    expect(report.findings.some((f) => f.kind === 'orphan-area' && f.area === 'payments')).toBe(false)
+  })
+
+  it('honours implementationKind=ui-flow (ignores endpoint for match but still counts ui-flow)', () => {
+    const invBase = inventory([{ id: 'FR-HOME-01', area: 'home', title: 'Landing page' }])
+    const inv: SrsInventory = {
+      ...invBase,
+      frs: [{ ...invBase.frs[0], implementationKind: 'ui-flow' }]
+    }
+    const findings: ScannerFinding[] = [endpoint('home', 'GET', '/api/home', true), uiFlow('home', '/home')]
+    const report = matchSrsAgainstScanners(inv, findings)
+    expect(report.counts.frMatched).toBe(1)
+    // The endpoint in `home` should now be unmatched (its area has the FR but impl kind mismatched) → code-without-fr
+    const cwf = report.findings.find((f) => f.kind === 'code-without-fr' && f.area === 'home')
+    expect(cwf).toBeDefined()
+  })
 })

--- a/src/__tests__/unit/srs/eval/matcher.spec.ts
+++ b/src/__tests__/unit/srs/eval/matcher.spec.ts
@@ -1,4 +1,4 @@
-import { EndpointFinding, ScannerFinding, TestFinding } from '../../../../srs/scanners/types'
+import { EndpointFinding, EntityFinding, ScannerFinding, TestFinding, UiFlowFinding } from '../../../../srs/scanners/types'
 import { matchSrsAgainstScanners } from '../../../../srs/eval/matcher'
 import { SrsInventory } from '../../../../srs/eval/types'
 
@@ -8,6 +8,14 @@ function endpoint(area: string, method: string, path: string, hasTests = false, 
 
 function test(area: string, file = `${area}/spec.ts`): TestFinding {
   return { kind: 'test', area, file, describe: 'd', cases: ['c'], title: 't' }
+}
+
+function uiFlow(area: string, route: string, file = `${area}/page.tsx`): UiFlowFinding {
+  return { kind: 'ui-flow', area, file, route, formFields: [], title: `UI ${route}` }
+}
+
+function entity(area: string, model: string, file = `${area}/schema.prisma`): EntityFinding {
+  return { kind: 'entity', area, file, model, fields: [], relations: [], title: `model ${model}` }
 }
 
 function inventory(frs: Array<{ id: string; area: string; title: string }>): SrsInventory {
@@ -111,5 +119,50 @@ describe('matchSrsAgainstScanners', () => {
       expect(report.categories[label].score).toBeNull()
       expect(report.categories[label].note).toMatch(/not evaluated in v1/i)
     }
+  })
+
+  it('matches an FR to a ui-flow finding (frontend-only feature)', () => {
+    const inv = inventory([{ id: 'FR-SETTINGS-01', area: 'settings', title: 'Preferences page' }])
+    const findings: ScannerFinding[] = [uiFlow('settings', '/settings/preferences')]
+    const report = matchSrsAgainstScanners(inv, findings)
+    expect(report.counts.frMatched).toBe(1)
+    expect(report.findings.some((f) => f.kind === 'fr-without-code')).toBe(false)
+    // No endpoint, no test — should surface fr-untested since coverage can't be proven
+    expect(report.findings.some((f) => f.kind === 'fr-untested')).toBe(true)
+  })
+
+  it('matches an FR to an entity finding (data-only feature)', () => {
+    const inv = inventory([{ id: 'FR-AUDIT-01', area: 'audit', title: 'Audit log model' }])
+    const findings: ScannerFinding[] = [entity('audit', 'AuditLog')]
+    const report = matchSrsAgainstScanners(inv, findings)
+    expect(report.counts.frMatched).toBe(1)
+    expect(report.findings.some((f) => f.kind === 'fr-without-code')).toBe(false)
+  })
+
+  it('matches an FR when only a test finding exists for its area', () => {
+    const inv = inventory([{ id: 'FR-HEALTH-01', area: 'health', title: 'Health probe' }])
+    const findings: ScannerFinding[] = [test('health')]
+    const report = matchSrsAgainstScanners(inv, findings)
+    expect(report.counts.frMatched).toBe(1)
+    // Test finding itself provides coverage — no fr-untested expected
+    expect(report.findings.some((f) => f.kind === 'fr-untested')).toBe(false)
+  })
+
+  it('reports orphan-area for ui-flow findings with no FR', () => {
+    const inv = inventory([{ id: 'FR-AUTH-01', area: 'auth', title: 'Sign in' }])
+    const findings: ScannerFinding[] = [endpoint('auth', 'POST', '/signin', true), uiFlow('marketing', '/landing')]
+    const report = matchSrsAgainstScanners(inv, findings)
+    const orphan = report.findings.find((f) => f.kind === 'orphan-area' && f.area === 'marketing')
+    expect(orphan).toBeDefined()
+    expect(orphan?.message).toMatch(/UI flow/)
+  })
+
+  it('reports orphan-area for entity findings with no FR', () => {
+    const inv = inventory([{ id: 'FR-AUTH-01', area: 'auth', title: 'Sign in' }])
+    const findings: ScannerFinding[] = [endpoint('auth', 'POST', '/signin', true), entity('legacy', 'OldTable')]
+    const report = matchSrsAgainstScanners(inv, findings)
+    const orphan = report.findings.find((f) => f.kind === 'orphan-area' && f.area === 'legacy')
+    expect(orphan).toBeDefined()
+    expect(orphan?.message).toMatch(/entity/)
   })
 })

--- a/src/__tests__/unit/srs/eval/review-packet.spec.ts
+++ b/src/__tests__/unit/srs/eval/review-packet.spec.ts
@@ -1,0 +1,72 @@
+import { matchSrsAgainstScanners } from '../../../../srs/eval/matcher'
+import { buildReviewPacket } from '../../../../srs/eval/review-packet'
+import { SrsInventory } from '../../../../srs/eval/types'
+import { EndpointFinding, ScannerFinding, UiFlowFinding } from '../../../../srs/scanners/types'
+
+function endpoint(area: string, method: string, path: string, hasTests = false, file = `${area}/controller.ts`): EndpointFinding {
+  return { kind: 'endpoint', area, method, path, hasTests, file, title: `${method} ${path}` }
+}
+
+function uiFlow(area: string, route: string, file = `${area}/page.tsx`): UiFlowFinding {
+  return { kind: 'ui-flow', area, file, route, formFields: [], title: `UI ${route}` }
+}
+
+function inv(frs: Array<{ id: string; area: string; title: string; implementationKind?: 'endpoint' | 'ui-flow' | 'entity' | 'mixed'; areaHints?: string[] }>): SrsInventory {
+  return {
+    rootPageId: 'root',
+    epics: [{ pageId: 'e', title: 'E' }],
+    frs: frs.map((f) => ({ id: f.id, area: f.area, title: f.title, pageId: `p-${f.id}`, epicPageId: 'e', epicTitle: 'E', implementationKind: f.implementationKind, areaHints: f.areaHints })),
+    unsupportedCategories: ['UR', 'DS', 'TC', 'NFR']
+  }
+}
+
+describe('buildReviewPacket', () => {
+  it('classifies each FR by status and threads areaHints + implementationKind through', () => {
+    const inventory = inv([
+      { id: 'FR-AUTH-01', area: 'auth', title: 'Sign in' },
+      { id: 'FR-HOME-01', area: 'home', title: 'Landing', implementationKind: 'ui-flow' },
+      { id: 'FR-BILL-01', area: 'billing', title: 'Invoices', areaHints: ['payments'] },
+      { id: 'FR-GONE-01', area: 'gone', title: 'Removed feature' }
+    ])
+    const findings: ScannerFinding[] = [endpoint('auth', 'POST', '/signin', true), uiFlow('home', '/home'), endpoint('payments', 'GET', '/charges', false)]
+    const report = matchSrsAgainstScanners(inventory, findings)
+    const packet = buildReviewPacket(inventory, findings, report)
+
+    const byId = new Map(packet.frs.map((f) => [f.id, f]))
+    expect(byId.get('FR-AUTH-01')?.status).toBe('matched')
+    expect(byId.get('FR-HOME-01')?.status).toBe('untested')
+    expect(byId.get('FR-BILL-01')?.status).toBe('untested')
+    expect(byId.get('FR-GONE-01')?.status).toBe('unmatched')
+    expect(byId.get('FR-HOME-01')?.implementationKind).toBe('ui-flow')
+    expect(byId.get('FR-BILL-01')?.areaHints).toEqual(['payments'])
+  })
+
+  it('records per-finding matchedFrIds so the agent can spot double-mapped findings', () => {
+    const inventory = inv([
+      { id: 'FR-A-01', area: 'auth', title: 'A' },
+      { id: 'FR-B-01', area: 'auth', title: 'B' }
+    ])
+    const findings: ScannerFinding[] = [endpoint('auth', 'POST', '/x', true)]
+    const report = matchSrsAgainstScanners(inventory, findings)
+    const packet = buildReviewPacket(inventory, findings, report)
+    expect(packet.findings).toHaveLength(1)
+    expect(packet.findings[0].matchedFrIds.sort()).toEqual(['FR-A-01', 'FR-B-01'])
+  })
+
+  it('emits prompt hints summarising gaps for the agent', () => {
+    const inventory = inv([{ id: 'FR-GONE-01', area: 'gone', title: 'Removed' }])
+    const findings: ScannerFinding[] = [endpoint('stray', 'GET', '/orphan', true)]
+    const report = matchSrsAgainstScanners(inventory, findings)
+    const packet = buildReviewPacket(inventory, findings, report)
+    expect(packet.promptHints.join(' ')).toMatch(/FR-GONE-01/)
+    expect(packet.promptHints.join(' ')).toMatch(/stray/)
+  })
+
+  it('falls back to a sweep hint when nothing is broken deterministically', () => {
+    const inventory = inv([{ id: 'FR-OK-01', area: 'ok', title: 'OK' }])
+    const findings: ScannerFinding[] = [endpoint('ok', 'GET', '/ok', true)]
+    const report = matchSrsAgainstScanners(inventory, findings)
+    const packet = buildReviewPacket(inventory, findings, report)
+    expect(packet.promptHints.some((h) => /semantic drift/i.test(h))).toBe(true)
+  })
+})

--- a/src/srs/bin/eval-srs.ts
+++ b/src/srs/bin/eval-srs.ts
@@ -1,10 +1,11 @@
-import { existsSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import { SrsAdapter } from '../../builders/srs/types'
 import { buildSrsInventory } from '../eval/inventory'
 import { matchSrsAgainstScanners } from '../eval/matcher'
 import { formatHumanReport, formatJsonReport } from '../eval/report'
+import { buildReviewPacket } from '../eval/review-packet'
 import { createSrsAdapter, SrsConfigError, SrsManifestSubset } from '../index'
 import { collectFindings } from './codebase-scan'
 
@@ -26,6 +27,7 @@ export interface EvalSrsOptions {
   output: 'human' | 'json'
   fixtureInventoryPath?: string
   fixtureFindingsPath?: string
+  reviewPacketPath?: string
 }
 
 export interface EvalSrsIO {
@@ -86,6 +88,12 @@ export async function runEvalSrs(options: EvalSrsOptions, io: EvalSrsIO = defaul
     }
 
     const report = matchSrsAgainstScanners(inventory, findings, { thresholdPct: options.thresholdPct })
+    if (options.reviewPacketPath) {
+      const packet = buildReviewPacket(inventory, findings, report)
+      const packetPath = resolve(options.reviewPacketPath)
+      writeFileSync(packetPath, JSON.stringify(packet, null, 2) + '\n', 'utf8')
+      io.stderr(`review packet written → ${packetPath}\n`)
+    }
     io.stdout(options.output === 'json' ? formatJsonReport(report) : formatHumanReport(report))
     return report.overall.status === 'fresh' ? 0 : 1
   } catch (error) {
@@ -107,6 +115,7 @@ export function parseArgs(argv: string[]): EvalSrsOptions {
   let output: 'human' | 'json' = 'human'
   let fixtureInventoryPath: string | undefined
   let fixtureFindingsPath: string | undefined
+  let reviewPacketPath: string | undefined
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
     if (arg === '--path' || arg === '-p') scanPath = argv[++i] ?? ''
@@ -120,8 +129,10 @@ export function parseArgs(argv: string[]): EvalSrsOptions {
     else if (arg === '--json') output = 'json'
     else if (arg === '--fixture-inventory') fixtureInventoryPath = argv[++i]
     else if (arg === '--fixture-findings') fixtureFindingsPath = argv[++i]
+    else if (arg === '--review-packet') reviewPacketPath = argv[++i]
+    else if (arg.startsWith('--review-packet=')) reviewPacketPath = arg.slice('--review-packet='.length)
   }
-  return { scanPath, manifestPath, rootPageId, thresholdPct, output, fixtureInventoryPath, fixtureFindingsPath }
+  return { scanPath, manifestPath, rootPageId, thresholdPct, output, fixtureInventoryPath, fixtureFindingsPath, reviewPacketPath }
 }
 
 if (require.main === module) {

--- a/src/srs/eval/matcher.ts
+++ b/src/srs/eval/matcher.ts
@@ -1,4 +1,4 @@
-import { EndpointFinding, ScannerFinding } from '../scanners/types'
+import { EndpointFinding, EntityFinding, ScannerFinding, UiFlowFinding } from '../scanners/types'
 import { CategoryScore, DriftFinding, FreshnessReport, SrsInventory } from './types'
 
 const DEFAULT_THRESHOLD_PCT = 80
@@ -7,15 +7,33 @@ export interface MatchOptions {
   thresholdPct?: number
 }
 
+type ImplementationFinding = EndpointFinding | UiFlowFinding | EntityFinding
+
+function isImplementation(f: ScannerFinding): f is ImplementationFinding {
+  return f.kind === 'endpoint' || f.kind === 'ui-flow' || f.kind === 'entity'
+}
+
+function describeImpl(f: ImplementationFinding): string {
+  if (f.kind === 'endpoint') return `${f.method} ${f.path}`
+  if (f.kind === 'ui-flow') return f.route ? `route ${f.route}` : `ui ${f.title}`
+  return `model ${f.model}`
+}
+
+function implLabel(kind: ImplementationFinding['kind']): string {
+  if (kind === 'endpoint') return 'endpoint'
+  if (kind === 'ui-flow') return 'UI flow'
+  return 'entity'
+}
+
 function normalizeArea(raw: string): string {
   return raw.trim().toLowerCase()
 }
 
-function endpointMatchesFrArea(endpoint: EndpointFinding, frArea: string): boolean {
-  const area = normalizeArea(endpoint.area)
+function findingMatchesFrArea(finding: ScannerFinding, frArea: string): boolean {
+  const area = normalizeArea(finding.area)
   if (area === frArea) return true
-  // Fall back to a prefix check: scanner areas are folder names, FR areas are
-  // tokens embedded in FR IDs — "accounts" / "account" should match.
+  // Prefix tolerance: scanner areas are folder names, FR areas are tokens
+  // embedded in FR IDs — "accounts" / "account" should match either way.
   if (area.startsWith(frArea) || frArea.startsWith(area)) return true
   return false
 }
@@ -53,26 +71,32 @@ function unsupportedCategory(label: 'UR' | 'DS' | 'TC' | 'NFR'): CategoryScore {
 export function matchSrsAgainstScanners(inventory: SrsInventory, findings: ScannerFinding[], options: MatchOptions = {}): FreshnessReport {
   const threshold = options.thresholdPct ?? DEFAULT_THRESHOLD_PCT
   const endpoints = findings.filter((f): f is EndpointFinding => f.kind === 'endpoint')
+  const implFindings = findings.filter(isImplementation)
   const tests = findings.filter((f) => f.kind === 'test')
   const testedAreas = new Set<string>(tests.map((t) => normalizeArea(t.area)))
   const driftFindings: DriftFinding[] = []
 
   const matchedFrIds = new Set<string>()
-  const matchedEndpointFiles = new Set<string>()
-  const frEndpointMap = new Map<string, EndpointFinding[]>()
+  const matchedImplFiles = new Set<string>()
 
   for (const fr of inventory.frs) {
-    const matches = endpoints.filter((e) => endpointMatchesFrArea(e, fr.area))
+    const matches = findings.filter((f) => findingMatchesFrArea(f, fr.area))
     if (matches.length > 0) {
       matchedFrIds.add(fr.id)
-      frEndpointMap.set(fr.id, matches)
-      for (const m of matches) matchedEndpointFiles.add(m.file)
-      const anyTested = matches.some((m) => m.hasTests) || testedAreas.has(fr.area)
+      for (const m of matches) {
+        if (isImplementation(m)) matchedImplFiles.add(m.file)
+      }
+      const endpointMatches = matches.filter((m): m is EndpointFinding => m.kind === 'endpoint')
+      const anyTested = endpointMatches.some((m) => m.hasTests) || testedAreas.has(fr.area) || matches.some((m) => m.kind === 'test')
       if (!anyTested) {
+        const msg =
+          endpointMatches.length > 0
+            ? `FR ${fr.id} is mapped to ${endpointMatches.length} endpoint(s) but none carry tests`
+            : `FR ${fr.id} matches ${matches.length} code finding(s) in area "${fr.area}" but no test coverage was detected`
         driftFindings.push({
           kind: 'fr-untested',
           severity: 'warn',
-          message: `FR ${fr.id} is mapped to ${matches.length} endpoint(s) but none carry tests`,
+          message: msg,
           frId: fr.id,
           frTitle: fr.title,
           area: fr.area,
@@ -91,21 +115,21 @@ export function matchSrsAgainstScanners(inventory: SrsInventory, findings: Scann
     }
   }
 
-  const frAreas = new Set<string>(inventory.frs.map((f) => f.area))
-  const unmatchedEndpoints = endpoints.filter((e) => !matchedEndpointFiles.has(e.file))
-  const unmatchedAreas = new Map<string, EndpointFinding[]>()
-  for (const e of unmatchedEndpoints) {
-    const area = normalizeArea(e.area)
-    if (!unmatchedAreas.has(area)) unmatchedAreas.set(area, [])
-    unmatchedAreas.get(area)!.push(e)
+  const frAreas = new Set<string>(inventory.frs.map((f) => normalizeArea(f.area)))
+  const unmatchedImpl = implFindings.filter((f) => !matchedImplFiles.has(f.file))
+  const unmatchedByArea = new Map<string, ImplementationFinding[]>()
+  for (const f of unmatchedImpl) {
+    const area = normalizeArea(f.area)
+    if (!unmatchedByArea.has(area)) unmatchedByArea.set(area, [])
+    unmatchedByArea.get(area)!.push(f)
   }
-  for (const [area, group] of unmatchedAreas) {
+  for (const [area, group] of unmatchedByArea) {
     const sample = group[0]
     if (!frAreas.has(area)) {
       driftFindings.push({
         kind: 'orphan-area',
         severity: 'error',
-        message: `Code area "${area}" carries ${group.length} endpoint(s) but has no FR page (e.g. ${sample.method} ${sample.path})`,
+        message: `Code area "${area}" carries ${group.length} ${implLabel(sample.kind)}(s) but has no FR page (e.g. ${describeImpl(sample)})`,
         area,
         file: sample.file
       })
@@ -113,7 +137,7 @@ export function matchSrsAgainstScanners(inventory: SrsInventory, findings: Scann
       driftFindings.push({
         kind: 'code-without-fr',
         severity: 'warn',
-        message: `${sample.method} ${sample.path} in "${area}" is not covered by any FR in the SRS`,
+        message: `${describeImpl(sample)} in "${area}" is not covered by any FR in the SRS`,
         area,
         file: sample.file
       })
@@ -124,6 +148,7 @@ export function matchSrsAgainstScanners(inventory: SrsInventory, findings: Scann
 
   const untestedFrCount = driftFindings.filter((d) => d.kind === 'fr-untested').length
   const untestedEndpoints = endpoints.filter((e) => !e.hasTests).length
+  const unmatchedEndpoints = endpoints.filter((e) => !matchedImplFiles.has(e.file))
   const frCoverageScore = frScore.score ?? 100
   const codeCoverageScore = endpoints.length === 0 ? 100 : percent(endpoints.length - unmatchedEndpoints.length, endpoints.length)
   const testCoverageScore = endpoints.length === 0 ? 100 : percent(endpoints.length - untestedEndpoints, endpoints.length)

--- a/src/srs/eval/matcher.ts
+++ b/src/srs/eval/matcher.ts
@@ -1,5 +1,5 @@
 import { EndpointFinding, EntityFinding, ScannerFinding, UiFlowFinding } from '../scanners/types'
-import { CategoryScore, DriftFinding, FreshnessReport, SrsInventory } from './types'
+import { CategoryScore, DriftFinding, FreshnessReport, ImplementationKind, SrsFrEntry, SrsInventory } from './types'
 
 const DEFAULT_THRESHOLD_PCT = 80
 
@@ -29,13 +29,29 @@ function normalizeArea(raw: string): string {
   return raw.trim().toLowerCase()
 }
 
-function findingMatchesFrArea(finding: ScannerFinding, frArea: string): boolean {
-  const area = normalizeArea(finding.area)
-  if (area === frArea) return true
+function areaMatchesToken(findingArea: string, frToken: string): boolean {
+  if (findingArea === frToken) return true
   // Prefix tolerance: scanner areas are folder names, FR areas are tokens
   // embedded in FR IDs — "accounts" / "account" should match either way.
-  if (area.startsWith(frArea) || frArea.startsWith(area)) return true
+  if (findingArea.startsWith(frToken) || frToken.startsWith(findingArea)) return true
   return false
+}
+
+function frAreaCandidates(fr: SrsFrEntry): string[] {
+  const hints = (fr.areaHints ?? []).map(normalizeArea).filter((h) => h.length > 0)
+  return [fr.area, ...hints]
+}
+
+function findingMatchesFr(finding: ScannerFinding, fr: SrsFrEntry): boolean {
+  const area = normalizeArea(finding.area)
+  return frAreaCandidates(fr).some((token) => areaMatchesToken(area, token))
+}
+
+function findingKindMatchesHint(finding: ScannerFinding, hint: ImplementationKind | undefined): boolean {
+  // Tests and doc-context always fit, regardless of implementationKind hint
+  if (finding.kind === 'test' || finding.kind === 'doc-context') return true
+  if (!hint || hint === 'mixed') return true
+  return finding.kind === hint
 }
 
 function percent(numer: number, denom: number): number {
@@ -80,7 +96,7 @@ export function matchSrsAgainstScanners(inventory: SrsInventory, findings: Scann
   const matchedImplFiles = new Set<string>()
 
   for (const fr of inventory.frs) {
-    const matches = findings.filter((f) => findingMatchesFrArea(f, fr.area))
+    const matches = findings.filter((f) => findingMatchesFr(f, fr) && findingKindMatchesHint(f, fr.implementationKind))
     if (matches.length > 0) {
       matchedFrIds.add(fr.id)
       for (const m of matches) {
@@ -115,7 +131,10 @@ export function matchSrsAgainstScanners(inventory: SrsInventory, findings: Scann
     }
   }
 
-  const frAreas = new Set<string>(inventory.frs.map((f) => normalizeArea(f.area)))
+  const frAreas = new Set<string>()
+  for (const fr of inventory.frs) {
+    for (const candidate of frAreaCandidates(fr)) frAreas.add(candidate)
+  }
   const unmatchedImpl = implFindings.filter((f) => !matchedImplFiles.has(f.file))
   const unmatchedByArea = new Map<string, ImplementationFinding[]>()
   for (const f of unmatchedImpl) {

--- a/src/srs/eval/review-packet.ts
+++ b/src/srs/eval/review-packet.ts
@@ -1,0 +1,120 @@
+import { ScannerFinding } from '../scanners/types'
+import { FreshnessReport, ReviewPacket, ReviewPacketFinding, ReviewPacketFrEntry, SrsFrEntry, SrsInventory } from './types'
+
+function normalizeArea(raw: string): string {
+  return raw.trim().toLowerCase()
+}
+
+function areaCandidates(fr: SrsFrEntry): string[] {
+  const hints = (fr.areaHints ?? []).map(normalizeArea).filter((h) => h.length > 0)
+  return [fr.area, ...hints]
+}
+
+function areaMatches(findingArea: string, token: string): boolean {
+  if (findingArea === token) return true
+  return findingArea.startsWith(token) || token.startsWith(findingArea)
+}
+
+function findingKindSatisfies(finding: ScannerFinding, kind: SrsFrEntry['implementationKind']): boolean {
+  if (finding.kind === 'test' || finding.kind === 'doc-context') return true
+  if (!kind || kind === 'mixed') return true
+  return finding.kind === kind
+}
+
+function findingFile(f: ScannerFinding): string | undefined {
+  if ('file' in f && typeof f.file === 'string') return f.file
+  return undefined
+}
+
+function findingTitle(f: ScannerFinding): string {
+  return f.title
+}
+
+function buildFrEntries(inventory: SrsInventory, findings: ScannerFinding[]): { entries: ReviewPacketFrEntry[]; findingMap: Map<number, string[]> } {
+  const findingMap = new Map<number, string[]>()
+  const entries: ReviewPacketFrEntry[] = inventory.frs.map((fr) => {
+    const candidates = areaCandidates(fr)
+    const matchIndexes: number[] = []
+    findings.forEach((f, idx) => {
+      const area = normalizeArea(f.area)
+      const matches = candidates.some((tok) => areaMatches(area, tok)) && findingKindSatisfies(f, fr.implementationKind)
+      if (matches) {
+        matchIndexes.push(idx)
+        const prev = findingMap.get(idx) ?? []
+        prev.push(fr.id)
+        findingMap.set(idx, prev)
+      }
+    })
+    const matched = matchIndexes.map((i) => findings[i])
+    const matchedFiles = Array.from(new Set(matched.map(findingFile).filter((f): f is string => Boolean(f))))
+    const hasImpl = matched.some((m) => m.kind === 'endpoint' || m.kind === 'ui-flow' || m.kind === 'entity')
+    const hasTest = matched.some((m) => m.kind === 'test')
+    const hasTestedEndpoint = matched.some((m) => m.kind === 'endpoint' && m.hasTests)
+    let status: ReviewPacketFrEntry['status']
+    if (matched.length === 0) status = 'unmatched'
+    else if (hasImpl && !hasTest && !hasTestedEndpoint) status = 'untested'
+    else status = 'matched'
+    return {
+      id: fr.id,
+      title: fr.title,
+      area: fr.area,
+      pageId: fr.pageId,
+      epicPageId: fr.epicPageId,
+      epicTitle: fr.epicTitle,
+      implementationKind: fr.implementationKind,
+      areaHints: fr.areaHints,
+      matchCount: matched.length,
+      matchedFiles,
+      status
+    }
+  })
+  return { entries, findingMap }
+}
+
+function buildFindingEntries(findings: ScannerFinding[], findingMap: Map<number, string[]>): ReviewPacketFinding[] {
+  return findings.map((f, idx) => ({
+    kind: f.kind,
+    area: normalizeArea(f.area),
+    file: findingFile(f),
+    title: findingTitle(f),
+    matchedFrIds: findingMap.get(idx) ?? []
+  }))
+}
+
+function buildPromptHints(frs: ReviewPacketFrEntry[], findings: ReviewPacketFinding[]): string[] {
+  const hints: string[] = []
+  const unmatchedFrs = frs.filter((f) => f.status === 'unmatched')
+  if (unmatchedFrs.length > 0) {
+    hints.push(`${unmatchedFrs.length} FR(s) have no deterministic match — review each to propose a semantic match or flag as truly unimplemented: ${unmatchedFrs.map((f) => f.id).join(', ')}`)
+  }
+  const untestedFrs = frs.filter((f) => f.status === 'untested')
+  if (untestedFrs.length > 0) {
+    hints.push(`${untestedFrs.length} FR(s) have impl but no tests — confirm test gap or point to missed test files: ${untestedFrs.map((f) => f.id).join(', ')}`)
+  }
+  const orphanFindings = findings.filter((f) => f.matchedFrIds.length === 0 && (f.kind === 'endpoint' || f.kind === 'ui-flow' || f.kind === 'entity'))
+  if (orphanFindings.length > 0) {
+    const byArea = new Set(orphanFindings.map((f) => f.area))
+    hints.push(
+      `${orphanFindings.length} code finding(s) in ${byArea.size} area(s) have no FR — propose either new FR pages or re-mapping to an existing FR: ${Array.from(byArea).slice(0, 10).join(', ')}`
+    )
+  }
+  if (hints.length === 0) hints.push('No deterministic gaps detected. Still sweep for semantic drift (FR title vs code behaviour, outdated acceptance criteria).')
+  return hints
+}
+
+export function buildReviewPacket(inventory: SrsInventory, findings: ScannerFinding[], report: FreshnessReport): ReviewPacket {
+  const { entries, findingMap } = buildFrEntries(inventory, findings)
+  const findingEntries = buildFindingEntries(findings, findingMap)
+  return {
+    generatedAt: report.generatedAt,
+    rootPageId: inventory.rootPageId,
+    inventory: {
+      epicCount: inventory.epics.length,
+      frCount: inventory.frs.length
+    },
+    frs: entries,
+    findings: findingEntries,
+    drift: report.findings,
+    promptHints: buildPromptHints(entries, findingEntries)
+  }
+}

--- a/src/srs/eval/types.ts
+++ b/src/srs/eval/types.ts
@@ -16,6 +16,8 @@ export interface DriftFinding {
   file?: string
 }
 
+export type ImplementationKind = 'endpoint' | 'ui-flow' | 'entity' | 'mixed'
+
 export interface SrsFrEntry {
   id: string // e.g. "FR-AUTH-01-01"
   area: string // normalised area token, e.g. "auth" (lowercase)
@@ -23,6 +25,12 @@ export interface SrsFrEntry {
   pageId: string
   epicPageId: string
   epicTitle: string
+  // L2 declarative hints — optional. When a page author wants to steer the
+  // matcher (e.g. a frontend-only FR), they can declare implementationKind
+  // and/or areaHints in the FR page body. Inventory builders may populate
+  // these; the matcher honours them when set.
+  implementationKind?: ImplementationKind
+  areaHints?: string[]
 }
 
 export interface SrsInventory {
@@ -66,4 +74,43 @@ export interface FreshnessReport {
     endpointsUntested: number
   }
   findings: DriftFinding[]
+}
+
+// Review packet — the deterministic summary emitted for agent refinement.
+// Tools never call an LLM themselves; they emit this JSON so that a skill
+// running in an agent context can dig deeper (e.g. propose a match the
+// matcher missed, reclassify a finding, or flag a semantic drift).
+export interface ReviewPacketFrEntry {
+  id: string
+  title: string
+  area: string
+  pageId: string
+  epicPageId: string
+  epicTitle: string
+  implementationKind?: ImplementationKind
+  areaHints?: string[]
+  matchCount: number
+  matchedFiles: string[]
+  status: 'matched' | 'unmatched' | 'untested'
+}
+
+export interface ReviewPacketFinding {
+  kind: string
+  area: string
+  file?: string
+  title: string
+  matchedFrIds: string[]
+}
+
+export interface ReviewPacket {
+  generatedAt: string
+  rootPageId: string
+  inventory: {
+    epicCount: number
+    frCount: number
+  }
+  frs: ReviewPacketFrEntry[]
+  findings: ReviewPacketFinding[]
+  drift: DriftFinding[]
+  promptHints: string[]
 }


### PR DESCRIPTION
## Summary
- **L1** — matcher now recognises `ui-flow`, `entity`, and `test` findings (not just `endpoint`), so frontend-only, data-only, and test-driven FRs match without human intervention.
- **L2** — optional `implementationKind` + `areaHints` on `SrsFrEntry` let FR authors steer the match when scanner area ≠ FR area or when impl kind needs narrowing.
- **L3** — `eval-srs --review-packet <path>` emits a deterministic JSON (per-FR status, per-finding mapping, `promptHints`) for the sf-srs skill to refine with AI. The CLI never calls an LLM itself — zero cost for non-agent users.

Resolves the "endpoint-biased matcher" blocker logged under `.srs-audit/follow-ups.md` §1 during the #203 capstone.

## Test plan
- [x] Unit tests: `matcher.spec.ts` (+7 cases), `review-packet.spec.ts` (4 cases), `eval-srs.spec.ts` (+2 cases)
- [x] Dogfood run against fixture: matched / untested / unmatched statuses + promptHints produced correctly
- [x] `npm run test:pre-commit` — 967 tests green
- [x] `npm run test:pre-push` — 2 docker scenarios green
- [ ] Human review on the three-layer design + skill prose

Parent: #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)