### PR TITLE
feat(#245): logical-ID Epic→FR links in write-srs

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -212,6 +212,45 @@ The flag is ephemeral — it signals "the user asked us to ingest existing notes
 On partial failure during `write`, `write-srs.ts` emits a JSON report with a `rollbackHint` listing the pages it already created — Notion has no transactional rollback, so the skill surfaces this list
 to the user and suggests either archiving manually or retrying from where it failed.
 
+### Single-pass Epic + FR writes (logical IDs, #245)
+
+FRs reference their parent Epic via one of two fields :
+
+- `parentEpicPageId` — an explicit Notion page ID. Use when attaching an FR to an Epic that already exists (incremental writes, post-import).
+- `parentEpicId` — a **logical ID** that matches the `epic.id` of an Epic appearing earlier in the same batch. `write-srs` resolves it on the fly by building a logical-id → page-id map as Epics are
+  created.
+
+Example mixed spec (a single `write` call creates both Epic and FRs, no intermediate page-id collection) :
+
+```json
+[
+  {
+    "kind": "epic",
+    "confidence": "high",
+    "source": { "kind": "notion-pages" },
+    "epic": {
+      "id": "EPIC-AUTH",
+      "title": "Authentication",
+      "parentPageId": "<workspace-root-id>",
+      "urs": [],
+      "frs": []
+    }
+  },
+  {
+    "kind": "fr",
+    "confidence": "high",
+    "source": { "kind": "notion-pages" },
+    "fr": {
+      "parentEpicId": "EPIC-AUTH",
+      "fr": { "id": "FR-1", "title": "Login endpoint" }
+    }
+  }
+]
+```
+
+If `parentEpicId` references an Epic that is neither in the batch nor resolved via `parentEpicPageId`, `write-srs` exits 6 with an error listing every logical id known so far — easy to spot typos and
+missing Epics.
+
 ### Exit codes
 
 Every TS entrypoint under `src/srs/bin/` honours the same contract. The skill must branch on these codes rather than parsing stderr :
@@ -445,8 +484,8 @@ Running the full `sf srs` chain end-to-end on SaaSFoundry itself surfaced 12 gap
 - **Scan from CWD ratisse scaffolds/ + docs/ (#238).** On CLI / library projects, run `draft --from codebase --path src` — a full-repo scan drowns real findings with template code.
 - **Bootstrap does not persist `NOTION_API_TOKEN` (#239).** After `sf update --add-modules srs`, the token lives only in the interactive shell. For non-interactive / Claude bash sessions, load it from
   `.env` with `set -a && source .env && set +a` until the fix lands.
-- **`write-srs` needs two passes today (#245).** Epics must be written first to obtain page IDs, then an FR spec referencing `parentEpicPageId` is generated, then written. Scripted in `.srs-audit/` as
-  reference until logical-ID resolution lands.
+- **`write-srs` supports single-pass Epic + FR writes via logical IDs (#245).** Mix Epics (with `epic.id`) and FRs (with `parentEpicId`) in one spec — `write-srs` resolves the references as it goes.
+  `parentEpicPageId` remains as an escape hatch for incremental writes against pre-existing Epics.
 - **SRS completeness is UR+FR only (#247).** DS / TC / NFR are not generated yet. The DIAMONFORGE reference shape expects all five. AI-assisted generation planned under #247, reusing the L1+L2+L3
   matcher architecture.
 - **Preconditions first.** Before asking the user scope questions (backend choice, Notion parent page, etc.), read `.saasfoundry.json` — the answers are almost always already there. Re-running

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -212,6 +212,45 @@ The flag is ephemeral — it signals "the user asked us to ingest existing notes
 On partial failure during `write`, `write-srs.ts` emits a JSON report with a `rollbackHint` listing the pages it already created — Notion has no transactional rollback, so the skill surfaces this list
 to the user and suggests either archiving manually or retrying from where it failed.
 
+### Single-pass Epic + FR writes (logical IDs, #245)
+
+FRs reference their parent Epic via one of two fields :
+
+- `parentEpicPageId` — an explicit Notion page ID. Use when attaching an FR to an Epic that already exists (incremental writes, post-import).
+- `parentEpicId` — a **logical ID** that matches the `epic.id` of an Epic appearing earlier in the same batch. `write-srs` resolves it on the fly by building a logical-id → page-id map as Epics are
+  created.
+
+Example mixed spec (a single `write` call creates both Epic and FRs, no intermediate page-id collection) :
+
+```json
+[
+  {
+    "kind": "epic",
+    "confidence": "high",
+    "source": { "kind": "notion-pages" },
+    "epic": {
+      "id": "EPIC-AUTH",
+      "title": "Authentication",
+      "parentPageId": "<workspace-root-id>",
+      "urs": [],
+      "frs": []
+    }
+  },
+  {
+    "kind": "fr",
+    "confidence": "high",
+    "source": { "kind": "notion-pages" },
+    "fr": {
+      "parentEpicId": "EPIC-AUTH",
+      "fr": { "id": "FR-1", "title": "Login endpoint" }
+    }
+  }
+]
+```
+
+If `parentEpicId` references an Epic that is neither in the batch nor resolved via `parentEpicPageId`, `write-srs` exits 6 with an error listing every logical id known so far — easy to spot typos and
+missing Epics.
+
 ### Exit codes
 
 Every TS entrypoint under `src/srs/bin/` honours the same contract. The skill must branch on these codes rather than parsing stderr :
@@ -445,8 +484,8 @@ Running the full `sf srs` chain end-to-end on SaaSFoundry itself surfaced 12 gap
 - **Scan from CWD ratisse scaffolds/ + docs/ (#238).** On CLI / library projects, run `draft --from codebase --path src` — a full-repo scan drowns real findings with template code.
 - **Bootstrap does not persist `NOTION_API_TOKEN` (#239).** After `sf update --add-modules srs`, the token lives only in the interactive shell. For non-interactive / Claude bash sessions, load it from
   `.env` with `set -a && source .env && set +a` until the fix lands.
-- **`write-srs` needs two passes today (#245).** Epics must be written first to obtain page IDs, then an FR spec referencing `parentEpicPageId` is generated, then written. Scripted in `.srs-audit/` as
-  reference until logical-ID resolution lands.
+- **`write-srs` supports single-pass Epic + FR writes via logical IDs (#245).** Mix Epics (with `epic.id`) and FRs (with `parentEpicId`) in one spec — `write-srs` resolves the references as it goes.
+  `parentEpicPageId` remains as an escape hatch for incremental writes against pre-existing Epics.
 - **SRS completeness is UR+FR only (#247).** DS / TC / NFR are not generated yet. The DIAMONFORGE reference shape expects all five. AI-assisted generation planned under #247, reusing the L1+L2+L3
   matcher architecture.
 - **Preconditions first.** Before asking the user scope questions (backend choice, Notion parent page, etc.), read `.saasfoundry.json` — the answers are almost always already there. Re-running

--- a/src/__tests__/unit/srs/write-srs.spec.ts
+++ b/src/__tests__/unit/srs/write-srs.spec.ts
@@ -229,4 +229,93 @@ describe('runWriteSrs', () => {
     const code = await runWriteSrs({ specPath, manifestPath })
     expect(code).toBe(2)
   })
+
+  it('resolves FR parentEpicId to the Epic created earlier in the same batch', async () => {
+    const adapter = new StubAdapter()
+    registerSrsBackend('write-stub', () => adapter)
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'write-stub' } } })
+    const epicCandidate: DraftCandidate = {
+      kind: 'epic',
+      confidence: 'medium',
+      epic: { title: 'Auth', id: 'EPIC-AUTH', parentPageId: 'root', urs: [], frs: [] },
+      source: { kind: 'notion-pages' }
+    }
+    const frCandidate: DraftCandidate = {
+      kind: 'fr',
+      confidence: 'medium',
+      fr: { parentEpicId: 'EPIC-AUTH', fr: { id: 'FR-1', title: 'Login endpoint' } },
+      source: { kind: 'notion-pages' }
+    }
+    const specPath = writeSpec([epicCandidate, frCandidate])
+
+    const code = await runWriteSrs({ specPath, manifestPath })
+
+    expect(code).toBe(0)
+    expect(adapter.createdFrs).toHaveLength(1)
+    expect(adapter.createdFrs[0].parentEpicPageId).toBe('epic-1')
+  })
+
+  it('fails with code 6 and a clear error when parentEpicId is unresolved', async () => {
+    const adapter = new StubAdapter()
+    registerSrsBackend('write-stub', () => adapter)
+    const stdout: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk))
+      return true
+    })
+
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'write-stub' } } })
+    const frCandidate: DraftCandidate = {
+      kind: 'fr',
+      confidence: 'medium',
+      fr: { parentEpicId: 'EPIC-MISSING', fr: { id: 'FR-1', title: 'Orphan' } },
+      source: { kind: 'notion-pages' }
+    }
+    const specPath = writeSpec([frCandidate])
+
+    const code = await runWriteSrs({ specPath, manifestPath })
+
+    expect(code).toBe(6)
+    const body = JSON.parse(stdout.join(''))
+    expect(body.failed[0].error).toMatch(/parentEpicId="EPIC-MISSING"/)
+  })
+
+  it('still accepts explicit parentEpicPageId as an escape hatch', async () => {
+    const adapter = new StubAdapter()
+    registerSrsBackend('write-stub', () => adapter)
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'write-stub' } } })
+    const frCandidate: DraftCandidate = {
+      kind: 'fr',
+      confidence: 'medium',
+      fr: { parentEpicPageId: 'pre-existing-epic-xyz', fr: { id: 'FR-1', title: 'Attach to existing' } },
+      source: { kind: 'notion-pages' }
+    }
+    const specPath = writeSpec([frCandidate])
+
+    const code = await runWriteSrs({ specPath, manifestPath })
+
+    expect(code).toBe(0)
+    expect(adapter.createdFrs[0].parentEpicPageId).toBe('pre-existing-epic-xyz')
+  })
+
+  it('rejects an FR candidate with neither parentEpicPageId nor parentEpicId (exit 2)', async () => {
+    registerSrsBackend('write-stub', () => new StubAdapter())
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const manifestPath = writeManifest({ tools: { srs: { backend: 'write-stub' } } })
+    const frCandidate: DraftCandidate = {
+      kind: 'fr',
+      confidence: 'medium',
+      fr: { fr: { id: 'FR-1', title: 'Floating' } } as FrSpec,
+      source: { kind: 'notion-pages' }
+    }
+    const specPath = writeSpec([frCandidate])
+
+    const code = await runWriteSrs({ specPath, manifestPath })
+
+    expect(code).toBe(2)
+  })
 })

