### PR TITLE
feat(#241): expose sf srs Commander façade over bin entrypoints

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -65,7 +65,14 @@ Dispatch resolution happens inside `src/srs/` (SUB-14.2) — never directly in t
 
 ## Commands
 
-All via `.claude/skills/sf-srs/scripts/srs-cli.sh <action> [args]`.
+Two equivalent entrypoints expose the same actions:
+
+- **CLI (preferred, non-interactive)**: `sf srs <action> [args]` — registered in Commander (see `src/commands/srs.ts`), forwards directly to the TS entrypoints under `src/srs/bin/*.ts`. Use this in
+  CI, scripts, and from AI agents that can't rely on a skill being installed.
+- **Skill shell wrapper**: `.claude/skills/sf-srs/scripts/srs-cli.sh <action> [args]` — same actions, kept in parallel so the skill stays self-contained and works even if `sf` isn't on the `PATH` of
+  the Claude Code session.
+
+Run `sf srs help` or `srs-cli.sh help` to see the full action list.
 
 | Action         | Purpose                                                               | Populated by |
 | -------------- | --------------------------------------------------------------------- | ------------ |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import noVersionPrefixPlugin from './eslint-rules/no-version-prefix.mjs'
 
 export default [
   {
-    ignores: ['node_modules', 'dist', 'coverage', 'scaffolds', 'blueprints', 'overlays', 'docs/.vitepress/cache', 'docs/.vitepress/dist']
+    ignores: ['node_modules', 'dist', 'coverage', 'scaffolds', 'blueprints', 'overlays', 'docs/.vitepress/cache', 'docs/.vitepress/dist', '.claude/worktrees']
   },
 
   ...tseslint.configs.recommended,

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -65,7 +65,14 @@ Dispatch resolution happens inside `src/srs/` (SUB-14.2) — never directly in t
 
 ## Commands
 
-All via `.claude/skills/sf-srs/scripts/srs-cli.sh <action> [args]`.
+Two equivalent entrypoints expose the same actions:
+
+- **CLI (preferred, non-interactive)**: `sf srs <action> [args]` — registered in Commander (see `src/commands/srs.ts`), forwards directly to the TS entrypoints under `src/srs/bin/*.ts`. Use this in
+  CI, scripts, and from AI agents that can't rely on a skill being installed.
+- **Skill shell wrapper**: `.claude/skills/sf-srs/scripts/srs-cli.sh <action> [args]` — same actions, kept in parallel so the skill stays self-contained and works even if `sf` isn't on the `PATH` of
+  the Claude Code session.
+
+Run `sf srs help` or `srs-cli.sh help` to see the full action list.
 
 | Action         | Purpose                                                               | Populated by |
 | -------------- | --------------------------------------------------------------------- | ------------ |

--- a/src/__tests__/unit/commands/srs.spec.ts
+++ b/src/__tests__/unit/commands/srs.spec.ts
@@ -1,0 +1,176 @@
+jest.mock('../../../srs/bin/validate', () => ({ runValidate: jest.fn().mockResolvedValue(0) }))
+jest.mock('../../../srs/bin/browse-tree', () => ({
+  runBrowseTree: jest.fn().mockResolvedValue(0),
+  parseArgs: jest.fn((argv: string[]) => {
+    let parentId = ''
+    let manifestPath = '.saasfoundry.json'
+    for (let i = 0; i < argv.length; i++) {
+      if (argv[i] === '--parent') parentId = argv[++i] ?? ''
+      else if (argv[i] === '--manifest') manifestPath = argv[++i] ?? manifestPath
+    }
+    return { parentId, manifestPath }
+  })
+}))
+jest.mock('../../../srs/bin/draft-from-notion-pages', () => ({
+  runDraftFromNotionPages: jest.fn().mockResolvedValue(0),
+  parseArgs: jest.fn((argv: string[]) => {
+    let pageIds: string[] = []
+    let manifestPath = '.saasfoundry.json'
+    for (let i = 0; i < argv.length; i++) {
+      if (argv[i] === '--ids') pageIds = (argv[++i] ?? '').split(',')
+      else if (argv[i] === '--manifest') manifestPath = argv[++i] ?? manifestPath
+    }
+    return { pageIds, manifestPath }
+  })
+}))
+jest.mock('../../../srs/bin/draft-from-codebase', () => ({
+  runDraftFromCodebase: jest.fn().mockResolvedValue(0),
+  parseArgs: jest.fn((argv: string[]) => {
+    let scanPath = ''
+    let manifestPath = '.saasfoundry.json'
+    for (let i = 0; i < argv.length; i++) {
+      if (argv[i] === '--path') scanPath = argv[++i] ?? ''
+      else if (argv[i] === '--manifest') manifestPath = argv[++i] ?? manifestPath
+    }
+    return { scanPath, manifestPath }
+  })
+}))
+jest.mock('../../../srs/bin/write-srs', () => ({
+  runWriteSrs: jest.fn().mockResolvedValue(0),
+  parseArgs: jest.fn((argv: string[]) => ({ specPath: argv[1] ?? '', manifestPath: '.saasfoundry.json', clearPendingIngestion: true }))
+}))
+jest.mock('../../../srs/bin/spawn', () => ({
+  runSpawn: jest.fn().mockResolvedValue(0),
+  parseArgs: jest.fn(() => ({ ticket: 0, epic: '', dryRun: false, manifestPath: '.saasfoundry.json' }))
+}))
+jest.mock('../../../srs/bin/apply-srs-update', () => ({
+  runApplyUpdate: jest.fn().mockResolvedValue(0),
+  parseArgs: jest.fn(() => ({ patchPath: undefined, manifestPath: '.saasfoundry.json' }))
+}))
+jest.mock('../../../srs/bin/eval-srs', () => ({
+  runEvalSrs: jest.fn().mockResolvedValue(0),
+  parseArgs: jest.fn(() => ({ scanPath: '', manifestPath: '.saasfoundry.json', thresholdPct: 80, output: 'human' as const }))
+}))
+
+import { runApplyUpdate } from '../../../srs/bin/apply-srs-update'
+import { runBrowseTree } from '../../../srs/bin/browse-tree'
+import { runDraftFromCodebase } from '../../../srs/bin/draft-from-codebase'
+import { runDraftFromNotionPages } from '../../../srs/bin/draft-from-notion-pages'
+import { runEvalSrs } from '../../../srs/bin/eval-srs'
+import { runSpawn } from '../../../srs/bin/spawn'
+import { runValidate } from '../../../srs/bin/validate'
+import { runWriteSrs } from '../../../srs/bin/write-srs'
+import { srsCommand } from '../../../commands/srs'
+
+describe('srsCommand', () => {
+  const originalExitCode: typeof process.exitCode = process.exitCode
+  let stdoutSpy: jest.SpyInstance
+  let stderrSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.exitCode = undefined
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+    stderrSpy.mockRestore()
+    process.exitCode = originalExitCode
+  })
+
+  it('prints usage on help', async () => {
+    await srsCommand('help')
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(output).toContain('Usage: sf srs <action>')
+    expect(output).toContain('validate')
+    expect(output).toContain('eval')
+  })
+
+  it('prints usage when called with no subcommand', async () => {
+    await srsCommand()
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(output).toContain('Usage: sf srs <action>')
+  })
+
+  it('forwards validate to runValidate with default manifest', async () => {
+    await srsCommand('validate')
+    expect(runValidate).toHaveBeenCalledWith({ manifestPath: '.saasfoundry.json' })
+  })
+
+  it('forwards validate with custom manifest positional', async () => {
+    await srsCommand('validate', 'custom.json')
+    expect(runValidate).toHaveBeenCalledWith({ manifestPath: 'custom.json' })
+  })
+
+  it('forwards browse with --parent and --manifest', async () => {
+    await srsCommand('browse', '--parent', 'page_1', '--manifest', 'my.json')
+    expect(runBrowseTree).toHaveBeenCalledWith({ parentId: 'page_1', manifestPath: 'my.json' })
+  })
+
+  it('routes draft --from notion-pages to runDraftFromNotionPages', async () => {
+    await srsCommand('draft', '--from', 'notion-pages', '--ids', 'p1,p2')
+    expect(runDraftFromNotionPages).toHaveBeenCalledWith({ pageIds: ['p1', 'p2'], manifestPath: '.saasfoundry.json' })
+    expect(runDraftFromCodebase).not.toHaveBeenCalled()
+  })
+
+  it('routes draft --from codebase to runDraftFromCodebase', async () => {
+    await srsCommand('draft', '--from', 'codebase', '--path', './src')
+    expect(runDraftFromCodebase).toHaveBeenCalledWith({ scanPath: './src', manifestPath: '.saasfoundry.json' })
+    expect(runDraftFromNotionPages).not.toHaveBeenCalled()
+  })
+
+  it('defaults draft source to notion-pages when --from is omitted', async () => {
+    await srsCommand('draft', '--ids', 'p1')
+    expect(runDraftFromNotionPages).toHaveBeenCalled()
+  })
+
+  it('rejects an unknown draft source with exit code 2', async () => {
+    await srsCommand('draft', '--from', 'magic')
+    expect(process.exitCode).toBe(2)
+    const err = stderrSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(err).toContain("unknown --from value 'magic'")
+  })
+
+  it('forwards write to runWriteSrs', async () => {
+    await srsCommand('write', '--spec', 'spec.json')
+    expect(runWriteSrs).toHaveBeenCalled()
+  })
+
+  it('forwards spawn to runSpawn', async () => {
+    await srsCommand('spawn', '--ticket', '42', '--epic', 'page_x')
+    expect(runSpawn).toHaveBeenCalled()
+  })
+
+  it('forwards apply-update to runApplyUpdate', async () => {
+    await srsCommand('apply-update')
+    expect(runApplyUpdate).toHaveBeenCalled()
+  })
+
+  it('forwards eval to runEvalSrs', async () => {
+    await srsCommand('eval')
+    expect(runEvalSrs).toHaveBeenCalled()
+  })
+
+  it('emits usage and sets exit code 2 for unknown action', async () => {
+    await srsCommand('make-coffee')
+    expect(process.exitCode).toBe(2)
+    const err = stderrSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(err).toContain("unknown action 'make-coffee'")
+  })
+
+  it('propagates runner exit codes to process.exitCode', async () => {
+    ;(runValidate as jest.Mock).mockResolvedValueOnce(3)
+    await srsCommand('validate')
+    expect(process.exitCode).toBe(3)
+  })
+
+  it('sets exit code 1 on unexpected runner error', async () => {
+    ;(runValidate as jest.Mock).mockRejectedValueOnce(new Error('boom'))
+    await srsCommand('validate')
+    expect(process.exitCode).toBe(1)
+    const err = stderrSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(err).toContain('unexpected error — boom')
+  })
+})

