### PR TITLE
feat(#243): SessionStart hook + Preconditions first directive in CLAUDE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sf status --claude-friendly --no-network"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,13 @@ CLI tool that scaffolds production-ready SaaS projects (NestJS + React + Postgre
 Before asking the user anything about scope, backend, or module choices, **read the manifest and check the configured tools**:
 
 1. Read `.saasfoundry.json` — this is the source of truth for workflow, SRS backend, and installed modules. Never re-ask what is already declared there.
-2. Run `sf status --claude-friendly --no-network` to get a summary of the manifest, installed modules, and preconditions. On a configured session this is also auto-injected via the `SessionStart` hook in `.claude/settings.json`.
-3. Only surface scope questions for things that are **not** resolvable from the manifest (e.g. genuine product decisions). If a precondition is `fail`, route the user to the relevant install/config CLI (`sf workflow`, `sf skill install`, etc.) instead of asking scope questions.
+2. Run `sf status --claude-friendly --no-network` to get a summary of the manifest, installed modules, and preconditions. On a configured session this is also auto-injected via the `SessionStart` hook
+   in `.claude/settings.json`.
+3. Only surface scope questions for things that are **not** resolvable from the manifest (e.g. genuine product decisions). If a precondition is `fail`, route the user to the relevant install/config
+   CLI (`sf workflow`, `sf skill install`, etc.) instead of asking scope questions.
 
-This rule exists because AI sessions historically asked users to re-pick the SRS backend (notion/atlassian/local-markdown) and parent page even though both were already in the manifest — those answers must come from `.saasfoundry.json`, not from a fresh dialogue.
+This rule exists because AI sessions historically asked users to re-pick the SRS backend (notion/atlassian/local-markdown) and parent page even though both were already in the manifest — those answers
+must come from `.saasfoundry.json`, not from a fresh dialogue.
 
 ## 🚨 Critical Rules (non-negotiable)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 CLI tool that scaffolds production-ready SaaS projects (NestJS + React + PostgreSQL + Docker).
 
+## 🧭 Preconditions first (read before asking questions)
+
+Before asking the user anything about scope, backend, or module choices, **read the manifest and check the configured tools**:
+
+1. Read `.saasfoundry.json` — this is the source of truth for workflow, SRS backend, and installed modules. Never re-ask what is already declared there.
+2. Run `sf status --claude-friendly --no-network` to get a summary of the manifest, installed modules, and preconditions. On a configured session this is also auto-injected via the `SessionStart` hook in `.claude/settings.json`.
+3. Only surface scope questions for things that are **not** resolvable from the manifest (e.g. genuine product decisions). If a precondition is `fail`, route the user to the relevant install/config CLI (`sf workflow`, `sf skill install`, etc.) instead of asking scope questions.
+
+This rule exists because AI sessions historically asked users to re-pick the SRS backend (notion/atlassian/local-markdown) and parent page even though both were already in the manifest — those answers must come from `.saasfoundry.json`, not from a fresh dialogue.
+
 ## 🚨 Critical Rules (non-negotiable)
 
 **We are dogfooding our own system.** Users of SaaSFoundry will rely on their AI agents to follow the workflows we generate. If we don't follow ours rigorously, we can't guarantee the system works.

--- a/scaffolds/blueprints/api/.claude/settings.json
+++ b/scaffolds/blueprints/api/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sf status --claude-friendly --no-network"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scaffolds/blueprints/api/CLAUDE.md
+++ b/scaffolds/blueprints/api/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Production-ready NestJS API generated with **SaaSFoundry** - An AI-First development platform.
 
+## 🧭 Preconditions first (read before asking questions)
+
+Before asking the user anything about scope, backend, or module choices, **read the manifest and check the configured tools**:
+
+1. Read `.saasfoundry.json` — the source of truth for workflow, SRS backend, and installed modules. Never re-ask what is already declared there.
+2. Run `sf status --claude-friendly --no-network` to get a summary of the manifest, installed modules, and preconditions. A `SessionStart` hook in `.claude/settings.json` also auto-injects this summary at session start.
+3. Only ask about things that are **not** resolvable from the manifest. If a precondition is `fail`, route the user to the relevant install/config CLI (`sf workflow`, `sf skill install`, etc.) instead of opening a scope dialogue.
+
 ## Tech Stack
 
 - **Backend**: NestJS 11, Prisma 7 (driver adapters + PrismaPg), PostgreSQL 16

--- a/scaffolds/blueprints/web/.claude/settings.json
+++ b/scaffolds/blueprints/web/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sf status --claude-friendly --no-network"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scaffolds/blueprints/web/CLAUDE.md
+++ b/scaffolds/blueprints/web/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Production-ready React application generated with **SaaSFoundry** - An AI-First development platform.
 
+## 🧭 Preconditions first (read before asking questions)
+
+Before asking the user anything about scope, backend, or module choices, **read the manifest and check the configured tools**:
+
+1. Read `.saasfoundry.json` — the source of truth for workflow, SRS backend, and installed modules. Never re-ask what is already declared there.
+2. Run `sf status --claude-friendly --no-network` to get a summary of the manifest, installed modules, and preconditions. A `SessionStart` hook in `.claude/settings.json` also auto-injects this summary at session start.
+3. Only ask about things that are **not** resolvable from the manifest. If a precondition is `fail`, route the user to the relevant install/config CLI (`sf workflow`, `sf skill install`, etc.) instead of opening a scope dialogue.
+
 ## Tech Stack
 
 - **Frontend**: React 19, React Router v7, Vite 7

--- a/scaffolds/overlays/monorepo/root/.claude/settings.json
+++ b/scaffolds/overlays/monorepo/root/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sf status --claude-friendly --no-network"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scaffolds/overlays/monorepo/root/CLAUDE.md
+++ b/scaffolds/overlays/monorepo/root/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Production-ready SaaS monorepo generated with **SaaSFoundry** - An AI-First development platform.
 
+## 🧭 Preconditions first (read before asking questions)
+
+Before asking the user anything about scope, backend, or module choices, **read the manifest and check the configured tools**:
+
+1. Read `.saasfoundry.json` — the source of truth for workflow, SRS backend, and installed modules. Never re-ask what is already declared there.
+2. Run `sf status --claude-friendly --no-network` to get a summary of the manifest, installed modules, and preconditions. A `SessionStart` hook in `.claude/settings.json` also auto-injects this summary at session start.
+3. Only ask about things that are **not** resolvable from the manifest. If a precondition is `fail`, route the user to the relevant install/config CLI (`sf workflow`, `sf skill install`, etc.) instead of opening a scope dialogue.
+
 ## 🏗️ Monorepo Structure
 
 This is a **Turborepo monorepo** with centralized tooling and shared skills.

--- a/src/__tests__/unit/skill/preconditions-scaffold.spec.ts
+++ b/src/__tests__/unit/skill/preconditions-scaffold.spec.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+
+// Regression guard for #243: every CLAUDE.md shipped by a SaaSFoundry scaffold
+// must carry the "Preconditions first" directive, and every scaffolded
+// `.claude/` must ship a `settings.json` wiring a SessionStart hook that calls
+// `sf status --claude-friendly`. If a new blueprint or overlay forgets either,
+// generated projects will regress to re-asking scope questions already answered
+// by the manifest.
+const ROOT = path.resolve(__dirname, '../../../..')
+
+const CLAUDE_MD_SCAFFOLDS = [
+  path.resolve(ROOT, 'scaffolds/blueprints/api/CLAUDE.md'),
+  path.resolve(ROOT, 'scaffolds/blueprints/web/CLAUDE.md'),
+  path.resolve(ROOT, 'scaffolds/overlays/monorepo/root/CLAUDE.md')
+]
+
+const SETTINGS_SCAFFOLDS = [
+  path.resolve(ROOT, 'scaffolds/blueprints/api/.claude/settings.json'),
+  path.resolve(ROOT, 'scaffolds/blueprints/web/.claude/settings.json'),
+  path.resolve(ROOT, 'scaffolds/overlays/monorepo/root/.claude/settings.json')
+]
+
+describe('Preconditions first directive (scaffold mirrors)', () => {
+  it.each(CLAUDE_MD_SCAFFOLDS)('%s contains the Preconditions first section', (file) => {
+    const content = readFileSync(file, 'utf8')
+    expect(content).toMatch(/Preconditions first/)
+    expect(content).toMatch(/\.saasfoundry\.json/)
+    expect(content).toMatch(/sf status --claude-friendly/)
+  })
+
+  it('repo-root CLAUDE.md contains the Preconditions first section', () => {
+    const content = readFileSync(path.resolve(ROOT, 'CLAUDE.md'), 'utf8')
+    expect(content).toMatch(/Preconditions first/)
+    expect(content).toMatch(/\.saasfoundry\.json/)
+    expect(content).toMatch(/sf status --claude-friendly/)
+  })
+})
+
+describe('SessionStart hook (scaffold mirrors)', () => {
+  it.each(SETTINGS_SCAFFOLDS)('%s wires a SessionStart hook calling sf status', (file) => {
+    const parsed = JSON.parse(readFileSync(file, 'utf8'))
+    const sessionStart = parsed?.hooks?.SessionStart
+    expect(Array.isArray(sessionStart)).toBe(true)
+    expect(sessionStart.length).toBeGreaterThan(0)
+    const commands: string[] = sessionStart.flatMap((entry: { hooks?: Array<{ type?: string; command?: string }> }) =>
+      (entry.hooks ?? []).filter((h) => h.type === 'command').map((h) => h.command ?? '')
+    )
+    expect(commands.some((cmd: string) => cmd.includes('sf status') && cmd.includes('--claude-friendly'))).toBe(true)
+  })
+
+  it('repo-root .claude/settings.json wires a SessionStart hook calling sf status', () => {
+    const parsed = JSON.parse(readFileSync(path.resolve(ROOT, '.claude/settings.json'), 'utf8'))
+    const sessionStart = parsed?.hooks?.SessionStart
+    expect(Array.isArray(sessionStart)).toBe(true)
+    const commands: string[] = sessionStart.flatMap((entry: { hooks?: Array<{ type?: string; command?: string }> }) =>
+      (entry.hooks ?? []).filter((h) => h.type === 'command').map((h) => h.command ?? '')
+    )
+    expect(commands.some((cmd: string) => cmd.includes('sf status') && cmd.includes('--claude-friendly'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #243 (SUB of #235).

- Adds `.claude/settings.json` with a `SessionStart` hook that runs `sf status --claude-friendly --no-network`, auto-injecting the manifest/precondition summary into every Claude Code session.
- Adds a **🧭 Preconditions first** section near the top of `CLAUDE.md` telling agents to read `.saasfoundry.json` and run `sf status` before asking scope questions.
- Mirrors both changes to scaffolded projects: `scaffolds/blueprints/api/`, `scaffolds/blueprints/web/`, `scaffolds/overlays/monorepo/root/`, so every generated project inherits the behavior.
- Adds `src/__tests__/unit/skill/preconditions-scaffold.spec.ts` as a regression guard (8 parametrised assertions covering all CLAUDE.md + settings.json scaffold mirrors + the repo-root pair).

## Why

From the #203 capstone / `.srs-audit/follow-ups.md` §8: a prior Claude session asked the user to re-pick the SRS backend (notion / atlassian / local-markdown) and parent page even though both answers were already declared in `.saasfoundry.json`. This wires the manifest into session bootstrap so agents can't miss it.

## Test plan

- [x] `npm run build` ✅
- [x] `npm run lint` ✅
- [x] `npm run test:unit` — 65 suites / 723 tests, all green
- [x] New `preconditions-scaffold.spec.ts` — 8/8 pass
- [x] Pre-push Docker scenarios (`multirepo-minimal`, `monorepo-minimal`) — both PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)