### PR TITLE
[#246] [Parent #235] FR page title: keep em-dash separator in sync between templates and parser

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -418,3 +418,10 @@ Artefacts from the capstone (kept for reference):
 
 - `.srs-audit/follow-ups.md` — full lessons-learned analysis
 - `.srs-audit/baseline-report-fixed-root.json` — first eval baseline (score 32, all FRs flagged fr-without-code due to #236)
+
+## Contributor notes
+
+- **FR page title format.** The canonical separator between the FR id and the title is the em-dash character (U+2014) wrapped in spaces: `FR-AREA-NN — Title`. It lives as the shared constant
+  `FR_TITLE_SEPARATOR` in `src/builders/srs/constants.ts`, imported by both the page renderer (`src/builders/srs/templates/pages/fr.tpl.ts`) and the inventory parser (`src/srs/eval/inventory.ts`). Do
+  not substitute an ASCII hyphen (U+002D) — it round-trips through Notion as the same glyph visually but breaks the byte-level identity the tests enforce. If you change the separator, update the
+  constant in one place and both sites follow.

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -418,3 +418,10 @@ Artefacts from the capstone (kept for reference):
 
 - `.srs-audit/follow-ups.md` — full lessons-learned analysis
 - `.srs-audit/baseline-report-fixed-root.json` — first eval baseline (score 32, all FRs flagged fr-without-code due to #236)
+
+## Contributor notes
+
+- **FR page title format.** The canonical separator between the FR id and the title is the em-dash character (U+2014) wrapped in spaces: `FR-AREA-NN — Title`. It lives as the shared constant
+  `FR_TITLE_SEPARATOR` in `src/builders/srs/constants.ts`, imported by both the page renderer (`src/builders/srs/templates/pages/fr.tpl.ts`) and the inventory parser (`src/srs/eval/inventory.ts`). Do
+  not substitute an ASCII hyphen (U+002D) — it round-trips through Notion as the same glyph visually but breaks the byte-level identity the tests enforce. If you change the separator, update the
+  constant in one place and both sites follow.

--- a/src/__tests__/unit/srs/eval/inventory.spec.ts
+++ b/src/__tests__/unit/srs/eval/inventory.spec.ts
@@ -1,3 +1,4 @@
+import { FR_TITLE_SEPARATOR } from '../../../../builders/srs/constants'
 import { EpicSpec, FrSpec, PageContent, PageRef, RawContent, ResolvedParent, SrsAdapter } from '../../../../builders/srs/types'
 import { buildSrsInventory, parseFrPageTitle } from '../../../../srs/eval/inventory'
 
@@ -39,6 +40,11 @@ describe('parseFrPageTitle', () => {
 
   it('accepts a colon separator', () => {
     expect(parseFrPageTitle('FR-STORAGE-01: Upload')).toEqual({ id: 'FR-STORAGE-01', area: 'storage', title: 'Upload' })
+  })
+
+  it('parses a title built with the shared FR_TITLE_SEPARATOR constant', () => {
+    const raw = `FR-AUTH-01${FR_TITLE_SEPARATOR}Sign in`
+    expect(parseFrPageTitle(raw)).toEqual({ id: 'FR-AUTH-01', area: 'auth', title: 'Sign in' })
   })
 
   it('normalises the area to lowercase', () => {

--- a/src/__tests__/unit/srs/templates/fr.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/fr.tpl.spec.ts
@@ -1,3 +1,4 @@
+import { FR_TITLE_SEPARATOR } from '../../../../builders/srs/constants'
 import { renderFrPage } from '../../../../builders/srs/templates/pages/fr.tpl'
 import { FrSpec, PageBlock, TableBlock } from '../../../../builders/srs/types'
 
@@ -17,6 +18,18 @@ describe('renderFrPage — DIAMONFORGE-style structure', () => {
     const spec: FrSpec = { parentEpicPageId: 'epic', fr: { id: 'FR-AUTH-01-01', title: 'Sign in' } }
     const page = renderFrPage(spec)
     expect(page.title).toBe('FR-AUTH-01-01 — Sign in')
+  })
+
+  it('separates FR id from title with em-dash (U+2014), not ASCII hyphen', () => {
+    const spec: FrSpec = { parentEpicPageId: 'epic', fr: { id: 'FR-AUTH-01-01', title: 'Sign in' } }
+    const page = renderFrPage(spec)
+    // Lock the exact separator at the byte level so a silent switch to "-"
+    // (U+002D) or ":" breaks the test and surfaces in review.
+    expect(page.title).toBe(`FR-AUTH-01-01${FR_TITLE_SEPARATOR}Sign in`)
+    expect(FR_TITLE_SEPARATOR).toBe(' \u2014 ')
+    const title = page.title ?? ''
+    expect(title.includes('\u2014')).toBe(true)
+    expect(title.split('\u2014').length).toBe(2)
   })
 
   it('emits Summary + divider + per-item detail in order', () => {

--- a/src/builders/srs/constants.ts
+++ b/src/builders/srs/constants.ts
@@ -1,0 +1,4 @@
+// FR page-title separator — em-dash (U+2014) with surrounding spaces.
+// Shared by the FR page renderer and the inventory parser so the template
+// output and the parser's canonical form stay aligned at a single source.
+export const FR_TITLE_SEPARATOR = ' \u2014 '

--- a/src/builders/srs/templates/pages/fr.tpl.ts
+++ b/src/builders/srs/templates/pages/fr.tpl.ts
@@ -1,3 +1,4 @@
+import { FR_TITLE_SEPARATOR } from '../../constants'
 import { FrItem, FrSpec, PageBlock, PageContent, Priority } from '../../types'
 
 const EMPTY_CELL = '—'
@@ -54,10 +55,10 @@ export function renderFrPage(spec: FrSpec): PageContent {
   blocks.push({ kind: 'divider' })
 
   frs.forEach((fr, idx) => {
-    blocks.push({ kind: 'heading', level: 2, text: `${fr.id} — ${fr.title}` })
+    blocks.push({ kind: 'heading', level: 2, text: `${fr.id}${FR_TITLE_SEPARATOR}${fr.title}` })
     blocks.push({ kind: 'table', header: ['Field', 'Value'], rows: detailRows(fr) })
     if (idx < frs.length - 1) blocks.push({ kind: 'divider' })
   })
 
-  return { title: `${spec.fr.id} — ${spec.fr.title}`, blocks }
+  return { title: `${spec.fr.id}${FR_TITLE_SEPARATOR}${spec.fr.title}`, blocks }
 }

--- a/src/srs/eval/inventory.ts
+++ b/src/srs/eval/inventory.ts
@@ -1,10 +1,14 @@
+import { FR_TITLE_SEPARATOR } from '../../builders/srs/constants'
 import { PageRef, SrsAdapter } from '../../builders/srs/types'
 import { SrsFrEntry, SrsInventory } from './types'
 
-// FR page titles follow "FR-AREA-NN[-MM] — Title" after SUB-3 / SUB-18.
-// parseFrTitle (src/srs/bin/spawn.ts) only handles the legacy "FR-NNN" shape,
-// so we ship a dedicated parser here that tolerates both.
+// FR page titles follow `FR-AREA-NN[-MM]${FR_TITLE_SEPARATOR}Title` (em-dash,
+// U+2014) produced by `renderFrPage`. The parser accepts the canonical
+// separator and tolerates colon or hyphen as fallbacks for resilience against
+// manual edits in Notion.
 const FR_ID_RE = /^(FR-([A-Z0-9]+)(?:-\d+)+)/i
+const CANONICAL_SEP_CHAR = FR_TITLE_SEPARATOR.trim()
+const SEPARATOR_RE = new RegExp(`^\\s*[${CANONICAL_SEP_CHAR}:\\-]\\s*`)
 
 export interface ParsedFrTitle {
   id: string
@@ -18,7 +22,7 @@ export function parseFrPageTitle(raw: string): ParsedFrTitle | null {
   if (!match) return null
   const id = match[1].toUpperCase()
   const area = match[2].toLowerCase()
-  const rest = trimmed.slice(match[0].length).replace(/^\s*[—:\-]\s*/, '')
+  const rest = trimmed.slice(match[0].length).replace(SEPARATOR_RE, '')
   const title = rest.length > 0 ? rest : id
   return { id, area, title }
 }


### PR DESCRIPTION
Resolves #246