--- a/src/commands/srs.ts
+++ b/src/commands/srs.ts
@@ -1,0 +1,135 @@
+import { parseArgs as parseApplyArgs, runApplyUpdate } from '../srs/bin/apply-srs-update'
+import { parseArgs as parseBrowseArgs, runBrowseTree } from '../srs/bin/browse-tree'
+import { parseArgs as parseDraftCodebaseArgs, runDraftFromCodebase } from '../srs/bin/draft-from-codebase'
+import { parseArgs as parseDraftNotionPagesArgs, runDraftFromNotionPages } from '../srs/bin/draft-from-notion-pages'
+import { parseArgs as parseEvalArgs, runEvalSrs } from '../srs/bin/eval-srs'
+import { parseArgs as parseSpawnArgs, runSpawn } from '../srs/bin/spawn'
+import { runValidate } from '../srs/bin/validate'
+import { parseArgs as parseWriteArgs, runWriteSrs } from '../srs/bin/write-srs'
+
+const USAGE = `Usage: sf srs <action> [args...]
+
+Actions:
+  help                                   Print this message
+  validate [manifest]                    Smoke-test the configured backend via adapter.init()
+  browse --parent <id> [--manifest]      List direct children of a parent page (JSON)
+  draft --from notion-pages --ids <id1,id2,...> [--manifest]
+                                         Fetch pages from the backend as RawContent (JSON)
+  draft --from codebase [--path <dir>] [--manifest]
+                                         Scan the local codebase and emit structured findings (JSON)
+  write --spec <path> [--manifest] [--no-clear-pending]
+                                         Apply a DraftCandidate[] spec file through the adapter
+  spawn --ticket <n> --epic <page-url-or-id> [--dry-run] [--manifest] [--bypass-reason <text>]
+                                         Enumerate FR page children of an Epic and create Story sub-tickets
+  apply-update [--patch <path>] [--manifest]
+                                         Apply a conversational eval-hook patch (ADD-only)
+  eval [--path <dir>] [--root-page <id>] [--threshold <pct>] [--json] [--manifest]
+                                         Score SRS freshness vs. codebase (batch)
+
+Common options:
+  --manifest <path>                      Manifest file to read (default: .saasfoundry.json)
+
+Exit codes (shared contract):
+  0 success · 2 bad input · 3 missing backend · 4 unknown backend · 5 runtime ·
+  6 write partial (rollbackHint) · 7 write ok but pendingIngestion clear failed
+
+For details, see .claude/skills/sf-srs/SKILL.md.
+`
+
+function emitUsage(): void {
+  process.stdout.write(USAGE)
+}
+
+function runDraft(argv: string[]): Promise<number> {
+  let source = 'notion-pages'
+  const forwarded: string[] = []
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--from') {
+      source = argv[++i] ?? ''
+    } else if (arg.startsWith('--from=')) {
+      source = arg.slice('--from='.length)
+    } else {
+      forwarded.push(arg)
+    }
+  }
+  if (!source) {
+    process.stderr.write('sf srs draft: --from <source> is required (notion-pages | codebase).\n')
+    return Promise.resolve(2)
+  }
+  if (source === 'notion-pages') {
+    const { pageIds, manifestPath } = parseDraftNotionPagesArgs(forwarded)
+    return runDraftFromNotionPages({ pageIds, manifestPath })
+  }
+  if (source === 'codebase') {
+    const { scanPath, manifestPath, unknown } = parseDraftCodebaseArgs(forwarded)
+    if (unknown) {
+      process.stderr.write(`sf srs draft --from codebase: unknown option '${unknown}'\n`)
+      return Promise.resolve(2)
+    }
+    return runDraftFromCodebase({ scanPath, manifestPath })
+  }
+  process.stderr.write(`sf srs draft: unknown --from value '${source}' (expected: notion-pages | codebase).\n`)
+  return Promise.resolve(2)
+}
+
+export async function srsCommand(subcommand?: string, ...rest: string[]): Promise<void> {
+  const action = subcommand ?? 'help'
+  const argv = rest.filter((arg): arg is string => typeof arg === 'string' && arg !== undefined)
+
+  let code = 0
+  try {
+    switch (action) {
+      case 'help':
+      case '-h':
+      case '--help':
+        emitUsage()
+        code = 0
+        break
+      case 'validate': {
+        const manifestPath = argv[0] ?? '.saasfoundry.json'
+        code = await runValidate({ manifestPath })
+        break
+      }
+      case 'browse': {
+        const { parentId, manifestPath } = parseBrowseArgs(argv)
+        code = await runBrowseTree({ parentId, manifestPath })
+        break
+      }
+      case 'draft':
+        code = await runDraft(argv)
+        break
+      case 'write': {
+        const options = parseWriteArgs(argv)
+        code = await runWriteSrs(options)
+        break
+      }
+      case 'spawn': {
+        const options = parseSpawnArgs(argv)
+        code = await runSpawn(options)
+        break
+      }
+      case 'apply-update': {
+        const options = parseApplyArgs(argv)
+        code = await runApplyUpdate(options)
+        break
+      }
+      case 'eval': {
+        const options = parseEvalArgs(argv)
+        code = await runEvalSrs(options)
+        break
+      }
+      default:
+        process.stderr.write(`sf srs: unknown action '${action}'\n`)
+        emitUsage()
+        code = 2
+        break
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`sf srs ${action}: unexpected error — ${message}\n`)
+    code = 1
+  }
+
+  if (code !== 0) process.exitCode = code
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { feedbackCommand } from './commands/feedback'
 import { modulesCommand } from './commands/modules'
 import { newCommand } from './commands/new'
 import { skillCommand, runFullUninstall } from './commands/skill'
+import { srsCommand } from './commands/srs'
 import { updateCommand } from './commands/update'
 import { toolsCommand } from './commands/tools'
 import { statusCommand } from './commands/status'
@@ -135,6 +136,13 @@ program
   .argument('[args...]', 'Additional arguments for the subcommand')
   .action((subcommand, args) => workflowCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
 program
+  .command('srs')
+  .description('SRS workspace operations (validate, browse, draft, write, spawn, apply-update, eval)')
+  .argument('[subcommand]', 'Subcommand to execute (validate, browse, draft, write, spawn, apply-update, eval)')
+  .argument('[args...]', 'Additional arguments forwarded to the subcommand (see `sf srs help`)')
+  .allowUnknownOption()
+  .action((subcommand, args) => srsCommand(subcommand, ...(Array.isArray(args) ? args : [args])))
+program
   .command('skill')
   .description('Manage the tool-saasfoundry Claude Code skill (install, update, uninstall)')
   .argument('[subcommand]', 'Subcommand to execute (install)')
@@ -162,4 +170,4 @@ program
   })
 program.parse()
 
