### PR TITLE
feat(#247): DS / TC / NFR seeding guidance (DIAMONFORGE completeness)

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -363,11 +363,12 @@ The skill's job is to convert raw findings into publishable draft candidates. Wo
    - One FR per `endpoint` (or per tight endpoint cluster — e.g. CRUD on the same resource collapses into one FR).
    - Reuse `ui-flow` routes as acceptance criteria on the user-facing FR.
    - Populate `dsRefs` / `tcRefs` from the items seeded in step 4 so the FR page surfaces the traceability links.
-4. **Seed the Epic-level DS / TC / NFR sections.** The DIAMONFORGE shape expects five categories per Epic (UR + FR + DS + TC + NFR). The seeding rules below turn scanner findings into initial items
-   the reviewer accepts / edits / rejects. See the dedicated subsection below.
+4. **Seed the Epic-level DS / TC / NFR sections.** Every Epic carries the SRS five-category shape (UR + FR + DS + TC + NFR) — see the canonical example at `templates/examples/example-epic.md`
+   (rendered) / `templates/examples/example-epic.spec.json` (machine-readable) for the exact layout. The seeding rules below turn scanner findings into initial items the reviewer accepts / edits /
+   rejects.
 5. **Flag gaps.** Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a **TODO** TC item (title `"{METHOD} {PATH} — happy path"`, `expectedResult: "to write"`), not silently.
 
-### Seeding DS / TC / NFR (DIAMONFORGE completeness)
+### Seeding DS / TC / NFR (five-category completeness)
 
 These three sections are **interpretive** — scanners surface the raw material, the agent synthesises the items. Reuse the L1+L2+L3 pattern from the eval (`docs/srs/scanner-findings.md`): deterministic
 findings feed AI prompts, the agent always runs, the user always validates before write.
@@ -438,7 +439,7 @@ Always emit NFRs with `priority: 'P3'` and `target: '<proposed — needs human v
 Before firing the review prompt on an Epic cluster, emit a one-shot **coverage table** so the reviewer sees what got seeded per category and where it came from:
 
 ```
-DIAMONFORGE coverage for Epic: <title>
+SRS coverage for Epic: <title>
 ┌──────┬───────────────┬──────────────────────────────────────────────┐
 │ Cat  │ Items proposed│ Source                                       │
 ├──────┼───────────────┼──────────────────────────────────────────────┤
@@ -573,8 +574,8 @@ Running the full `sf srs` chain end-to-end on SaaSFoundry itself surfaced 12 gap
   `.env` with `set -a && source .env && set +a` until the fix lands.
 - **`write-srs` supports single-pass Epic + FR writes via logical IDs (#245).** Mix Epics (with `epic.id`) and FRs (with `parentEpicId`) in one spec — `write-srs` resolves the references as it goes.
   `parentEpicPageId` remains as an escape hatch for incremental writes against pre-existing Epics.
-- **SRS completeness is UR+FR only (#247).** DS / TC / NFR are not generated yet. The DIAMONFORGE reference shape expects all five. AI-assisted generation planned under #247, reusing the L1+L2+L3
-  matcher architecture.
+- **SRS completeness is UR+FR only (pre-#247).** Historically DS / TC / NFR were not generated. The five-category shape (UR+FR+DS+TC+NFR) is now seeded by #247, reusing the L1+L2+L3 matcher
+  architecture — see the "Seeding DS / TC / NFR" section above for the full mapping.
 - **Preconditions first.** Before asking the user scope questions (backend choice, Notion parent page, etc.), read `.saasfoundry.json` — the answers are almost always already there. Re-running
   `sf update --add-modules srs` on an already-installed module silently re-bootstraps and duplicates Notion pages (#240).
 

--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -361,10 +361,97 @@ The skill's job is to convert raw findings into publishable draft candidates. Wo
 2. **Pick the Epic level.** One Epic per coherent area (e.g. `auth`, `storage`, `accounts`). Title + narrative come from the richest `doc-context` in the group, or from the user's wording.
 3. **Propose the FRs.**
    - One FR per `endpoint` (or per tight endpoint cluster — e.g. CRUD on the same resource collapses into one FR).
-   - Add DS items for noteworthy `entity` fields (PK, unique constraints, relations).
-   - Seed TC items from `test.cases[]` of the matching area.
    - Reuse `ui-flow` routes as acceptance criteria on the user-facing FR.
-4. **Flag gaps.** Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a TODO in the drafted FR, not silently.
+   - Populate `dsRefs` / `tcRefs` from the items seeded in step 4 so the FR page surfaces the traceability links.
+4. **Seed the Epic-level DS / TC / NFR sections.** The DIAMONFORGE shape expects five categories per Epic (UR + FR + DS + TC + NFR). The seeding rules below turn scanner findings into initial items
+   the reviewer accepts / edits / rejects. See the dedicated subsection below.
+5. **Flag gaps.** Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a **TODO** TC item (title `"{METHOD} {PATH} — happy path"`, `expectedResult: "to write"`), not silently.
+
+### Seeding DS / TC / NFR (DIAMONFORGE completeness)
+
+These three sections are **interpretive** — scanners surface the raw material, the agent synthesises the items. Reuse the L1+L2+L3 pattern from the eval (`docs/srs/scanner-findings.md`): deterministic
+findings feed AI prompts, the agent always runs, the user always validates before write.
+
+#### DS items (Design Specifications)
+
+One `DsItem` per material design decision visible in code. Source findings → seeded `DsItem`:
+
+| Finding                                                      | Seeded `DsItem.title`            | Seeded `description` source                                                |
+| ------------------------------------------------------------ | -------------------------------- | -------------------------------------------------------------------------- |
+| `entity` (Prisma model)                                      | `Data model — <EntityName>`      | fields + `@unique` / `@id` / `@relation` + `deletedAt` flag                |
+| `endpoint` with non-trivial DTO (POST/PATCH body ≥ 2 fields) | `API contract — <METHOD> <path>` | DTO field list + validation rules surfaced by `class-validator` decorators |
+| `ui-flow` with `formFields.length ≥ 2`                       | `UI form — <PageName>`           | form field list + `linkedEndpointGuess` if present                         |
+
+Group by the Epic's area; set `frRefs` to every FR in the group whose endpoint/entity/UI flow matches. Deduplicate by title prefix — if two entities share the same core name (e.g. `User` +
+`UserProfile`), collapse them into a single DS item with both sub-models listed in the description.
+
+#### TC items (Test Cases)
+
+One `TcItem` per `test.cases[]` entry. Source mapping:
+
+| Source                                   | Seeded `TcItem` field                                                                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `test.cases[i].title`                    | `title` (the `it(...)` / `test(...)` string verbatim)                                                |
+| `test.cases[i]` structure                | `steps` — parse Given/When/Then from the title if phrased that way, else bullet the `describe` chain |
+| assertion in the test body (if readable) | `expectedResult`; if not parseable, use `"see <test.file>"`                                          |
+| `test.area` or `endpoint.area`           | `frRefs` — every FR whose area matches                                                               |
+
+**Untested endpoints** — for each `endpoint` with `hasTests=false`, emit a **TODO** TC item so the drift is auditable, not invisible:
+
+```jsonc
+{
+  "id": "TC-<area>-<slug>-todo",
+  "title": "<METHOD> <path> — happy path",
+  "expectedResult": "to write",
+  "frRefs": ["<FR-id>"]
+}
+```
+
+The reviewer can either accept the TODO (making the gap part of the public contract) or reject it and flag it upstream.
+
+#### NFR items (Non-Functional Requirements)
+
+NFRs are **proposed, not derived** — every seeded item must be marked for explicit human validation. Build the candidate list from two layers:
+
+**Layer 1 — stack signals** (present in `.saasfoundry.json` or inferred from findings):
+
+| Signal                                                                                       | Seeded NFR(s)                                                                                                                                             |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth` module present (endpoints under `/auth/*` or Prisma `Session` / `RefreshToken` model) | `Security — JWT access token expiry ≤ 15 min`; `Security — refresh token rotation on every use`; `Security — login rate limit ≤ 5 attempts / minute / IP` |
+| `i18n` module (`src/locales/` folder or `i18next` dep)                                       | `i18n — all user-facing strings translated in FR + EN`; `a11y — locale switchable without page reload`                                                    |
+| Prisma + Postgres detected                                                                   | `Data — soft delete via deletedAt on user-owned entities`; `Data — all migrations reversible (up + down)`                                                 |
+| `docker-compose*.yml` + `/health` endpoint present                                           | `Ops — API health check p95 ≤ 1 s`                                                                                                                        |
+| Playwright or e2e spec files present                                                         | `Quality — e2e coverage on critical user flows (login, signup, checkout when applicable)`                                                                 |
+| `@nestjs/swagger` + `docs/openapi.json` generated                                            | `Docs — OpenAPI spec regenerated on every API change (CI guard)`                                                                                          |
+
+**Layer 2 — standard SaaS catalogue** (always propose, mark low-confidence):
+
+- `Perf — p95 API latency ≤ 500 ms at 100 req/s sustained`
+- `Availability — uptime target 99.5% (excluding scheduled maintenance)`
+- `Security — all user-uploaded files virus-scanned before persistence` (only if storage module present)
+- `Privacy — PII fields encrypted at rest` (only if the schema carries `email`, `phone`, `address`)
+
+Always emit NFRs with `priority: 'P3'` and `target: '<proposed — needs human validation>'`. The reviewer lifts priority / refines target before accepting.
+
+#### Coverage table (pre-accept)
+
+Before firing the review prompt on an Epic cluster, emit a one-shot **coverage table** so the reviewer sees what got seeded per category and where it came from:
+
+```
+DIAMONFORGE coverage for Epic: <title>
+┌──────┬───────────────┬──────────────────────────────────────────────┐
+│ Cat  │ Items proposed│ Source                                       │
+├──────┼───────────────┼──────────────────────────────────────────────┤
+│ UR   │ 3             │ doc-context + inferred from FRs              │
+│ FR   │ 5             │ 5 endpoint clusters                          │
+│ DS   │ 4             │ 2 entities + 1 endpoint + 1 UI form          │
+│ TC   │ 8 (+ 2 TODO)  │ test.cases[] across 3 spec files             │
+│ NFR  │ 4 (proposed)  │ auth + i18n + prisma + playwright signals    │
+└──────┴───────────────┴──────────────────────────────────────────────┘
+```
+
+A cluster with **zero DS or zero TC** is a red flag — either the area is genuinely pure UI glue (no data model, no tests yet) or the scanners missed something. Surface the anomaly in the review prompt
+rather than silently proposing an Epic with empty sections.
 
 ### Review-loop prompts
 

--- a/.claude/skills/sf-srs/templates/examples/example-epic.md
+++ b/.claude/skills/sf-srs/templates/examples/example-epic.md
@@ -1,0 +1,88 @@
+# Authentication & session management
+
+> **Business value.** Users can create an account, sign in securely, and stay signed in across short interruptions without re-entering credentials.
+>
+> **Scope.** Covers signup with account validation, email+password signin, and signout. Session refresh is handled internally via `UserToken{type=SESSION_REFRESH}`. Does NOT cover SSO, password reset,
+> or MFA (tracked as separate Epics).
+
+> [!NOTE] This file is the canonical reference example shipped with the `sf-srs` skill. It shows what a complete Epic page looks like for the built-in SaaSFoundry auth module (`User` + polymorphic
+> `UserToken`, endpoints `/auth/signup` `/auth/signin` `/auth/signout`). Every DS / TC / NFR seeding pattern documented in `SKILL.md` is demonstrated here. The machine-readable source lives alongside
+> as `example-epic.spec.json`.
+
+## Traceability
+
+```
+UR (User Requirement)
+  └── FR (Functional Requirement)
+        ├── DS (Design Specification)
+        ├── TC (Test Case)
+        └── NFR (Non-Functional Requirement)
+```
+
+Each lower-level requirement traces back to a higher-level requirement, ensuring complete coverage and compliance traceability.
+
+## Requirement Types
+
+| Prefix | Type                       | Description                                                           | Example                                                                                 |
+| ------ | -------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| UR     | User Requirement           | High-level user need describing what the user wants to achieve.       | "The user must be able to log in to access the product"                                 |
+| FR     | Functional Requirement     | What the system must do to fulfill user requirements.                 | "The system displays a generic error message on login failure"                          |
+| DS     | Design Specification       | How the system implements the functional requirements.                | "JWT tokens stored in httpOnly cookies"                                                 |
+| TC     | Test Case                  | Verifiable steps that prove a functional requirement is satisfied.    | "Given valid credentials, when user submits login form, then 200 OK and JWT cookie set" |
+| NFR    | Non-Functional Requirement | Quality attributes: performance, security, availability, scalability. | "Login response time ≤ 1 second (p95)"                                                  |
+
+## User Requirements (UR)
+
+| ID          | Requirement                                                                                      | Priority | Related FR  |
+| ----------- | ------------------------------------------------------------------------------------------------ | -------- | ----------- |
+| UR-AUTH-001 | As a new user, I can create an account with an email and a password so I can access the product. | P1       | FR-AUTH-002 |
+| UR-AUTH-002 | As a returning user, I can sign in with my email and password to resume using the product.       | P1       | FR-AUTH-001 |
+| UR-AUTH-003 | As a signed-in user, I can sign out on demand so my session on a shared device is terminated.    | P2       | FR-AUTH-003 |
+
+## Functional Requirements (FR)
+
+| ID          | Requirement                    | Priority | Related UR  | Related DS                                         |
+| ----------- | ------------------------------ | -------- | ----------- | -------------------------------------------------- |
+| FR-AUTH-001 | Email + password signin        | P1       | UR-AUTH-002 | DS-AUTH-001, DS-AUTH-002, DS-AUTH-004, DS-AUTH-006 |
+| FR-AUTH-002 | Signup with account validation | P1       | UR-AUTH-001 | DS-AUTH-001, DS-AUTH-002, DS-AUTH-005              |
+| FR-AUTH-003 | Signout                        | P2       | UR-AUTH-003 | DS-AUTH-002, DS-AUTH-004                           |
+
+## Design Specifications (DS)
+
+| ID               | Specification                    | Related FR                            |
+| ---------------- | -------------------------------- | ------------------------------------- |
+| **Data model**   |                                  |                                       |
+| DS-AUTH-001      | Data model — User                | FR-AUTH-001, FR-AUTH-002              |
+| DS-AUTH-002      | Data model — UserToken           | FR-AUTH-001, FR-AUTH-002, FR-AUTH-003 |
+| **API contract** |                                  |                                       |
+| DS-AUTH-004      | API contract — POST /auth/signin | FR-AUTH-001, FR-AUTH-003              |
+| DS-AUTH-005      | API contract — POST /auth/signup | FR-AUTH-002                           |
+| **UI form**      |                                  |                                       |
+| DS-AUTH-006      | UI form — SignInPage             | FR-AUTH-001                           |
+
+## Test Cases (TC)
+
+| ID          | Title                                                                         | Expected Result                                                                          | Related FR  |
+| ----------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------- |
+| TC-AUTH-001 | should sign in user successfully                                              | 200 with access + refresh tokens and User.lastLoginAt updated                            | FR-AUTH-001 |
+| TC-AUTH-002 | should throw UnauthorizedException if credentials are invalid                 | 401 with generic message (same shape for unknown email and wrong password)               | FR-AUTH-001 |
+| TC-AUTH-003 | should create a new user successfully                                         | User row with isActive=false + UserToken{type=ACCOUNT_VALIDATION}                        | FR-AUTH-002 |
+| TC-AUTH-004 | should handle existing user gracefully                                        | Duplicate-email signup returns a generic response (no user-enumeration leak)             | FR-AUTH-002 |
+| TC-AUTH-005 | should create account when signing in with confirmation token                 | Consuming the token flips User.isActive=true and allows subsequent signin                | FR-AUTH-002 |
+| TC-AUTH-006 | should sign out user successfully                                             | SESSION_REFRESH UserToken for the caller is revoked                                      | FR-AUTH-003 |
+| TC-AUTH-007 | **TODO** — POST /auth/signup triggers email dispatch with the validation link | to write — seeded because the email dispatch path is not covered by auth.service.spec.ts | FR-AUTH-002 |
+
+## Non-Functional Requirements (NFR)
+
+| ID                 | Requirement                              | Target                                                                                                            | Priority | Related FR               |
+| ------------------ | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------- | ------------------------ |
+| **Security**       |                                          |                                                                                                                   |          |                          |
+| NFR-AUTH-001       | JWT access token expiry ≤ 15 minutes     | accessToken.exp − iat ≤ 900s                                                                                      | P1       | FR-AUTH-001              |
+| NFR-AUTH-002       | Refresh token rotation on every use      | SESSION_REFRESH UserToken rotated on each refresh; old token invalidated before the new one is issued             | P1       | FR-AUTH-001, FR-AUTH-003 |
+| NFR-AUTH-003       | Auth endpoints rate-limited per IP       | ≤ 5 failed signin attempts per IP per 60s — proposed, needs human validation                                      | P3       | FR-AUTH-001              |
+| **i18n**           |                                          |                                                                                                                   |          |                          |
+| NFR-AUTH-004       | Auth error messages translated (FR + EN) | All user-facing strings resolve through i18next in FR and EN — proposed, needs human validation                   | P3       | FR-AUTH-001, FR-AUTH-002 |
+| **Data lifecycle** |                                          |                                                                                                                   |          |                          |
+| NFR-AUTH-005       | User deactivation flow via isActive flag | Admin can flip User.isActive=false to lock an account without deleting the row — proposed, needs human validation | P3       | FR-AUTH-001              |
+| **Performance**    |                                          |                                                                                                                   |          |                          |
+| NFR-AUTH-006       | Signin p95 latency ≤ 1 second            | POST /auth/signin p95 ≤ 1s under expected concurrency — proposed, needs human validation                          | P3       | FR-AUTH-001              |

--- a/.claude/skills/sf-srs/templates/examples/example-epic.spec.json
+++ b/.claude/skills/sf-srs/templates/examples/example-epic.spec.json
@@ -1,0 +1,183 @@
+{
+  "title": "Authentication & session management",
+  "parentPageId": "<replaced-at-write-time>",
+  "id": "EPIC-AUTH",
+  "businessValue": "Users can create an account, sign in securely, and stay signed in across short interruptions without re-entering credentials.",
+  "scope": "Covers signup with account validation, email+password signin, and signout. Session refresh is handled internally via UserToken{type=SESSION_REFRESH}. Does NOT cover SSO, password reset, or MFA (tracked as separate Epics).",
+
+  "urs": [
+    { "id": "UR-AUTH-001", "narrative": "As a new user, I can create an account with an email and a password so I can access the product.", "priority": "P1" },
+    { "id": "UR-AUTH-002", "narrative": "As a returning user, I can sign in with my email and password to resume using the product.", "priority": "P1" },
+    { "id": "UR-AUTH-003", "narrative": "As a signed-in user, I can sign out on demand so my session on a shared device is terminated.", "priority": "P2" }
+  ],
+
+  "frs": [
+    {
+      "id": "FR-AUTH-001",
+      "title": "Email + password signin",
+      "description": "POST /auth/signin validates credentials against User.password (bcrypt) and issues a short-lived access JWT + a SESSION_REFRESH UserToken.",
+      "priority": "P1",
+      "urRefs": ["UR-AUTH-002"],
+      "dsRefs": ["DS-AUTH-001", "DS-AUTH-002", "DS-AUTH-004", "DS-AUTH-006"],
+      "tcRefs": ["TC-AUTH-001", "TC-AUTH-002"],
+      "endpoint": "POST /auth/signin",
+      "acceptanceCriteria": [
+        "Valid credentials return 200 with an access token and a refresh token (cookie or body depending on deployment).",
+        "Invalid credentials return 401 with a generic error message (no user-enumeration leak).",
+        "An inactive User (User.isActive=false) cannot sign in; the response invites the user to validate their account first."
+      ]
+    },
+    {
+      "id": "FR-AUTH-002",
+      "title": "Signup with account validation",
+      "description": "POST /auth/signup creates a User with isActive=false and a UserToken{type=ACCOUNT_VALIDATION}. Account becomes usable only after the validation token is consumed (typically via an email link).",
+      "priority": "P1",
+      "urRefs": ["UR-AUTH-001"],
+      "dsRefs": ["DS-AUTH-001", "DS-AUTH-002", "DS-AUTH-005"],
+      "tcRefs": ["TC-AUTH-003", "TC-AUTH-004", "TC-AUTH-005"],
+      "endpoint": "POST /auth/signup",
+      "acceptanceCriteria": [
+        "Unique email + valid password return 200 and queue an account-validation token + email.",
+        "Duplicate email is handled gracefully with a generic response (no user-enumeration leak).",
+        "Unvalidated accounts have User.isActive=false and cannot sign in until the token is consumed."
+      ]
+    },
+    {
+      "id": "FR-AUTH-003",
+      "title": "Signout",
+      "description": "POST /auth/signout revokes the caller's SESSION_REFRESH UserToken so the refresh chain for this session can no longer be used.",
+      "priority": "P2",
+      "urRefs": ["UR-AUTH-003"],
+      "dsRefs": ["DS-AUTH-002", "DS-AUTH-004"],
+      "tcRefs": ["TC-AUTH-006"],
+      "endpoint": "POST /auth/signout",
+      "acceptanceCriteria": [
+        "Authenticated caller receives 200 and their SESSION_REFRESH token is invalidated.",
+        "Subsequent refresh attempts with the revoked token return 401.",
+        "Unauthenticated callers receive 401 without leaking whether the token existed."
+      ]
+    }
+  ],
+
+  "dsItems": [
+    {
+      "id": "DS-AUTH-001",
+      "title": "Data model — User",
+      "description": "Prisma model User { id, email @unique, password, isActive @default(false), peopleId?, lastLoginAt? }. Passwords hashed with bcrypt. isActive gates signin until the ACCOUNT_VALIDATION token is consumed.",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-002"],
+      "group": "Data model"
+    },
+    {
+      "id": "DS-AUTH-002",
+      "title": "Data model — UserToken",
+      "description": "Prisma model UserToken { id, userId, token, type: TokenType, expiresAt? } with enum TokenType { ACCOUNT_VALIDATION, SESSION_REFRESH, PASSWORD_RESET, INVITATION }. @@unique([userId, type]) enforces one live token per (user, type).",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-002", "FR-AUTH-003"],
+      "group": "Data model"
+    },
+    {
+      "id": "DS-AUTH-004",
+      "title": "API contract — POST /auth/signin",
+      "description": "Body: SignInDto { email, password }. Response: SignInResponseDto { accessToken, refreshToken, user }. Emits SESSION_REFRESH UserToken.",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-003"],
+      "group": "API contract"
+    },
+    {
+      "id": "DS-AUTH-005",
+      "title": "API contract — POST /auth/signup",
+      "description": "Body: SignUpDto { email, password, locale? }. Response: SignUpResponseDto. Creates User.isActive=false + ACCOUNT_VALIDATION UserToken; when the email module is installed, a validation email is queued.",
+      "frRefs": ["FR-AUTH-002"],
+      "group": "API contract"
+    },
+    {
+      "id": "DS-AUTH-006",
+      "title": "UI form — SignInPage",
+      "description": "web/src/pages/public/SignInPage.tsx — fields: email, password. Zod schema: email format + password min length. Submits via the useSigninMutation React Query hook.",
+      "frRefs": ["FR-AUTH-001"],
+      "group": "UI form"
+    }
+  ],
+
+  "tcItems": [
+    {
+      "id": "TC-AUTH-001",
+      "title": "should sign in user successfully",
+      "frRefs": ["FR-AUTH-001"],
+      "expectedResult": "200 with access + refresh tokens and User.lastLoginAt updated — see auth.service.spec.ts"
+    },
+    {
+      "id": "TC-AUTH-002",
+      "title": "should throw UnauthorizedException if credentials are invalid",
+      "frRefs": ["FR-AUTH-001"],
+      "expectedResult": "401 Unauthorized with generic message (same shape for unknown email and wrong password)"
+    },
+    {
+      "id": "TC-AUTH-003",
+      "title": "should create a new user successfully",
+      "frRefs": ["FR-AUTH-002"],
+      "expectedResult": "User row with isActive=false + UserToken{type=ACCOUNT_VALIDATION} — see auth.service.spec.ts"
+    },
+    {
+      "id": "TC-AUTH-004",
+      "title": "should handle existing user gracefully",
+      "frRefs": ["FR-AUTH-002"],
+      "expectedResult": "Signup with a duplicate email returns a generic response (no user-enumeration leak)"
+    },
+    {
+      "id": "TC-AUTH-005",
+      "title": "should create account when signing in with confirmation token",
+      "frRefs": ["FR-AUTH-002"],
+      "expectedResult": "Consuming an ACCOUNT_VALIDATION token flips User.isActive=true and allows subsequent signin"
+    },
+    { "id": "TC-AUTH-006", "title": "should sign out user successfully", "frRefs": ["FR-AUTH-003"], "expectedResult": "SESSION_REFRESH UserToken for the caller is deleted / revoked" },
+    {
+      "id": "TC-AUTH-007",
+      "title": "TODO — POST /auth/signup triggers email dispatch with the validation link",
+      "frRefs": ["FR-AUTH-002"],
+      "expectedResult": "to write — seeded because the email dispatch path is not covered by auth.service.spec.ts today"
+    }
+  ],
+
+  "nfrItems": [
+    { "id": "NFR-AUTH-001", "title": "JWT access token expiry ≤ 15 minutes", "target": "accessToken.exp − iat ≤ 900s", "priority": "P1", "frRefs": ["FR-AUTH-001"], "group": "Security" },
+    {
+      "id": "NFR-AUTH-002",
+      "title": "Refresh token rotation on every use",
+      "target": "SESSION_REFRESH UserToken is rotated on each refresh; old token is invalidated before the new one is issued",
+      "priority": "P1",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-003"],
+      "group": "Security"
+    },
+    {
+      "id": "NFR-AUTH-003",
+      "title": "Auth endpoints rate-limited per IP",
+      "target": "≤ 5 failed signin attempts per IP per 60s — proposed, needs human validation",
+      "priority": "P3",
+      "frRefs": ["FR-AUTH-001"],
+      "group": "Security"
+    },
+    {
+      "id": "NFR-AUTH-004",
+      "title": "Auth error messages translated (FR + EN)",
+      "target": "All user-facing error strings resolve through i18next in FR and EN — proposed, needs human validation",
+      "priority": "P3",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-002"],
+      "group": "i18n"
+    },
+    {
+      "id": "NFR-AUTH-005",
+      "title": "User deactivation flow via isActive flag",
+      "target": "Admin can flip User.isActive=false to lock an account without deleting the row — proposed, needs human validation",
+      "priority": "P3",
+      "frRefs": ["FR-AUTH-001"],
+      "group": "Data lifecycle"
+    },
+    {
+      "id": "NFR-AUTH-006",
+      "title": "Signin p95 latency ≤ 1 second",
+      "target": "POST /auth/signin p95 ≤ 1s under expected concurrency — proposed, needs human validation",
+      "priority": "P3",
+      "frRefs": ["FR-AUTH-001"],
+      "group": "Performance"
+    }
+  ]
+}

--- a/.claude/skills/sf-srs/templates/pages/README.md
+++ b/.claude/skills/sf-srs/templates/pages/README.md
@@ -32,7 +32,7 @@ type PageBlock =
 
 ## Epic page sections
 
-Produced by `renderEpicPage(spec)` in this order (DIAMONFORGE-style):
+Produced by `renderEpicPage(spec)` in this order (five-category shape):
 
 1. `Traceability` (H2) + plain-text code block (ASCII tree `UR → FR → { DS, TC, NFR }`) + explanatory paragraph
 2. `Requirement Types` (H2) + definitions table `Prefix | Type | Description | Example` with one row per UR/FR/DS/TC/NFR
@@ -47,7 +47,7 @@ carrying the group id followed by empty cells matching the table arity.
 
 ## FR page sections
 
-Produced by `renderFrPage(spec)` in this order (DIAMONFORGE-style):
+Produced by `renderFrPage(spec)` in this order (five-category shape):
 
 1. `Summary` (H2) + table `ID | Requirement | Priority | Related UR | Related DS | Related TC` — one row per FR item on the page
 2. Divider

--- a/docs/srs/scanner-findings.md
+++ b/docs/srs/scanner-findings.md
@@ -197,9 +197,10 @@ Example :
 
 `excerpt` is capped to keep payloads small and to prime the skill with a summary, not the full document. Load the file directly when you need more than the excerpt.
 
-## DIAMONFORGE section seeding (#247)
+## Five-category section seeding (#247)
 
-Scanner findings are the raw material for the five DIAMONFORGE sections. The mapping below tells the skill which finding kind feeds which section when the drafter builds an Epic cluster:
+Scanner findings are the raw material for the five SRS categories (UR + FR + DS + TC + NFR). The mapping below tells the skill which finding kind feeds which section when the drafter builds an Epic
+cluster:
 
 | Section | Primary source                                                                                         | Seeding rule (summary)                                                                                                                                      |
 | ------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -209,8 +210,9 @@ Scanner findings are the raw material for the five DIAMONFORGE sections. The map
 | **TC**  | `test.cases[]`, plus **TODO** items for `endpoint.hasTests=false`                                      | One TC per `test.cases[i].title`; untested endpoints emit a TODO TC (`expectedResult: "to write"`) so the gap is auditable.                                 |
 | **NFR** | stack signals (auth / i18n / prisma / docker-compose / playwright / swagger) + standard SaaS catalogue | Always **proposed** with `priority: 'P3'` and `target: '<proposed — needs human validation>'`. Reviewer lifts priority and refines target before accepting. |
 
-The full seeding rules (including the catalogue of stack signals → NFRs and the pre-accept coverage table) live in `.claude/skills/sf-srs/SKILL.md` → "Seeding DS / TC / NFR (DIAMONFORGE
-completeness)". Keep the two documents consistent — the skill is the source of truth for the agent's behaviour, this file is the source of truth for the finding shapes it consumes.
+The full seeding rules (including the catalogue of stack signals → NFRs and the pre-accept coverage table) live in `.claude/skills/sf-srs/SKILL.md` → "Seeding DS / TC / NFR (five-category
+completeness)". Keep the two documents consistent — the skill is the source of truth for the agent's behaviour, this file is the source of truth for the finding shapes it consumes. The canonical
+example `example-epic.md` shipped with the skill demonstrates all five categories on the built-in auth module.
 
 ## Stability guarantees
 

--- a/docs/srs/scanner-findings.md
+++ b/docs/srs/scanner-findings.md
@@ -197,6 +197,21 @@ Example :
 
 `excerpt` is capped to keep payloads small and to prime the skill with a summary, not the full document. Load the file directly when you need more than the excerpt.
 
+## DIAMONFORGE section seeding (#247)
+
+Scanner findings are the raw material for the five DIAMONFORGE sections. The mapping below tells the skill which finding kind feeds which section when the drafter builds an Epic cluster:
+
+| Section | Primary source                                                                                         | Seeding rule (summary)                                                                                                                                      |
+| ------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **UR**  | `doc-context` excerpts + inferred from FR titles                                                       | One UR per coherent user goal in the area — narrative comes from the richest `doc-context`, else written by the agent from FR groupings.                    |
+| **FR**  | `endpoint`, `ui-flow`                                                                                  | One FR per endpoint (or tight endpoint cluster). `ui-flow` routes become acceptance criteria.                                                               |
+| **DS**  | `entity`, `endpoint` (non-trivial DTO), `ui-flow` (forms)                                              | `Data model — <Entity>`, `API contract — <METHOD> <path>`, `UI form — <Page>`. Deduplicate by title prefix.                                                 |
+| **TC**  | `test.cases[]`, plus **TODO** items for `endpoint.hasTests=false`                                      | One TC per `test.cases[i].title`; untested endpoints emit a TODO TC (`expectedResult: "to write"`) so the gap is auditable.                                 |
+| **NFR** | stack signals (auth / i18n / prisma / docker-compose / playwright / swagger) + standard SaaS catalogue | Always **proposed** with `priority: 'P3'` and `target: '<proposed — needs human validation>'`. Reviewer lifts priority and refines target before accepting. |
+
+The full seeding rules (including the catalogue of stack signals → NFRs and the pre-accept coverage table) live in `.claude/skills/sf-srs/SKILL.md` → "Seeding DS / TC / NFR (DIAMONFORGE
+completeness)". Keep the two documents consistent — the skill is the source of truth for the agent's behaviour, this file is the source of truth for the finding shapes it consumes.
+
 ## Stability guarantees
 
 The scanner pipeline respects `.gitignore` and hard-excludes `node_modules`, `dist`, `coverage`, `.git`, and `.vitepress/cache`. The order of findings is :

--- a/docs/srs/walkthrough.md
+++ b/docs/srs/walkthrough.md
@@ -261,9 +261,9 @@ Claude then drives a review loop **one domain at a time**. The scanner output gr
 Accept this Epic structure, or tighten the FR split first? [accept / edit / reject / skip-area]
 ```
 
-Before asking for accept/edit, Claude emits a **DIAMONFORGE coverage table** so the reviewer sees what got seeded per section and where it came from — UR/FR come from endpoints and docs, DS comes from
-entities and API contracts, TC comes from `test.cases[]` (plus TODO items for endpoints without tests), NFR is proposed from stack signals and always marked `proposed — needs human validation`. See
-[Scanner findings reference → DIAMONFORGE section seeding](/srs/scanner-findings#diamonforge-section-seeding-247) for the full mapping.
+Before asking for accept/edit, Claude emits a **five-category coverage table** so the reviewer sees what got seeded per section and where it came from — UR/FR come from endpoints and docs, DS comes
+from entities and API contracts, TC comes from `test.cases[]` (plus TODO items for endpoints without tests), NFR is proposed from stack signals and always marked `proposed — needs human validation`.
+See [Scanner findings reference → Five-category section seeding](/srs/scanner-findings#five-category-section-seeding-247) for the full mapping.
 
 On **accept**, Claude serialises the cluster as `DraftCandidate[]` and calls `srs-cli.sh write --spec <tmp.json>` exactly like the green-field flow in section 4. You can drive multiple Epics in a row,
 one prompt per cluster — the reviewer always gets a chance to course-correct before any Notion write happens.

--- a/docs/srs/walkthrough.md
+++ b/docs/srs/walkthrough.md
@@ -261,6 +261,10 @@ Claude then drives a review loop **one domain at a time**. The scanner output gr
 Accept this Epic structure, or tighten the FR split first? [accept / edit / reject / skip-area]
 ```
 
+Before asking for accept/edit, Claude emits a **DIAMONFORGE coverage table** so the reviewer sees what got seeded per section and where it came from — UR/FR come from endpoints and docs, DS comes from
+entities and API contracts, TC comes from `test.cases[]` (plus TODO items for endpoints without tests), NFR is proposed from stack signals and always marked `proposed — needs human validation`. See
+[Scanner findings reference → DIAMONFORGE section seeding](/srs/scanner-findings#diamonforge-section-seeding-247) for the full mapping.
+
 On **accept**, Claude serialises the cluster as `DraftCandidate[]` and calls `srs-cli.sh write --spec <tmp.json>` exactly like the green-field flow in section 4. You can drive multiple Epics in a row,
 one prompt per cluster — the reviewer always gets a chance to course-correct before any Notion write happens.
 

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -363,11 +363,12 @@ The skill's job is to convert raw findings into publishable draft candidates. Wo
    - One FR per `endpoint` (or per tight endpoint cluster — e.g. CRUD on the same resource collapses into one FR).
    - Reuse `ui-flow` routes as acceptance criteria on the user-facing FR.
    - Populate `dsRefs` / `tcRefs` from the items seeded in step 4 so the FR page surfaces the traceability links.
-4. **Seed the Epic-level DS / TC / NFR sections.** The DIAMONFORGE shape expects five categories per Epic (UR + FR + DS + TC + NFR). The seeding rules below turn scanner findings into initial items
-   the reviewer accepts / edits / rejects. See the dedicated subsection below.
+4. **Seed the Epic-level DS / TC / NFR sections.** Every Epic carries the SRS five-category shape (UR + FR + DS + TC + NFR) — see the canonical example at `templates/examples/example-epic.md`
+   (rendered) / `templates/examples/example-epic.spec.json` (machine-readable) for the exact layout. The seeding rules below turn scanner findings into initial items the reviewer accepts / edits /
+   rejects.
 5. **Flag gaps.** Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a **TODO** TC item (title `"{METHOD} {PATH} — happy path"`, `expectedResult: "to write"`), not silently.
 
-### Seeding DS / TC / NFR (DIAMONFORGE completeness)
+### Seeding DS / TC / NFR (five-category completeness)
 
 These three sections are **interpretive** — scanners surface the raw material, the agent synthesises the items. Reuse the L1+L2+L3 pattern from the eval (`docs/srs/scanner-findings.md`): deterministic
 findings feed AI prompts, the agent always runs, the user always validates before write.
@@ -438,7 +439,7 @@ Always emit NFRs with `priority: 'P3'` and `target: '<proposed — needs human v
 Before firing the review prompt on an Epic cluster, emit a one-shot **coverage table** so the reviewer sees what got seeded per category and where it came from:
 
 ```
-DIAMONFORGE coverage for Epic: <title>
+SRS coverage for Epic: <title>
 ┌──────┬───────────────┬──────────────────────────────────────────────┐
 │ Cat  │ Items proposed│ Source                                       │
 ├──────┼───────────────┼──────────────────────────────────────────────┤
@@ -573,8 +574,8 @@ Running the full `sf srs` chain end-to-end on SaaSFoundry itself surfaced 12 gap
   `.env` with `set -a && source .env && set +a` until the fix lands.
 - **`write-srs` supports single-pass Epic + FR writes via logical IDs (#245).** Mix Epics (with `epic.id`) and FRs (with `parentEpicId`) in one spec — `write-srs` resolves the references as it goes.
   `parentEpicPageId` remains as an escape hatch for incremental writes against pre-existing Epics.
-- **SRS completeness is UR+FR only (#247).** DS / TC / NFR are not generated yet. The DIAMONFORGE reference shape expects all five. AI-assisted generation planned under #247, reusing the L1+L2+L3
-  matcher architecture.
+- **SRS completeness is UR+FR only (pre-#247).** Historically DS / TC / NFR were not generated. The five-category shape (UR+FR+DS+TC+NFR) is now seeded by #247, reusing the L1+L2+L3 matcher
+  architecture — see the "Seeding DS / TC / NFR" section above for the full mapping.
 - **Preconditions first.** Before asking the user scope questions (backend choice, Notion parent page, etc.), read `.saasfoundry.json` — the answers are almost always already there. Re-running
   `sf update --add-modules srs` on an already-installed module silently re-bootstraps and duplicates Notion pages (#240).
 

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -361,10 +361,97 @@ The skill's job is to convert raw findings into publishable draft candidates. Wo
 2. **Pick the Epic level.** One Epic per coherent area (e.g. `auth`, `storage`, `accounts`). Title + narrative come from the richest `doc-context` in the group, or from the user's wording.
 3. **Propose the FRs.**
    - One FR per `endpoint` (or per tight endpoint cluster — e.g. CRUD on the same resource collapses into one FR).
-   - Add DS items for noteworthy `entity` fields (PK, unique constraints, relations).
-   - Seed TC items from `test.cases[]` of the matching area.
    - Reuse `ui-flow` routes as acceptance criteria on the user-facing FR.
-4. **Flag gaps.** Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a TODO in the drafted FR, not silently.
+   - Populate `dsRefs` / `tcRefs` from the items seeded in step 4 so the FR page surfaces the traceability links.
+4. **Seed the Epic-level DS / TC / NFR sections.** The DIAMONFORGE shape expects five categories per Epic (UR + FR + DS + TC + NFR). The seeding rules below turn scanner findings into initial items
+   the reviewer accepts / edits / rejects. See the dedicated subsection below.
+5. **Flag gaps.** Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a **TODO** TC item (title `"{METHOD} {PATH} — happy path"`, `expectedResult: "to write"`), not silently.
+
+### Seeding DS / TC / NFR (DIAMONFORGE completeness)
+
+These three sections are **interpretive** — scanners surface the raw material, the agent synthesises the items. Reuse the L1+L2+L3 pattern from the eval (`docs/srs/scanner-findings.md`): deterministic
+findings feed AI prompts, the agent always runs, the user always validates before write.
+
+#### DS items (Design Specifications)
+
+One `DsItem` per material design decision visible in code. Source findings → seeded `DsItem`:
+
+| Finding                                                      | Seeded `DsItem.title`            | Seeded `description` source                                                |
+| ------------------------------------------------------------ | -------------------------------- | -------------------------------------------------------------------------- |
+| `entity` (Prisma model)                                      | `Data model — <EntityName>`      | fields + `@unique` / `@id` / `@relation` + `deletedAt` flag                |
+| `endpoint` with non-trivial DTO (POST/PATCH body ≥ 2 fields) | `API contract — <METHOD> <path>` | DTO field list + validation rules surfaced by `class-validator` decorators |
+| `ui-flow` with `formFields.length ≥ 2`                       | `UI form — <PageName>`           | form field list + `linkedEndpointGuess` if present                         |
+
+Group by the Epic's area; set `frRefs` to every FR in the group whose endpoint/entity/UI flow matches. Deduplicate by title prefix — if two entities share the same core name (e.g. `User` +
+`UserProfile`), collapse them into a single DS item with both sub-models listed in the description.
+
+#### TC items (Test Cases)
+
+One `TcItem` per `test.cases[]` entry. Source mapping:
+
+| Source                                   | Seeded `TcItem` field                                                                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `test.cases[i].title`                    | `title` (the `it(...)` / `test(...)` string verbatim)                                                |
+| `test.cases[i]` structure                | `steps` — parse Given/When/Then from the title if phrased that way, else bullet the `describe` chain |
+| assertion in the test body (if readable) | `expectedResult`; if not parseable, use `"see <test.file>"`                                          |
+| `test.area` or `endpoint.area`           | `frRefs` — every FR whose area matches                                                               |
+
+**Untested endpoints** — for each `endpoint` with `hasTests=false`, emit a **TODO** TC item so the drift is auditable, not invisible:
+
+```jsonc
+{
+  "id": "TC-<area>-<slug>-todo",
+  "title": "<METHOD> <path> — happy path",
+  "expectedResult": "to write",
+  "frRefs": ["<FR-id>"]
+}
+```
+
+The reviewer can either accept the TODO (making the gap part of the public contract) or reject it and flag it upstream.
+
+#### NFR items (Non-Functional Requirements)
+
+NFRs are **proposed, not derived** — every seeded item must be marked for explicit human validation. Build the candidate list from two layers:
+
+**Layer 1 — stack signals** (present in `.saasfoundry.json` or inferred from findings):
+
+| Signal                                                                                       | Seeded NFR(s)                                                                                                                                             |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth` module present (endpoints under `/auth/*` or Prisma `Session` / `RefreshToken` model) | `Security — JWT access token expiry ≤ 15 min`; `Security — refresh token rotation on every use`; `Security — login rate limit ≤ 5 attempts / minute / IP` |
+| `i18n` module (`src/locales/` folder or `i18next` dep)                                       | `i18n — all user-facing strings translated in FR + EN`; `a11y — locale switchable without page reload`                                                    |
+| Prisma + Postgres detected                                                                   | `Data — soft delete via deletedAt on user-owned entities`; `Data — all migrations reversible (up + down)`                                                 |
+| `docker-compose*.yml` + `/health` endpoint present                                           | `Ops — API health check p95 ≤ 1 s`                                                                                                                        |
+| Playwright or e2e spec files present                                                         | `Quality — e2e coverage on critical user flows (login, signup, checkout when applicable)`                                                                 |
+| `@nestjs/swagger` + `docs/openapi.json` generated                                            | `Docs — OpenAPI spec regenerated on every API change (CI guard)`                                                                                          |
+
+**Layer 2 — standard SaaS catalogue** (always propose, mark low-confidence):
+
+- `Perf — p95 API latency ≤ 500 ms at 100 req/s sustained`
+- `Availability — uptime target 99.5% (excluding scheduled maintenance)`
+- `Security — all user-uploaded files virus-scanned before persistence` (only if storage module present)
+- `Privacy — PII fields encrypted at rest` (only if the schema carries `email`, `phone`, `address`)
+
+Always emit NFRs with `priority: 'P3'` and `target: '<proposed — needs human validation>'`. The reviewer lifts priority / refines target before accepting.
+
+#### Coverage table (pre-accept)
+
+Before firing the review prompt on an Epic cluster, emit a one-shot **coverage table** so the reviewer sees what got seeded per category and where it came from:
+
+```
+DIAMONFORGE coverage for Epic: <title>
+┌──────┬───────────────┬──────────────────────────────────────────────┐
+│ Cat  │ Items proposed│ Source                                       │
+├──────┼───────────────┼──────────────────────────────────────────────┤
+│ UR   │ 3             │ doc-context + inferred from FRs              │
+│ FR   │ 5             │ 5 endpoint clusters                          │
+│ DS   │ 4             │ 2 entities + 1 endpoint + 1 UI form          │
+│ TC   │ 8 (+ 2 TODO)  │ test.cases[] across 3 spec files             │
+│ NFR  │ 4 (proposed)  │ auth + i18n + prisma + playwright signals    │
+└──────┴───────────────┴──────────────────────────────────────────────┘
+```
+
+A cluster with **zero DS or zero TC** is a red flag — either the area is genuinely pure UI glue (no data model, no tests yet) or the scanners missed something. Surface the anomaly in the review prompt
+rather than silently proposing an Epic with empty sections.
 
 ### Review-loop prompts
 

--- a/scaffolds/skills-templates/sf-srs/templates/examples/example-epic.md
+++ b/scaffolds/skills-templates/sf-srs/templates/examples/example-epic.md
@@ -1,0 +1,88 @@
+# Authentication & session management
+
+> **Business value.** Users can create an account, sign in securely, and stay signed in across short interruptions without re-entering credentials.
+>
+> **Scope.** Covers signup with account validation, email+password signin, and signout. Session refresh is handled internally via `UserToken{type=SESSION_REFRESH}`. Does NOT cover SSO, password reset,
+> or MFA (tracked as separate Epics).
+
+> [!NOTE] This file is the canonical reference example shipped with the `sf-srs` skill. It shows what a complete Epic page looks like for the built-in SaaSFoundry auth module (`User` + polymorphic
+> `UserToken`, endpoints `/auth/signup` `/auth/signin` `/auth/signout`). Every DS / TC / NFR seeding pattern documented in `SKILL.md` is demonstrated here. The machine-readable source lives alongside
+> as `example-epic.spec.json`.
+
+## Traceability
+
+```
+UR (User Requirement)
+  └── FR (Functional Requirement)
+        ├── DS (Design Specification)
+        ├── TC (Test Case)
+        └── NFR (Non-Functional Requirement)
+```
+
+Each lower-level requirement traces back to a higher-level requirement, ensuring complete coverage and compliance traceability.
+
+## Requirement Types
+
+| Prefix | Type                       | Description                                                           | Example                                                                                 |
+| ------ | -------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| UR     | User Requirement           | High-level user need describing what the user wants to achieve.       | "The user must be able to log in to access the product"                                 |
+| FR     | Functional Requirement     | What the system must do to fulfill user requirements.                 | "The system displays a generic error message on login failure"                          |
+| DS     | Design Specification       | How the system implements the functional requirements.                | "JWT tokens stored in httpOnly cookies"                                                 |
+| TC     | Test Case                  | Verifiable steps that prove a functional requirement is satisfied.    | "Given valid credentials, when user submits login form, then 200 OK and JWT cookie set" |
+| NFR    | Non-Functional Requirement | Quality attributes: performance, security, availability, scalability. | "Login response time ≤ 1 second (p95)"                                                  |
+
+## User Requirements (UR)
+
+| ID          | Requirement                                                                                      | Priority | Related FR  |
+| ----------- | ------------------------------------------------------------------------------------------------ | -------- | ----------- |
+| UR-AUTH-001 | As a new user, I can create an account with an email and a password so I can access the product. | P1       | FR-AUTH-002 |
+| UR-AUTH-002 | As a returning user, I can sign in with my email and password to resume using the product.       | P1       | FR-AUTH-001 |
+| UR-AUTH-003 | As a signed-in user, I can sign out on demand so my session on a shared device is terminated.    | P2       | FR-AUTH-003 |
+
+## Functional Requirements (FR)
+
+| ID          | Requirement                    | Priority | Related UR  | Related DS                                         |
+| ----------- | ------------------------------ | -------- | ----------- | -------------------------------------------------- |
+| FR-AUTH-001 | Email + password signin        | P1       | UR-AUTH-002 | DS-AUTH-001, DS-AUTH-002, DS-AUTH-004, DS-AUTH-006 |
+| FR-AUTH-002 | Signup with account validation | P1       | UR-AUTH-001 | DS-AUTH-001, DS-AUTH-002, DS-AUTH-005              |
+| FR-AUTH-003 | Signout                        | P2       | UR-AUTH-003 | DS-AUTH-002, DS-AUTH-004                           |
+
+## Design Specifications (DS)
+
+| ID               | Specification                    | Related FR                            |
+| ---------------- | -------------------------------- | ------------------------------------- |
+| **Data model**   |                                  |                                       |
+| DS-AUTH-001      | Data model — User                | FR-AUTH-001, FR-AUTH-002              |
+| DS-AUTH-002      | Data model — UserToken           | FR-AUTH-001, FR-AUTH-002, FR-AUTH-003 |
+| **API contract** |                                  |                                       |
+| DS-AUTH-004      | API contract — POST /auth/signin | FR-AUTH-001, FR-AUTH-003              |
+| DS-AUTH-005      | API contract — POST /auth/signup | FR-AUTH-002                           |
+| **UI form**      |                                  |                                       |
+| DS-AUTH-006      | UI form — SignInPage             | FR-AUTH-001                           |
+
+## Test Cases (TC)
+
+| ID          | Title                                                                         | Expected Result                                                                          | Related FR  |
+| ----------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------- |
+| TC-AUTH-001 | should sign in user successfully                                              | 200 with access + refresh tokens and User.lastLoginAt updated                            | FR-AUTH-001 |
+| TC-AUTH-002 | should throw UnauthorizedException if credentials are invalid                 | 401 with generic message (same shape for unknown email and wrong password)               | FR-AUTH-001 |
+| TC-AUTH-003 | should create a new user successfully                                         | User row with isActive=false + UserToken{type=ACCOUNT_VALIDATION}                        | FR-AUTH-002 |
+| TC-AUTH-004 | should handle existing user gracefully                                        | Duplicate-email signup returns a generic response (no user-enumeration leak)             | FR-AUTH-002 |
+| TC-AUTH-005 | should create account when signing in with confirmation token                 | Consuming the token flips User.isActive=true and allows subsequent signin                | FR-AUTH-002 |
+| TC-AUTH-006 | should sign out user successfully                                             | SESSION_REFRESH UserToken for the caller is revoked                                      | FR-AUTH-003 |
+| TC-AUTH-007 | **TODO** — POST /auth/signup triggers email dispatch with the validation link | to write — seeded because the email dispatch path is not covered by auth.service.spec.ts | FR-AUTH-002 |
+
+## Non-Functional Requirements (NFR)
+
+| ID                 | Requirement                              | Target                                                                                                            | Priority | Related FR               |
+| ------------------ | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------- | ------------------------ |
+| **Security**       |                                          |                                                                                                                   |          |                          |
+| NFR-AUTH-001       | JWT access token expiry ≤ 15 minutes     | accessToken.exp − iat ≤ 900s                                                                                      | P1       | FR-AUTH-001              |
+| NFR-AUTH-002       | Refresh token rotation on every use      | SESSION_REFRESH UserToken rotated on each refresh; old token invalidated before the new one is issued             | P1       | FR-AUTH-001, FR-AUTH-003 |
+| NFR-AUTH-003       | Auth endpoints rate-limited per IP       | ≤ 5 failed signin attempts per IP per 60s — proposed, needs human validation                                      | P3       | FR-AUTH-001              |
+| **i18n**           |                                          |                                                                                                                   |          |                          |
+| NFR-AUTH-004       | Auth error messages translated (FR + EN) | All user-facing strings resolve through i18next in FR and EN — proposed, needs human validation                   | P3       | FR-AUTH-001, FR-AUTH-002 |
+| **Data lifecycle** |                                          |                                                                                                                   |          |                          |
+| NFR-AUTH-005       | User deactivation flow via isActive flag | Admin can flip User.isActive=false to lock an account without deleting the row — proposed, needs human validation | P3       | FR-AUTH-001              |
+| **Performance**    |                                          |                                                                                                                   |          |                          |
+| NFR-AUTH-006       | Signin p95 latency ≤ 1 second            | POST /auth/signin p95 ≤ 1s under expected concurrency — proposed, needs human validation                          | P3       | FR-AUTH-001              |

--- a/scaffolds/skills-templates/sf-srs/templates/examples/example-epic.spec.json
+++ b/scaffolds/skills-templates/sf-srs/templates/examples/example-epic.spec.json
@@ -1,0 +1,183 @@
+{
+  "title": "Authentication & session management",
+  "parentPageId": "<replaced-at-write-time>",
+  "id": "EPIC-AUTH",
+  "businessValue": "Users can create an account, sign in securely, and stay signed in across short interruptions without re-entering credentials.",
+  "scope": "Covers signup with account validation, email+password signin, and signout. Session refresh is handled internally via UserToken{type=SESSION_REFRESH}. Does NOT cover SSO, password reset, or MFA (tracked as separate Epics).",
+
+  "urs": [
+    { "id": "UR-AUTH-001", "narrative": "As a new user, I can create an account with an email and a password so I can access the product.", "priority": "P1" },
+    { "id": "UR-AUTH-002", "narrative": "As a returning user, I can sign in with my email and password to resume using the product.", "priority": "P1" },
+    { "id": "UR-AUTH-003", "narrative": "As a signed-in user, I can sign out on demand so my session on a shared device is terminated.", "priority": "P2" }
+  ],
+
+  "frs": [
+    {
+      "id": "FR-AUTH-001",
+      "title": "Email + password signin",
+      "description": "POST /auth/signin validates credentials against User.password (bcrypt) and issues a short-lived access JWT + a SESSION_REFRESH UserToken.",
+      "priority": "P1",
+      "urRefs": ["UR-AUTH-002"],
+      "dsRefs": ["DS-AUTH-001", "DS-AUTH-002", "DS-AUTH-004", "DS-AUTH-006"],
+      "tcRefs": ["TC-AUTH-001", "TC-AUTH-002"],
+      "endpoint": "POST /auth/signin",
+      "acceptanceCriteria": [
+        "Valid credentials return 200 with an access token and a refresh token (cookie or body depending on deployment).",
+        "Invalid credentials return 401 with a generic error message (no user-enumeration leak).",
+        "An inactive User (User.isActive=false) cannot sign in; the response invites the user to validate their account first."
+      ]
+    },
+    {
+      "id": "FR-AUTH-002",
+      "title": "Signup with account validation",
+      "description": "POST /auth/signup creates a User with isActive=false and a UserToken{type=ACCOUNT_VALIDATION}. Account becomes usable only after the validation token is consumed (typically via an email link).",
+      "priority": "P1",
+      "urRefs": ["UR-AUTH-001"],
+      "dsRefs": ["DS-AUTH-001", "DS-AUTH-002", "DS-AUTH-005"],
+      "tcRefs": ["TC-AUTH-003", "TC-AUTH-004", "TC-AUTH-005"],
+      "endpoint": "POST /auth/signup",
+      "acceptanceCriteria": [
+        "Unique email + valid password return 200 and queue an account-validation token + email.",
+        "Duplicate email is handled gracefully with a generic response (no user-enumeration leak).",
+        "Unvalidated accounts have User.isActive=false and cannot sign in until the token is consumed."
+      ]
+    },
+    {
+      "id": "FR-AUTH-003",
+      "title": "Signout",
+      "description": "POST /auth/signout revokes the caller's SESSION_REFRESH UserToken so the refresh chain for this session can no longer be used.",
+      "priority": "P2",
+      "urRefs": ["UR-AUTH-003"],
+      "dsRefs": ["DS-AUTH-002", "DS-AUTH-004"],
+      "tcRefs": ["TC-AUTH-006"],
+      "endpoint": "POST /auth/signout",
+      "acceptanceCriteria": [
+        "Authenticated caller receives 200 and their SESSION_REFRESH token is invalidated.",
+        "Subsequent refresh attempts with the revoked token return 401.",
+        "Unauthenticated callers receive 401 without leaking whether the token existed."
+      ]
+    }
+  ],
+
+  "dsItems": [
+    {
+      "id": "DS-AUTH-001",
+      "title": "Data model — User",
+      "description": "Prisma model User { id, email @unique, password, isActive @default(false), peopleId?, lastLoginAt? }. Passwords hashed with bcrypt. isActive gates signin until the ACCOUNT_VALIDATION token is consumed.",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-002"],
+      "group": "Data model"
+    },
+    {
+      "id": "DS-AUTH-002",
+      "title": "Data model — UserToken",
+      "description": "Prisma model UserToken { id, userId, token, type: TokenType, expiresAt? } with enum TokenType { ACCOUNT_VALIDATION, SESSION_REFRESH, PASSWORD_RESET, INVITATION }. @@unique([userId, type]) enforces one live token per (user, type).",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-002", "FR-AUTH-003"],
+      "group": "Data model"
+    },
+    {
+      "id": "DS-AUTH-004",
+      "title": "API contract — POST /auth/signin",
+      "description": "Body: SignInDto { email, password }. Response: SignInResponseDto { accessToken, refreshToken, user }. Emits SESSION_REFRESH UserToken.",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-003"],
+      "group": "API contract"
+    },
+    {
+      "id": "DS-AUTH-005",
+      "title": "API contract — POST /auth/signup",
+      "description": "Body: SignUpDto { email, password, locale? }. Response: SignUpResponseDto. Creates User.isActive=false + ACCOUNT_VALIDATION UserToken; when the email module is installed, a validation email is queued.",
+      "frRefs": ["FR-AUTH-002"],
+      "group": "API contract"
+    },
+    {
+      "id": "DS-AUTH-006",
+      "title": "UI form — SignInPage",
+      "description": "web/src/pages/public/SignInPage.tsx — fields: email, password. Zod schema: email format + password min length. Submits via the useSigninMutation React Query hook.",
+      "frRefs": ["FR-AUTH-001"],
+      "group": "UI form"
+    }
+  ],
+
+  "tcItems": [
+    {
+      "id": "TC-AUTH-001",
+      "title": "should sign in user successfully",
+      "frRefs": ["FR-AUTH-001"],
+      "expectedResult": "200 with access + refresh tokens and User.lastLoginAt updated — see auth.service.spec.ts"
+    },
+    {
+      "id": "TC-AUTH-002",
+      "title": "should throw UnauthorizedException if credentials are invalid",
+      "frRefs": ["FR-AUTH-001"],
+      "expectedResult": "401 Unauthorized with generic message (same shape for unknown email and wrong password)"
+    },
+    {
+      "id": "TC-AUTH-003",
+      "title": "should create a new user successfully",
+      "frRefs": ["FR-AUTH-002"],
+      "expectedResult": "User row with isActive=false + UserToken{type=ACCOUNT_VALIDATION} — see auth.service.spec.ts"
+    },
+    {
+      "id": "TC-AUTH-004",
+      "title": "should handle existing user gracefully",
+      "frRefs": ["FR-AUTH-002"],
+      "expectedResult": "Signup with a duplicate email returns a generic response (no user-enumeration leak)"
+    },
+    {
+      "id": "TC-AUTH-005",
+      "title": "should create account when signing in with confirmation token",
+      "frRefs": ["FR-AUTH-002"],
+      "expectedResult": "Consuming an ACCOUNT_VALIDATION token flips User.isActive=true and allows subsequent signin"
+    },
+    { "id": "TC-AUTH-006", "title": "should sign out user successfully", "frRefs": ["FR-AUTH-003"], "expectedResult": "SESSION_REFRESH UserToken for the caller is deleted / revoked" },
+    {
+      "id": "TC-AUTH-007",
+      "title": "TODO — POST /auth/signup triggers email dispatch with the validation link",
+      "frRefs": ["FR-AUTH-002"],
+      "expectedResult": "to write — seeded because the email dispatch path is not covered by auth.service.spec.ts today"
+    }
+  ],
+
+  "nfrItems": [
+    { "id": "NFR-AUTH-001", "title": "JWT access token expiry ≤ 15 minutes", "target": "accessToken.exp − iat ≤ 900s", "priority": "P1", "frRefs": ["FR-AUTH-001"], "group": "Security" },
+    {
+      "id": "NFR-AUTH-002",
+      "title": "Refresh token rotation on every use",
+      "target": "SESSION_REFRESH UserToken is rotated on each refresh; old token is invalidated before the new one is issued",
+      "priority": "P1",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-003"],
+      "group": "Security"
+    },
+    {
+      "id": "NFR-AUTH-003",
+      "title": "Auth endpoints rate-limited per IP",
+      "target": "≤ 5 failed signin attempts per IP per 60s — proposed, needs human validation",
+      "priority": "P3",
+      "frRefs": ["FR-AUTH-001"],
+      "group": "Security"
+    },
+    {
+      "id": "NFR-AUTH-004",
+      "title": "Auth error messages translated (FR + EN)",
+      "target": "All user-facing error strings resolve through i18next in FR and EN — proposed, needs human validation",
+      "priority": "P3",
+      "frRefs": ["FR-AUTH-001", "FR-AUTH-002"],
+      "group": "i18n"
+    },
+    {
+      "id": "NFR-AUTH-005",
+      "title": "User deactivation flow via isActive flag",
+      "target": "Admin can flip User.isActive=false to lock an account without deleting the row — proposed, needs human validation",
+      "priority": "P3",
+      "frRefs": ["FR-AUTH-001"],
+      "group": "Data lifecycle"
+    },
+    {
+      "id": "NFR-AUTH-006",
+      "title": "Signin p95 latency ≤ 1 second",
+      "target": "POST /auth/signin p95 ≤ 1s under expected concurrency — proposed, needs human validation",
+      "priority": "P3",
+      "frRefs": ["FR-AUTH-001"],
+      "group": "Performance"
+    }
+  ]
+}

--- a/scaffolds/skills-templates/sf-srs/templates/pages/README.md
+++ b/scaffolds/skills-templates/sf-srs/templates/pages/README.md
@@ -32,7 +32,7 @@ type PageBlock =
 
 ## Epic page sections
 
-Produced by `renderEpicPage(spec)` in this order (DIAMONFORGE-style):
+Produced by `renderEpicPage(spec)` in this order (five-category shape):
 
 1. `Traceability` (H2) + plain-text code block (ASCII tree `UR → FR → { DS, TC, NFR }`) + explanatory paragraph
 2. `Requirement Types` (H2) + definitions table `Prefix | Type | Description | Example` with one row per UR/FR/DS/TC/NFR
@@ -47,7 +47,7 @@ carrying the group id followed by empty cells matching the table arity.
 
 ## FR page sections
 
-Produced by `renderFrPage(spec)` in this order (DIAMONFORGE-style):
+Produced by `renderFrPage(spec)` in this order (five-category shape):
 
 1. `Summary` (H2) + table `ID | Requirement | Priority | Related UR | Related DS | Related TC` — one row per FR item on the page
 2. Divider

--- a/src/__tests__/integration/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/integration/tools/notion/srs.adapter.spec.ts
@@ -85,7 +85,7 @@ describeIntegration('NotionSrsAdapter (integration, sandbox)', () => {
     expect(raw.title).toBe(epicSpec.title)
     expect(raw.blocks.length).toBeGreaterThan(0)
 
-    // Structural assertions on the rendered DIAMONFORGE shape (table count, TC + NFR sections, headings)
+    // Structural assertions on the rendered five-category shape (table count, TC + NFR sections, headings)
     const tables = raw.blocks.filter((b) => b.kind === 'table')
     // 6 tables: Requirement Types + UR + FR + DS + TC + NFR
     expect(tables).toHaveLength(6)

--- a/src/__tests__/unit/skill/srs-diamonforge-seeding.spec.ts
+++ b/src/__tests__/unit/skill/srs-diamonforge-seeding.spec.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+
+// Regression guard for #247: the sf-srs SKILL.md must teach the AI agent how to
+// seed DS / TC / NFR items from scanner findings (DIAMONFORGE completeness).
+// Without this guidance the drafter silently produces UR+FR only and the
+// generated SRS can't pass a real audit. The byte-equality drift guard
+// (tool-skill-drift.spec.ts) ensures the scaffolded copy stays in sync — this
+// spec pins the *content* so a refactor can't accidentally strip the sections.
+const SKILL_PATHS = [path.resolve(__dirname, '../../../../.claude/skills/sf-srs/SKILL.md'), path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/SKILL.md')]
+
+const REQUIRED_HEADINGS = [
+  /### Seeding DS \/ TC \/ NFR \(DIAMONFORGE completeness\)/,
+  /#### DS items \(Design Specifications\)/,
+  /#### TC items \(Test Cases\)/,
+  /#### NFR items \(Non-Functional Requirements\)/,
+  /#### Coverage table \(pre-accept\)/
+]
+
+const REQUIRED_MAPPINGS = [
+  /entity.*Data model/,
+  /API contract.*METHOD/,
+  /UI form/,
+  /test\.cases\[i\]\.title/,
+  /hasTests=false/,
+  /TODO.*TC/,
+  /JWT access token expiry/,
+  /refresh token rotation/,
+  /i18n.*translated/,
+  /deletedAt/,
+  /proposed — needs human validation/
+]
+
+describe('sf-srs DIAMONFORGE seeding guidance (#247)', () => {
+  it.each(SKILL_PATHS)('%s declares all DS/TC/NFR seeding headings', (file) => {
+    const content = readFileSync(file, 'utf8')
+    for (const pattern of REQUIRED_HEADINGS) {
+      expect(content).toMatch(pattern)
+    }
+  })
+
+  it.each(SKILL_PATHS)('%s carries the scanner-finding → section mapping signals', (file) => {
+    const content = readFileSync(file, 'utf8')
+    for (const pattern of REQUIRED_MAPPINGS) {
+      expect(content).toMatch(pattern)
+    }
+  })
+
+  it.each(SKILL_PATHS)('%s tells the agent to emit a DIAMONFORGE coverage table', (file) => {
+    const content = readFileSync(file, 'utf8')
+    expect(content).toMatch(/DIAMONFORGE coverage for Epic/)
+    expect(content).toMatch(/Items proposed/)
+  })
+})

--- a/src/__tests__/unit/skill/srs-example-epic.spec.ts
+++ b/src/__tests__/unit/skill/srs-example-epic.spec.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+
+import { renderEpicPage } from '../../../builders/srs/templates/pages/epic.tpl'
+import { EpicSpec } from '../../../builders/srs/types'
+
+// Regression guard for the canonical example shipped with the sf-srs skill.
+// The agent is told to reference `templates/examples/example-epic.spec.json`
+// as the source of truth for what a complete Epic looks like. If that file
+// ever drifts into an invalid EpicSpec shape, the agent would teach itself
+// broken structure — so we pin the shape here.
+const EXAMPLE_PATHS = [
+  path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/examples/example-epic.spec.json'),
+  path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/examples/example-epic.spec.json')
+]
+
+describe('sf-srs canonical example Epic', () => {
+  it.each(EXAMPLE_PATHS)('%s parses as a valid EpicSpec and renders without throwing', (file) => {
+    const raw = readFileSync(file, 'utf8')
+    const spec = JSON.parse(raw) as EpicSpec
+
+    expect(spec.title).toBeTruthy()
+    expect(spec.parentPageId).toBeTruthy()
+    expect(spec.urs.length).toBeGreaterThan(0)
+    expect(spec.frs.length).toBeGreaterThan(0)
+    expect(spec.dsItems?.length ?? 0).toBeGreaterThan(0)
+    expect(spec.tcItems?.length ?? 0).toBeGreaterThan(0)
+    expect(spec.nfrItems?.length ?? 0).toBeGreaterThan(0)
+
+    // Demonstrates the "at least one TODO TC" and "every NFR is proposed" patterns
+    // the skill documents — fail loudly if the example stops teaching those.
+    const hasTodoTc = (spec.tcItems ?? []).some((tc) => /TODO/.test(tc.title) || /to write/.test(tc.expectedResult ?? ''))
+    expect(hasTodoTc).toBe(true)
+
+    const hasProposedNfr = (spec.nfrItems ?? []).some((nfr) => /proposed.*needs human validation/.test(nfr.target ?? ''))
+    expect(hasProposedNfr).toBe(true)
+
+    const page = renderEpicPage(spec)
+    expect(page.title).toBe(spec.title)
+    expect(page.blocks.length).toBeGreaterThan(0)
+  })
+})

--- a/src/__tests__/unit/skill/srs-five-category-seeding.spec.ts
+++ b/src/__tests__/unit/skill/srs-five-category-seeding.spec.ts
@@ -2,15 +2,16 @@ import { readFileSync } from 'fs'
 import path from 'path'
 
 // Regression guard for #247: the sf-srs SKILL.md must teach the AI agent how to
-// seed DS / TC / NFR items from scanner findings (DIAMONFORGE completeness).
-// Without this guidance the drafter silently produces UR+FR only and the
-// generated SRS can't pass a real audit. The byte-equality drift guard
-// (tool-skill-drift.spec.ts) ensures the scaffolded copy stays in sync — this
-// spec pins the *content* so a refactor can't accidentally strip the sections.
+// seed DS / TC / NFR items from scanner findings (five-category completeness:
+// UR + FR + DS + TC + NFR). Without this guidance the drafter silently produces
+// UR+FR only and the generated SRS can't pass a real audit. The byte-equality
+// drift guard (tool-skill-drift.spec.ts) ensures the scaffolded copy stays in
+// sync — this spec pins the *content* so a refactor can't accidentally strip
+// the sections.
 const SKILL_PATHS = [path.resolve(__dirname, '../../../../.claude/skills/sf-srs/SKILL.md'), path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/SKILL.md')]
 
 const REQUIRED_HEADINGS = [
-  /### Seeding DS \/ TC \/ NFR \(DIAMONFORGE completeness\)/,
+  /### Seeding DS \/ TC \/ NFR \(five-category completeness\)/,
   /#### DS items \(Design Specifications\)/,
   /#### TC items \(Test Cases\)/,
   /#### NFR items \(Non-Functional Requirements\)/,
@@ -31,7 +32,7 @@ const REQUIRED_MAPPINGS = [
   /proposed — needs human validation/
 ]
 
-describe('sf-srs DIAMONFORGE seeding guidance (#247)', () => {
+describe('sf-srs five-category seeding guidance (#247)', () => {
   it.each(SKILL_PATHS)('%s declares all DS/TC/NFR seeding headings', (file) => {
     const content = readFileSync(file, 'utf8')
     for (const pattern of REQUIRED_HEADINGS) {
@@ -46,9 +47,9 @@ describe('sf-srs DIAMONFORGE seeding guidance (#247)', () => {
     }
   })
 
-  it.each(SKILL_PATHS)('%s tells the agent to emit a DIAMONFORGE coverage table', (file) => {
+  it.each(SKILL_PATHS)('%s tells the agent to emit a five-category coverage table', (file) => {
     const content = readFileSync(file, 'utf8')
-    expect(content).toMatch(/DIAMONFORGE coverage for Epic/)
+    expect(content).toMatch(/SRS coverage for Epic/)
     expect(content).toMatch(/Items proposed/)
   })
 })

--- a/src/__tests__/unit/skill/tool-skill-drift.spec.ts
+++ b/src/__tests__/unit/skill/tool-skill-drift.spec.ts
@@ -56,6 +56,16 @@ const PAIRS = [
     name: 'sf-srs templates/tickets/README.md',
     inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/tickets/README.md'),
     scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/tickets/README.md')
+  },
+  {
+    name: 'sf-srs templates/examples/example-epic.spec.json',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/examples/example-epic.spec.json'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/examples/example-epic.spec.json')
+  },
+  {
+    name: 'sf-srs templates/examples/example-epic.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/examples/example-epic.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/examples/example-epic.md')
   }
 ]
 

--- a/src/__tests__/unit/srs/eval/inventory.spec.ts
+++ b/src/__tests__/unit/srs/eval/inventory.spec.ts
@@ -30,7 +30,7 @@ class StubAdapter implements SrsAdapter {
 }
 
 describe('parseFrPageTitle', () => {
-  it('parses the DIAMONFORGE shape "FR-AREA-NN — Title"', () => {
+  it('parses the canonical FR page-title shape "FR-AREA-NN — Title"', () => {
     expect(parseFrPageTitle('FR-AUTH-01 — Sign in')).toEqual({ id: 'FR-AUTH-01', area: 'auth', title: 'Sign in' })
   })
 

--- a/src/__tests__/unit/srs/templates/epic.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/epic.tpl.spec.ts
@@ -27,7 +27,7 @@ function findParagraphAfterHeading(blocks: PageBlock[], headingText: string): st
   throw new Error(`paragraph after heading "${headingText}" not found`)
 }
 
-describe('renderEpicPage — DIAMONFORGE-style structure', () => {
+describe('renderEpicPage — five-category structure', () => {
   it('emits the spec-sections scaffold in order', () => {
     const spec: EpicSpec = {
       title: 'Authentication',

--- a/src/__tests__/unit/srs/templates/fr.tpl.spec.ts
+++ b/src/__tests__/unit/srs/templates/fr.tpl.spec.ts
@@ -13,7 +13,7 @@ function findTableAfterHeading(blocks: PageBlock[], headingText: string): TableB
   throw new Error(`table after heading "${headingText}" not found`)
 }
 
-describe('renderFrPage — DIAMONFORGE-style structure', () => {
+describe('renderFrPage — five-category structure', () => {
   it('uses "ID — Title" as the page title', () => {
     const spec: FrSpec = { parentEpicPageId: 'epic', fr: { id: 'FR-AUTH-01-01', title: 'Sign in' } }
     const page = renderFrPage(spec)

--- a/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
+++ b/src/__tests__/unit/tools/notion/srs.adapter.spec.ts
@@ -298,7 +298,7 @@ describe('NotionSrsAdapter', () => {
       expect(call.children.length).toBeGreaterThan(0)
     })
 
-    it('produces the DIAMONFORGE-shape children: Summary table + divider + per-item detail table', async () => {
+    it('produces the five-category children: Summary table + divider + per-item detail table', async () => {
       const { client, calls } = buildMockClient()
       const adapter = new NotionSrsAdapter({ apiToken: 'tk', client })
 
@@ -319,7 +319,7 @@ describe('NotionSrsAdapter', () => {
     })
   })
 
-  describe('createEpicPage — DIAMONFORGE structural shape', () => {
+  describe('createEpicPage — five-category structural shape', () => {
     it('emits Traceability + Requirement Types + UR/FR/DS/TC/NFR sections with grouped tables', async () => {
       const richEpic: EpicSpec = {
         title: 'Auth epic',


### PR DESCRIPTION
## Summary

Closes #247 (last SUB of #235 — SRS toolchain post-capstone follow-ups).

Teaches the `sf-srs` skill how to synthesise DS / TC / NFR items from scanner findings so the drafter produces a full DIAMONFORGE-shaped Epic / FR tree instead of UR + FR only.

## Why

The DIAMONFORGE reference shape expects five categories per Epic (UR + FR + DS + TC + NFR). The rendering infrastructure (types, templates, write pipeline, Notion adapter) was already landed in #223 / #245 — but the skill prompt stopped at UR+FR and never told the agent how to populate the DS / TC / NFR sections the templates already render. This PR closes that loop.

## What

- `.claude/skills/sf-srs/SKILL.md` — new **Seeding DS / TC / NFR (DIAMONFORGE completeness)** section with per-category mappings:
  - **DS** — `entity` → `Data model`, `endpoint` non-trivial DTO → `API contract`, `ui-flow` with forms → `UI form`
  - **TC** — one `TcItem` per `test.cases[]` entry; untested endpoints emit **TODO** TC items so drift is auditable
  - **NFR** — stack signals (auth / i18n / prisma / docker-compose / playwright / swagger) + standard SaaS catalogue, always marked `proposed — needs human validation`
- Pre-accept **DIAMONFORGE coverage table** so reviewers see what got seeded per category before approving
- `scaffolds/skills-templates/sf-srs/SKILL.md` mirrored byte-identical (existing drift guard covers it)
- `docs/srs/scanner-findings.md` — findings-to-sections mapping table cross-linking to the skill
- `docs/srs/walkthrough.md` — mention the coverage table in the codebase-drafting flow
- `src/__tests__/unit/skill/srs-diamonforge-seeding.spec.ts` — regression guard (5 headings + 11 signal patterns pinned across both SKILL.md copies)

## Zero infra change

No change to types, templates, adapters, or the write pipeline. Only skill prompt guidance + docs + tests.

## Test plan

- [x] `npm run build` ✅
- [x] `npm run lint` ✅
- [x] `npm run test:unit` — 93 suites / 1051 tests (6 new)
- [x] Drift guard (`tool-skill-drift.spec.ts`) — byte-equality maintained
- [x] Pre-push Docker — `multirepo-minimal` + `monorepo-minimal` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)