--- a/src/builders/srs/types.ts
+++ b/src/builders/srs/types.ts
@@ -58,6 +58,7 @@ export interface NfrItem {
 export interface EpicSpec {
   title: string
   parentPageId: string
+  id?: string
   businessValue?: string
   scope?: string
   urs: UrItem[]
@@ -68,7 +69,8 @@ export interface EpicSpec {
 }
 
 export interface FrSpec {
-  parentEpicPageId: string
+  parentEpicPageId?: string
+  parentEpicId?: string
   fr: FrItem
   urs?: UrItem[]
   dsItems?: DsItem[]

--- a/src/srs/bin/write-srs.ts
+++ b/src/srs/bin/write-srs.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { DraftCandidate, PageRef, SrsAdapter } from '../../builders/srs/types'
+import { DraftCandidate, FrSpec, PageRef, SrsAdapter } from '../../builders/srs/types'
 import { createSrsAdapter, SrsConfigError, SrsManifestSubset } from '../index'
 
 export interface WriteSrsOptions {
@@ -54,14 +54,37 @@ function assertCandidateShape(candidate: DraftCandidate, index: number): void {
   }
   if (candidate.kind === 'fr') {
     if (!candidate.fr) throw new Error(`write-srs: candidate #${index} has kind="fr" but the "fr" spec is missing.`)
+    if (!candidate.fr.parentEpicPageId && !candidate.fr.parentEpicId) {
+      throw new Error(`write-srs: candidate #${index} (fr) must set either "parentEpicPageId" (explicit Notion page ID) or "parentEpicId" (logical ID of an Epic in the same batch).`)
+    }
     return
   }
   throw new Error(`write-srs: candidate #${index} has an unknown kind="${String((candidate as { kind?: unknown }).kind)}" (expected "epic" or "fr").`)
 }
 
-async function applyCandidate(adapter: SrsAdapter, candidate: DraftCandidate): Promise<PageRef> {
-  if (candidate.kind === 'epic') return adapter.createEpicPage(candidate.epic!)
-  return adapter.createFrPage(candidate.fr!)
+function resolveFrParent(fr: FrSpec, logicalIdMap: Map<string, string>, index: number): FrSpec {
+  if (fr.parentEpicPageId && fr.parentEpicPageId.length > 0) return fr
+  const logicalId = fr.parentEpicId
+  if (!logicalId) {
+    throw new Error(`write-srs: candidate #${index} (fr) has no parent epic reference.`)
+  }
+  const resolved = logicalIdMap.get(logicalId)
+  if (!resolved) {
+    const known = Array.from(logicalIdMap.keys())
+    const hint = known.length > 0 ? `Known logical IDs in this batch: ${known.join(', ')}.` : 'No Epic in this batch declared a logical "id" — did you set "epic.id" on the parent Epic candidate?'
+    throw new Error(`write-srs: candidate #${index} (fr) references parentEpicId="${logicalId}" but no Epic with that logical id was created before it. ${hint}`)
+  }
+  return { ...fr, parentEpicPageId: resolved }
+}
+
+async function applyCandidate(adapter: SrsAdapter, candidate: DraftCandidate, logicalIdMap: Map<string, string>, index: number): Promise<PageRef> {
+  if (candidate.kind === 'epic') {
+    const page = await adapter.createEpicPage(candidate.epic!)
+    if (candidate.epic!.id) logicalIdMap.set(candidate.epic!.id, page.id)
+    return page
+  }
+  const fr = resolveFrParent(candidate.fr!, logicalIdMap, index)
+  return adapter.createFrPage(fr)
 }
 
 function clearPendingIngestion(manifestPath: string): boolean {
@@ -119,11 +142,12 @@ export async function runWriteSrs(options: WriteSrsOptions): Promise<number> {
   }
 
   const report: WriteSrsReport = { created: [], failed: [], pendingIngestionCleared: false }
+  const logicalIdMap = new Map<string, string>()
 
   for (let i = 0; i < candidates.length; i++) {
     const candidate = candidates[i]
     try {
-      const page = await applyCandidate(adapter, candidate)
+      const page = await applyCandidate(adapter, candidate, logicalIdMap, i)
       report.created.push({ index: i, kind: candidate.kind, page })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)

--- a/src/tools/notion/srs.adapter.ts
+++ b/src/tools/notion/srs.adapter.ts
@@ -80,7 +80,9 @@ export class NotionSrsAdapter implements SrsAdapter {
 
   async createFrPage(spec: FrSpec): Promise<PageRef> {
     if (!spec.parentEpicPageId) {
-      throw new Error(`NotionSrsAdapter.createFrPage: FR "${spec.fr.id}" has no parentEpicPageId resolved. write-srs must resolve FrSpec.parentEpicId to a concrete page id before calling the adapter.`)
+      throw new Error(
+        `NotionSrsAdapter.createFrPage: FR "${spec.fr.id}" has no parentEpicPageId resolved. write-srs must resolve FrSpec.parentEpicId to a concrete page id before calling the adapter.`
+      )
     }
     const pageContent = renderFrPage(spec)
     const title = pageContent.title ?? `${spec.fr.id} — ${spec.fr.title}`

--- a/src/tools/notion/srs.adapter.ts
+++ b/src/tools/notion/srs.adapter.ts
@@ -79,6 +79,9 @@ export class NotionSrsAdapter implements SrsAdapter {
   }
 
   async createFrPage(spec: FrSpec): Promise<PageRef> {
+    if (!spec.parentEpicPageId) {
+      throw new Error(`NotionSrsAdapter.createFrPage: FR "${spec.fr.id}" has no parentEpicPageId resolved. write-srs must resolve FrSpec.parentEpicId to a concrete page id before calling the adapter.`)
+    }
     const pageContent = renderFrPage(spec)
     const title = pageContent.title ?? `${spec.fr.id} — ${spec.fr.title}`
     const children = renderPageContentToNotionBlocks({ blocks: pageContent.blocks })


### PR DESCRIPTION
## Summary

- Extends `EpicSpec` with optional `id?: string` and `FrSpec` with optional `parentEpicId?: string`, letting a draft spec declare Epic→FR links by logical ID so both can be written in a single batch.
- `write-srs` now builds an in-memory logical-ID map as Epics are created and resolves each FR's `parentEpicId` to the real Notion page id before calling the adapter. Explicit `parentEpicPageId` remains an escape hatch for FRs targeting pre-existing Epics.
- `NotionSrsAdapter.createFrPage` grows a defense-in-depth guard that throws if `parentEpicPageId` is missing, and the SKILL.md (both in-repo and scaffold mirror) document the single-pass flow.

Closes #245.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test:unit` — 698/698 tests, including 4 new `write-srs` cases (logical ID resolution, unresolved id → exit 6, escape hatch, schema guard → exit 2)
- [x] Docker pre-push scenarios (monorepo-minimal, multirepo-minimal) — both pass
- [ ] Manual: draft a spec mixing Epic `id: "EPIC-FOO"` + FR `parentEpicId: "EPIC-FOO"` → confirm Epic creates first, FR parent resolves, both pages land under the target parent