-export { newCommand, updateCommand, modulesCommand, toolsCommand, workflowCommand, skillCommand, feedbackCommand, statusCommand }
+export { newCommand, updateCommand, modulesCommand, toolsCommand, workflowCommand, skillCommand, srsCommand, feedbackCommand, statusCommand }

--- a/src/srs/bin/browse-tree.ts
+++ b/src/srs/bin/browse-tree.ts
@@ -57,7 +57,7 @@ export async function runBrowseTree(options: BrowseTreeOptions): Promise<number>
   }
 }
 
-function parseArgs(argv: string[]): { parentId: string; manifestPath: string } {
+export function parseArgs(argv: string[]): { parentId: string; manifestPath: string } {
   let parentId = ''
   let manifestPath = '.saasfoundry.json'
   for (let i = 0; i < argv.length; i++) {

--- a/src/srs/bin/draft-from-codebase.ts
+++ b/src/srs/bin/draft-from-codebase.ts
@@ -85,7 +85,7 @@ export async function runDraftFromCodebase(options: DraftFromCodebaseOptions): P
   }
 }
 
-function parseArgs(argv: string[]): { scanPath: string; manifestPath: string; unknown?: string } {
+export function parseArgs(argv: string[]): { scanPath: string; manifestPath: string; unknown?: string } {
   let scanPath = ''
   let manifestPath = '.saasfoundry.json'
   for (let i = 0; i < argv.length; i++) {

--- a/src/srs/bin/draft-from-notion-pages.ts
+++ b/src/srs/bin/draft-from-notion-pages.ts
@@ -63,7 +63,7 @@ export async function runDraftFromNotionPages(options: DraftFromNotionPagesOptio
   }
 }
 
-function parseArgs(argv: string[]): { pageIds: string[]; manifestPath: string } {
+export function parseArgs(argv: string[]): { pageIds: string[]; manifestPath: string } {
   let pageIds: string[] = []
   let manifestPath = '.saasfoundry.json'
   for (let i = 0; i < argv.length; i++) {

--- a/src/srs/bin/write-srs.ts
+++ b/src/srs/bin/write-srs.ts
@@ -152,7 +152,7 @@ export async function runWriteSrs(options: WriteSrsOptions): Promise<number> {
   return 0
 }
 
-function parseArgs(argv: string[]): { specPath: string; manifestPath: string; clearPendingIngestion: boolean } {
+export function parseArgs(argv: string[]): { specPath: string; manifestPath: string; clearPendingIngestion: boolean } {
   let specPath = ''
   let manifestPath = '.saasfoundry.json'
   let clearPendingIngestion = true


### PR DESCRIPTION
## Summary

- New `sf srs` Commander subcommand dispatches to the existing bin entrypoints (`validate`, `browse`, `draft`, `write`, `spawn`, `apply-update`, `eval`), giving users a single, discoverable CLI surface parallel to the skill shell wrapper.
- `draft` routes between `--from notion-pages` (default) and `--from codebase`.
- Bin modules' internal `parseArgs` helpers are now exported so the façade reuses the exact argv contract, avoiding drift.
- Skill SKILL.md (both `.claude/skills/sf-srs/` and `scaffolds/skills-templates/sf-srs/`) updated to present the CLI as the preferred surface alongside the skill shell wrapper with rationale.

## Implementation

- New `src/commands/srs.ts` — Commander dispatcher with `emitUsage()` + per-action argv parsers that defer to the bin modules' own `parseArgs` implementations.
- `src/index.ts` — registers `program.command('srs')` between `workflow` and `skill` with `allowUnknownOption()`; adds `srsCommand` to exports.
- `src/srs/bin/browse-tree.ts`, `draft-from-codebase.ts`, `draft-from-notion-pages.ts`, `write-srs.ts` — `export` the internal `parseArgs` helper so the façade's dispatcher can reuse it verbatim.
- `eslint.config.mjs` — adds `.claude/worktrees` to ignores to unblock lint (stale git worktree contains a nested `.prettierrc` with a missing plugin dep).

## Tests

- New: `src/__tests__/unit/commands/srs.spec.ts` (16 cases) — mocks all 8 bin modules, covers help, each subcommand dispatch, draft routing (notion-pages / codebase / unknown), unknown action → exit 2, exit-code propagation, unexpected-error → `process.exitCode=1`.

## Test plan

- [x] `npm run test:pre-commit` (format + lint + type-check + jest)
- [x] `npm run test:pre-push` (top 2 Docker scenarios)
- [ ] `sf srs --help` → lists all actions + args
- [ ] `sf srs draft --from codebase --path .` → prints scanner findings JSON
- [ ] `sf srs validate` → returns 0 on a manifest with valid SRS config
- [ ] `sf srs browse <parent-id>` → lists children

🤖 Generated with [Claude Code](https://claude.com/claude-code)