### PR TITLE
feat(#271): ticket authoring examples gallery

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -33,9 +33,13 @@ sf-srs/
 ├── templates/
 │   ├── pages/                       # Epic + FR page templates → PageContent   (SUB-3)
 │   └── tickets/                     # GitHub ticket templates (srs-epic, srs-story)   (SUB-4)
+│       └── examples/                # archetypal filled-in examples: epic.md | story.md | task.md | issue.md
 └── scripts/
     └── srs-cli.sh                   # single orchestrator entrypoint           (SUB-14.3)
 ```
+
+**Authoring guidance** — before drafting a real Epic / Story / Task / Issue body, skim the matching file under [`templates/tickets/examples/`](templates/tickets/examples/). Each example opens with a
+`<!-- Why this example -->` preamble that names the pattern it illustrates and the anti-patterns to avoid. Import the **pattern** (tone, section density, title convention), not the fictional content.
 
 TS entrypoints dispatched by `srs-cli.sh` live alongside the CLI source under `src/srs/bin/` (dogfood) or `node_modules/saasfoundry-cli/dist/srs/bin/` (shipped). They are **not** duplicated inside the
 skill folder — the skill is a thin orchestrator.

--- a/.claude/skills/sf-srs/templates/tickets/README.md
+++ b/.claude/skills/sf-srs/templates/tickets/README.md
@@ -116,6 +116,18 @@ Produced by `renderIssueTicketBody(spec)` in this order:
 5. `## Impact / Severity` — optional `**Severity:**` line + free-form impact paragraph (placeholder when both are empty)
 6. `## Evidence / Data` — bulleted list (placeholder when empty)
 
+## Authoring examples
+
+Filled-in archetypal examples — one per type — live under `examples/` and are the reference a writing agent should skim before drafting a real ticket:
+
+- [`examples/epic.md`](examples/epic.md) — Epic archetype (multi-tenant workspace isolation)
+- [`examples/story.md`](examples/story.md) — Story archetype (invite teammate to workspace)
+- [`examples/task.md`](examples/task.md) — Task archetype (extract shared email validation)
+- [`examples/issue.md`](examples/issue.md) — Issue archetype (register form swallows `E_EMAIL_TAKEN`)
+
+Each example opens with a `<!-- Why this example -->` preamble that names the pattern it illustrates and the anti-patterns to avoid. Import the **pattern** (tone, density, section usage, title
+convention) — not the literal content, which is fictional.
+
 ## Adding a new ticket body variant
 
 Add a new template under `src/builders/srs/templates/tickets/`, export it from `src/srs/index.ts`, and wire the subtask spawner (SUB-9) to dispatch to the right renderer based on the parent label

--- a/.claude/skills/sf-srs/templates/tickets/examples/epic.md
+++ b/.claude/skills/sf-srs/templates/tickets/examples/epic.md
@@ -1,0 +1,92 @@
+<!--
+Why this example
+================
+Shows:
+- Goal = outcome ("user can..."), not a task list.
+- Business Value = 2-3 lines, stakeholder-facing, no implementation words.
+- Scope Included ≈ one bullet per child Story. Excluded names what's tempting to grab but deferred.
+- FR table lists ALL children so reviewers can jump.
+- Definition of Done = verifiable facts, not intents.
+
+Avoid:
+- AC tables at Epic level (those live on Stories).
+- Step-by-step tech tasks (live on Stories/Tasks).
+- Deadlines in prose — put them in Dates.
+
+Title convention:
+  [EPIC] <English> — <French>
+  e.g. [EPIC] Multi-tenant workspace isolation — Cloisonnement multi-tenant des espaces de travail
+
+Domain chosen: multi-tenant workspace isolation for a generated SaaS app.
+Content is fictional — import the pattern, not the facts.
+-->
+
+## Goal
+
+When this Epic is Done, a user can create, switch between, and delete workspaces that are fully isolated — data, members, billing, and audit logs scoped to the active workspace, and no API route leaks
+cross-workspace data.
+
+## Business Value
+
+Agencies and holdings need clean client separation without managing multiple accounts. Today we force them onto a second subscription or accept data comingling — both cost ARR. This Epic unblocks the
+agency pricing tier and removes the top Q1 churn reason.
+
+## Dates
+
+- Target start: 2026-05-05
+- Target end: 2026-06-20
+- Milestone: workspace switcher on staging by 2026-06-01 (agency-tier sales demo)
+
+## Scope
+
+### Included
+
+- Workspace CRUD with role-gated actions
+- Invite teammates scoped to a workspace, per-workspace roles
+- Workspace switcher in the app shell, persisted per session
+- Row-level isolation via a Prisma tenancy middleware
+- Audit log entries tagged with emitting workspace
+
+### Excluded
+
+- Per-workspace custom domains (separate Epic)
+- Cross-workspace analytics (breaks isolation guarantee)
+- Workspace-to-workspace data import
+- Stripe subscription split per workspace (v1 stays one-per-user)
+
+## Specifications
+
+Main spec: [Epic SRS page — Multi-tenant workspace isolation](https://www.notion.so/epic-workspace-isolation-abc)
+
+| FR     | Title                     | Page                                   |
+| ------ | ------------------------- | -------------------------------------- |
+| FR-421 | Create & rename workspace | [FR-421](https://www.notion.so/fr-421) |
+| FR-422 | Invite teammate           | [FR-422](https://www.notion.so/fr-422) |
+| FR-423 | Switch active workspace   | [FR-423](https://www.notion.so/fr-423) |
+| FR-424 | Prisma tenancy middleware | [FR-424](https://www.notion.so/fr-424) |
+| FR-425 | Per-workspace audit log   | [FR-425](https://www.notion.so/fr-425) |
+
+## Dependencies
+
+- #184 Auth v2 refresh-token rotation — session context must carry `workspaceId`
+- Stripe agency-tier SKU (owner: @finance)
+
+## Constraints
+
+- All new API routes go through the tenancy middleware. No opt-out.
+- Existing single-workspace users are migrated transparently (default workspace auto-created).
+- No breaking changes to public API contracts — `workspaceId` inferred from session, not URL.
+
+## Assumptions
+
+- Stripe subscription stays at user level; workspace is a billing attribute.
+- Audit log volume growth (~2×) fits within existing Loki retention budget.
+- Frontend role-gating reuses `<RequireRole>`; no new permission primitive.
+
+## Definition of Done
+
+- All 5 child FRs are `Done`.
+- `pnpm test:e2e tenancy` passes: 0 cross-workspace data leaks.
+- Staging migration executed; 100% of existing users have a default workspace.
+- `docs/workspace-isolation.md` exists and is linked from getting-started.
+- Agency-tier sales demo signed off by @sales.

--- a/.claude/skills/sf-srs/templates/tickets/examples/issue.md
+++ b/.claude/skills/sf-srs/templates/tickets/examples/issue.md
@@ -1,0 +1,66 @@
+<!--
+Why this example
+================
+Shows:
+- Behavior observed = FACTS only (what actually happens). No hypothesis, no diagnosis.
+- Expected Behavior = what should happen, with the contract it violates.
+- Steps to Reproduce = deterministic, numbered, copy-pasteable.
+- Environment = versions, browsers, OS that matter for this bug.
+- Impact / Severity = concrete user/business effect; severity explicit.
+- Evidence = screenshots, logs, request IDs, code pointers — things reviewers can click or grep.
+
+Avoid:
+- Mixing diagnosis into "Behavior observed" (save it for a comment).
+- Vague "doesn't work" — every bug has a precise input + a precise wrong output.
+- Missing severity — unassigned means triage will be wrong.
+
+Title convention:
+  [BUG] <English> — <French>
+  e.g. [BUG] Register form swallows E_EMAIL_TAKEN — Le formulaire d'inscription masque E_EMAIL_TAKEN
+
+Domain chosen: a front-end bug in the generated app — archetypal "handler ignores response code".
+Content is fictional — import the pattern, not the facts.
+-->
+
+## Behavior observed
+
+When a registered user submits the `/register` form with an email that already exists, the backend responds `409 Conflict` with `{ code: "E_EMAIL_TAKEN" }` — but the React form shows a generic
+`"Something went wrong, please retry"` banner. The specific code is never rendered, no `email` field error appears under the input, and the password field is cleared.
+
+## Expected Behavior
+
+Per the API contract (`docs/api-errors.md`) and the design of `RegisterForm`, a `409 / E_EMAIL_TAKEN` response must:
+
+1. Surface an inline error _on the email field_: "This email is already registered — sign in instead?" with a link to `/login`.
+2. NOT trigger the generic banner.
+3. Keep the password field value intact so the user doesn't have to re-type.
+
+## Steps to Reproduce / Trigger Conditions
+
+1. Register normally with `user@example.com` / `P@ssw0rd!` — succeeds.
+2. Log out.
+3. Navigate to `/register`.
+4. Submit the same email `user@example.com` with any password.
+5. Observe: generic banner appears at the top; email field has no error; password field is cleared.
+
+## Environment / Configuration
+
+- Affected: `web/` frontend, `RegisterForm.tsx`
+- Versions: `saasfoundry-cli 1.0.0-beta`, generated project uses `react 19.0.0`, `react-hook-form 7.56.0`
+- Browsers: reproduced on Chrome 133, Firefox 138, Safari 18 — not browser-specific
+- API: NestJS backend, `409 / E_EMAIL_TAKEN` confirmed correct via `curl`
+
+## Impact / Severity
+
+**Severity: medium**
+
+- Returning users can't tell why they can't register — 18% bounce rate on duplicate-email attempts (Amplitude funnel, last 30 days).
+- Support tickets tagged `signup-confused` up 40% since the 1.0.0-beta cut.
+- No data integrity or security risk — purely UX.
+
+## Evidence / Data
+
+- Request ID: `req_7f3a91c2` (Sentry: [event 445812](https://sentry.io/fake/445812))
+- Screenshot comparing the generic banner vs. expected inline error: [attachment](https://img.example.com/issue-evidence.png)
+- Network tab capture confirming backend response: `{"statusCode": 409, "code": "E_EMAIL_TAKEN", "message": "Email already in use"}`
+- Relevant code: `src/components/auth/RegisterForm.tsx:87` — the `onError` handler only checks `err.response.status` and ignores `err.response.data.code`.

--- a/.claude/skills/sf-srs/templates/tickets/examples/story.md
+++ b/.claude/skills/sf-srs/templates/tickets/examples/story.md
@@ -1,0 +1,69 @@
+<!--
+Why this example
+================
+Shows:
+- Objective = one sentence, user-facing, names the *capability* and the FR it implements.
+- Context (User Requirements) links UR items so reviewers see the user narrative.
+- Scope (Functional Requirements) = usually one FR; if two, that's a smell.
+- Acceptance Criteria table: 3-5 rows, each testable, each traced back to a Source FR.
+- Specifications points to the FR SRS page and the parent Epic spec.
+- Design References links DS items (Figma frames, email templates).
+
+Avoid:
+- Implementation steps ("use useMutation", "add /api/invite route") — those belong on Task subissues or are inferred.
+- More than 5 AC — if you need more, split the Story or move some to CC on Tasks.
+- Bare "should work" AC — every AC names the input *and* the observable outcome.
+
+Title convention:
+  [Parent #<epic>] <English> — <French>
+  e.g. [Parent #251] Invite teammate to workspace — Inviter un coéquipier dans un espace de travail
+
+Domain chosen: Story under the workspace-isolation Epic (see examples/epic.md).
+Content is fictional — import the pattern, not the facts.
+-->
+
+## Objective
+
+Implement FR-422 — Invite teammate to workspace. A workspace owner or admin can invite a new member by email, choose their role (`admin` / `member` / `viewer`), and the invitee receives an email link
+that joins them to the workspace on first accept.
+
+## Context (User Requirements)
+
+- **UR-33** — As a workspace owner, I want to invite teammates by email so I can onboard my clients without creating accounts for them myself.
+- **UR-34** — As an invited user, I want to accept an invite with one click (already logged in) or create my account on accept (new user).
+
+## Scope (Functional Requirements)
+
+- **FR-422** — Invite teammate to workspace
+
+## Acceptance Criteria
+
+| AC  | Criterion                                                                                                                                                  | Source FR |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| AC1 | Owner/admin submits email + role via `POST /workspace/members/invite`; a row is created in `WorkspaceInvite` with status `pending` and a 7-day expiry      | FR-422    |
+| AC2 | An email is sent via the Mailer module containing a signed link `/invite/:token`; the token is a single-use JWT                                            | FR-422    |
+| AC3 | Accepting while logged in as the invitee's email: creates a `WorkspaceMember` with the assigned role, marks invite `accepted`, redirects to workspace home | FR-422    |
+| AC4 | Accepting while logged out: redirects to `/register?invite=<token>`; on registration completion, membership is created atomically                          | FR-422    |
+| AC5 | Roles `member` and `viewer` cannot invite; attempting returns `403 Forbidden` with code `E_ROLE_INSUFFICIENT`                                              | FR-422    |
+
+## Specifications
+
+- FR page: [FR-422 — Invite teammate](https://www.notion.so/fr-422)
+- Epic spec: [Multi-tenant workspace isolation](https://www.notion.so/epic-workspace-isolation-abc)
+
+## Dependencies
+
+- #184 Auth v2 — JWT service required for signed invite tokens
+- Mailer module installed (run `sf skill install sf-skill-email` if missing)
+
+## Constraints
+
+- Expired or already-used tokens must return a friendly 410 Gone page, not a 500.
+- Email content respects i18n — render in the invitee's preferred locale if they already exist.
+- No silent role escalation: workspace-scoped role applies only to THIS workspace.
+
+## Design References
+
+- **DS-14** — Invite dialog (Figma frame)
+- **DS-15** — `/invite/:token` accept screen (Figma frame)
+- **DS-16** — Invite email template

--- a/.claude/skills/sf-srs/templates/tickets/examples/task.md
+++ b/.claude/skills/sf-srs/templates/tickets/examples/task.md
@@ -1,0 +1,77 @@
+<!--
+Why this example
+================
+Shows:
+- Objective = the technical deliverable, not a user-facing capability.
+- Context = "why now" — typically duplication, drift, or an upcoming dependency.
+- Scope Included/Excluded is granular — a Task touches a bounded set of files.
+- Completion Criteria = fine-grained contract (each CC ≈ a test you can write).
+- Specifications lists the existing artifacts being modified.
+
+When Task vs Story:
+- Task: refactor, migration, tooling, internal schema change, docs overhaul — no user-observable change.
+- Story: user-facing capability.
+
+Avoid:
+- Turning a Task into a Story by inventing a "user can…" framing to look like feature work.
+- AC tables on a Task (use Completion Criteria).
+- Tasks without a parent — every Task lives under an Epic or is a standalone meta-task.
+
+Title convention:
+  [Parent #<epic-or-story>] <English> — <French>
+  e.g. [Parent #251] Extract shared email validation — Extraire la validation email partagée
+
+Domain chosen: cross-cutting Task under the same workspace-isolation Epic.
+Content is fictional — import the pattern, not the facts.
+-->
+
+## Objective
+
+Extract the email-validation logic duplicated across `auth/register`, `auth/forgot-password`, `users/update-profile`, and the upcoming `workspace/members/invite` into a shared Zod schema at
+`@common/schemas/email.schema.ts`, and migrate the three existing callsites to consume it.
+
+## Context
+
+Today each route re-declares `z.string().email().min(5).max(254)` with slight drift — two callsites forgot `.max(254)`, one uses `.toLowerCase()`, one doesn't. This caused #268 (inconsistent rejection
+of uppercase emails on forgot-password vs register). The upcoming workspace-invite work (FR-422) adds a 4th callsite — we lock the schema before that lands to stop the drift.
+
+## Scope
+
+### Included
+
+- Create `src/common/schemas/email.schema.ts` with the canonical Zod schema.
+- Migrate the 3 existing callsites to import from it.
+- Replace inline DTO validators in the corresponding `*.dto.ts` files.
+- Update unit tests to assert the shared schema is referenced (not reimplemented).
+
+### Excluded
+
+- Password schema extraction (separate Task — scope creep).
+- Frontend-side email validation (React Hook Form resolvers, owned elsewhere).
+- Changing the rules themselves (lowercase, max length) — lift-and-shift only.
+
+## Completion Criteria
+
+| CC  | Criterion                                                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| CC1 | `src/common/schemas/email.schema.ts` exports `emailSchema` with `.toLowerCase().email().max(254)` — matches the pre-existing register-route behavior exactly |
+| CC2 | All 3 callsites import `emailSchema`; no inline `z.string().email()` remains in those files (grep returns 0 hits)                                            |
+| CC3 | Existing unit + e2e tests for the 3 routes still pass unchanged                                                                                              |
+| CC4 | New unit test `email.schema.spec.ts` covers: lowercase normalization, > 254 chars rejected, invalid format rejected, trimmed whitespace rejected             |
+| CC5 | No behavior change observable in the 3 routes (confirmed via existing e2e tests)                                                                             |
+
+## Specifications
+
+- Duplicated today at: `src/modules/auth/dto/register.dto.ts:12`, `src/modules/users/dto/update-profile.dto.ts:8`, `src/modules/auth/dto/forgot-password.dto.ts:5`
+- Zod v4 guidance: prefer `.email()` over custom regex
+- Shared schemas convention: `docs/architecture-modules.md#shared-schemas`
+
+## Dependencies
+
+- None — lift-and-shift only.
+
+## Constraints
+
+- Must land before FR-422 (workspace invite) to avoid introducing a 4th drifted callsite.
+- API response error message stays `"Invalid email"` — no user-visible change.
+- Backward compatibility: callsites that previously accepted uppercase emails keep silently normalizing.

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -33,9 +33,13 @@ sf-srs/
 ├── templates/
 │   ├── pages/                       # Epic + FR page templates → PageContent   (SUB-3)
 │   └── tickets/                     # GitHub ticket templates (srs-epic, srs-story)   (SUB-4)
+│       └── examples/                # archetypal filled-in examples: epic.md | story.md | task.md | issue.md
 └── scripts/
     └── srs-cli.sh                   # single orchestrator entrypoint           (SUB-14.3)
 ```
+
+**Authoring guidance** — before drafting a real Epic / Story / Task / Issue body, skim the matching file under [`templates/tickets/examples/`](templates/tickets/examples/). Each example opens with a
+`<!-- Why this example -->` preamble that names the pattern it illustrates and the anti-patterns to avoid. Import the **pattern** (tone, section density, title convention), not the fictional content.
 
 TS entrypoints dispatched by `srs-cli.sh` live alongside the CLI source under `src/srs/bin/` (dogfood) or `node_modules/saasfoundry-cli/dist/srs/bin/` (shipped). They are **not** duplicated inside the
 skill folder — the skill is a thin orchestrator.

--- a/scaffolds/skills-templates/sf-srs/templates/tickets/README.md
+++ b/scaffolds/skills-templates/sf-srs/templates/tickets/README.md
@@ -116,6 +116,18 @@ Produced by `renderIssueTicketBody(spec)` in this order:
 5. `## Impact / Severity` — optional `**Severity:**` line + free-form impact paragraph (placeholder when both are empty)
 6. `## Evidence / Data` — bulleted list (placeholder when empty)
 
+## Authoring examples
+
+Filled-in archetypal examples — one per type — live under `examples/` and are the reference a writing agent should skim before drafting a real ticket:
+
+- [`examples/epic.md`](examples/epic.md) — Epic archetype (multi-tenant workspace isolation)
+- [`examples/story.md`](examples/story.md) — Story archetype (invite teammate to workspace)
+- [`examples/task.md`](examples/task.md) — Task archetype (extract shared email validation)
+- [`examples/issue.md`](examples/issue.md) — Issue archetype (register form swallows `E_EMAIL_TAKEN`)
+
+Each example opens with a `<!-- Why this example -->` preamble that names the pattern it illustrates and the anti-patterns to avoid. Import the **pattern** (tone, density, section usage, title
+convention) — not the literal content, which is fictional.
+
 ## Adding a new ticket body variant
 
 Add a new template under `src/builders/srs/templates/tickets/`, export it from `src/srs/index.ts`, and wire the subtask spawner (SUB-9) to dispatch to the right renderer based on the parent label

--- a/scaffolds/skills-templates/sf-srs/templates/tickets/examples/epic.md
+++ b/scaffolds/skills-templates/sf-srs/templates/tickets/examples/epic.md
@@ -1,0 +1,92 @@
+<!--
+Why this example
+================
+Shows:
+- Goal = outcome ("user can..."), not a task list.
+- Business Value = 2-3 lines, stakeholder-facing, no implementation words.
+- Scope Included ≈ one bullet per child Story. Excluded names what's tempting to grab but deferred.
+- FR table lists ALL children so reviewers can jump.
+- Definition of Done = verifiable facts, not intents.
+
+Avoid:
+- AC tables at Epic level (those live on Stories).
+- Step-by-step tech tasks (live on Stories/Tasks).
+- Deadlines in prose — put them in Dates.
+
+Title convention:
+  [EPIC] <English> — <French>
+  e.g. [EPIC] Multi-tenant workspace isolation — Cloisonnement multi-tenant des espaces de travail
+
+Domain chosen: multi-tenant workspace isolation for a generated SaaS app.
+Content is fictional — import the pattern, not the facts.
+-->
+
+## Goal
+
+When this Epic is Done, a user can create, switch between, and delete workspaces that are fully isolated — data, members, billing, and audit logs scoped to the active workspace, and no API route leaks
+cross-workspace data.
+
+## Business Value
+
+Agencies and holdings need clean client separation without managing multiple accounts. Today we force them onto a second subscription or accept data comingling — both cost ARR. This Epic unblocks the
+agency pricing tier and removes the top Q1 churn reason.
+
+## Dates
+
+- Target start: 2026-05-05
+- Target end: 2026-06-20
+- Milestone: workspace switcher on staging by 2026-06-01 (agency-tier sales demo)
+
+## Scope
+
+### Included
+
+- Workspace CRUD with role-gated actions
+- Invite teammates scoped to a workspace, per-workspace roles
+- Workspace switcher in the app shell, persisted per session
+- Row-level isolation via a Prisma tenancy middleware
+- Audit log entries tagged with emitting workspace
+
+### Excluded
+
+- Per-workspace custom domains (separate Epic)
+- Cross-workspace analytics (breaks isolation guarantee)
+- Workspace-to-workspace data import
+- Stripe subscription split per workspace (v1 stays one-per-user)
+
+## Specifications
+
+Main spec: [Epic SRS page — Multi-tenant workspace isolation](https://www.notion.so/epic-workspace-isolation-abc)
+
+| FR     | Title                     | Page                                   |
+| ------ | ------------------------- | -------------------------------------- |
+| FR-421 | Create & rename workspace | [FR-421](https://www.notion.so/fr-421) |
+| FR-422 | Invite teammate           | [FR-422](https://www.notion.so/fr-422) |
+| FR-423 | Switch active workspace   | [FR-423](https://www.notion.so/fr-423) |
+| FR-424 | Prisma tenancy middleware | [FR-424](https://www.notion.so/fr-424) |
+| FR-425 | Per-workspace audit log   | [FR-425](https://www.notion.so/fr-425) |
+
+## Dependencies
+
+- #184 Auth v2 refresh-token rotation — session context must carry `workspaceId`
+- Stripe agency-tier SKU (owner: @finance)
+
+## Constraints
+
+- All new API routes go through the tenancy middleware. No opt-out.
+- Existing single-workspace users are migrated transparently (default workspace auto-created).
+- No breaking changes to public API contracts — `workspaceId` inferred from session, not URL.
+
+## Assumptions
+
+- Stripe subscription stays at user level; workspace is a billing attribute.
+- Audit log volume growth (~2×) fits within existing Loki retention budget.
+- Frontend role-gating reuses `<RequireRole>`; no new permission primitive.
+
+## Definition of Done
+
+- All 5 child FRs are `Done`.
+- `pnpm test:e2e tenancy` passes: 0 cross-workspace data leaks.
+- Staging migration executed; 100% of existing users have a default workspace.
+- `docs/workspace-isolation.md` exists and is linked from getting-started.
+- Agency-tier sales demo signed off by @sales.

--- a/scaffolds/skills-templates/sf-srs/templates/tickets/examples/issue.md
+++ b/scaffolds/skills-templates/sf-srs/templates/tickets/examples/issue.md
@@ -1,0 +1,66 @@
+<!--
+Why this example
+================
+Shows:
+- Behavior observed = FACTS only (what actually happens). No hypothesis, no diagnosis.
+- Expected Behavior = what should happen, with the contract it violates.
+- Steps to Reproduce = deterministic, numbered, copy-pasteable.
+- Environment = versions, browsers, OS that matter for this bug.
+- Impact / Severity = concrete user/business effect; severity explicit.
+- Evidence = screenshots, logs, request IDs, code pointers — things reviewers can click or grep.
+
+Avoid:
+- Mixing diagnosis into "Behavior observed" (save it for a comment).
+- Vague "doesn't work" — every bug has a precise input + a precise wrong output.
+- Missing severity — unassigned means triage will be wrong.
+
+Title convention:
+  [BUG] <English> — <French>
+  e.g. [BUG] Register form swallows E_EMAIL_TAKEN — Le formulaire d'inscription masque E_EMAIL_TAKEN
+
+Domain chosen: a front-end bug in the generated app — archetypal "handler ignores response code".
+Content is fictional — import the pattern, not the facts.
+-->
+
+## Behavior observed
+
+When a registered user submits the `/register` form with an email that already exists, the backend responds `409 Conflict` with `{ code: "E_EMAIL_TAKEN" }` — but the React form shows a generic
+`"Something went wrong, please retry"` banner. The specific code is never rendered, no `email` field error appears under the input, and the password field is cleared.
+
+## Expected Behavior
+
+Per the API contract (`docs/api-errors.md`) and the design of `RegisterForm`, a `409 / E_EMAIL_TAKEN` response must:
+
+1. Surface an inline error _on the email field_: "This email is already registered — sign in instead?" with a link to `/login`.
+2. NOT trigger the generic banner.
+3. Keep the password field value intact so the user doesn't have to re-type.
+
+## Steps to Reproduce / Trigger Conditions
+
+1. Register normally with `user@example.com` / `P@ssw0rd!` — succeeds.
+2. Log out.
+3. Navigate to `/register`.
+4. Submit the same email `user@example.com` with any password.
+5. Observe: generic banner appears at the top; email field has no error; password field is cleared.
+
+## Environment / Configuration
+
+- Affected: `web/` frontend, `RegisterForm.tsx`
+- Versions: `saasfoundry-cli 1.0.0-beta`, generated project uses `react 19.0.0`, `react-hook-form 7.56.0`
+- Browsers: reproduced on Chrome 133, Firefox 138, Safari 18 — not browser-specific
+- API: NestJS backend, `409 / E_EMAIL_TAKEN` confirmed correct via `curl`
+
+## Impact / Severity
+
+**Severity: medium**
+
+- Returning users can't tell why they can't register — 18% bounce rate on duplicate-email attempts (Amplitude funnel, last 30 days).
+- Support tickets tagged `signup-confused` up 40% since the 1.0.0-beta cut.
+- No data integrity or security risk — purely UX.
+
+## Evidence / Data
+
+- Request ID: `req_7f3a91c2` (Sentry: [event 445812](https://sentry.io/fake/445812))
+- Screenshot comparing the generic banner vs. expected inline error: [attachment](https://img.example.com/issue-evidence.png)
+- Network tab capture confirming backend response: `{"statusCode": 409, "code": "E_EMAIL_TAKEN", "message": "Email already in use"}`
+- Relevant code: `src/components/auth/RegisterForm.tsx:87` — the `onError` handler only checks `err.response.status` and ignores `err.response.data.code`.

--- a/scaffolds/skills-templates/sf-srs/templates/tickets/examples/story.md
+++ b/scaffolds/skills-templates/sf-srs/templates/tickets/examples/story.md
@@ -1,0 +1,69 @@
+<!--
+Why this example
+================
+Shows:
+- Objective = one sentence, user-facing, names the *capability* and the FR it implements.
+- Context (User Requirements) links UR items so reviewers see the user narrative.
+- Scope (Functional Requirements) = usually one FR; if two, that's a smell.
+- Acceptance Criteria table: 3-5 rows, each testable, each traced back to a Source FR.
+- Specifications points to the FR SRS page and the parent Epic spec.
+- Design References links DS items (Figma frames, email templates).
+
+Avoid:
+- Implementation steps ("use useMutation", "add /api/invite route") — those belong on Task subissues or are inferred.
+- More than 5 AC — if you need more, split the Story or move some to CC on Tasks.
+- Bare "should work" AC — every AC names the input *and* the observable outcome.
+
+Title convention:
+  [Parent #<epic>] <English> — <French>
+  e.g. [Parent #251] Invite teammate to workspace — Inviter un coéquipier dans un espace de travail
+
+Domain chosen: Story under the workspace-isolation Epic (see examples/epic.md).
+Content is fictional — import the pattern, not the facts.
+-->
+
+## Objective
+
+Implement FR-422 — Invite teammate to workspace. A workspace owner or admin can invite a new member by email, choose their role (`admin` / `member` / `viewer`), and the invitee receives an email link
+that joins them to the workspace on first accept.
+
+## Context (User Requirements)
+
+- **UR-33** — As a workspace owner, I want to invite teammates by email so I can onboard my clients without creating accounts for them myself.
+- **UR-34** — As an invited user, I want to accept an invite with one click (already logged in) or create my account on accept (new user).
+
+## Scope (Functional Requirements)
+
+- **FR-422** — Invite teammate to workspace
+
+## Acceptance Criteria
+
+| AC  | Criterion                                                                                                                                                  | Source FR |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| AC1 | Owner/admin submits email + role via `POST /workspace/members/invite`; a row is created in `WorkspaceInvite` with status `pending` and a 7-day expiry      | FR-422    |
+| AC2 | An email is sent via the Mailer module containing a signed link `/invite/:token`; the token is a single-use JWT                                            | FR-422    |
+| AC3 | Accepting while logged in as the invitee's email: creates a `WorkspaceMember` with the assigned role, marks invite `accepted`, redirects to workspace home | FR-422    |
+| AC4 | Accepting while logged out: redirects to `/register?invite=<token>`; on registration completion, membership is created atomically                          | FR-422    |
+| AC5 | Roles `member` and `viewer` cannot invite; attempting returns `403 Forbidden` with code `E_ROLE_INSUFFICIENT`                                              | FR-422    |
+
+## Specifications
+
+- FR page: [FR-422 — Invite teammate](https://www.notion.so/fr-422)
+- Epic spec: [Multi-tenant workspace isolation](https://www.notion.so/epic-workspace-isolation-abc)
+
+## Dependencies
+
+- #184 Auth v2 — JWT service required for signed invite tokens
+- Mailer module installed (run `sf skill install sf-skill-email` if missing)
+
+## Constraints
+
+- Expired or already-used tokens must return a friendly 410 Gone page, not a 500.
+- Email content respects i18n — render in the invitee's preferred locale if they already exist.
+- No silent role escalation: workspace-scoped role applies only to THIS workspace.
+
+## Design References
+
+- **DS-14** — Invite dialog (Figma frame)
+- **DS-15** — `/invite/:token` accept screen (Figma frame)
+- **DS-16** — Invite email template

--- a/scaffolds/skills-templates/sf-srs/templates/tickets/examples/task.md
+++ b/scaffolds/skills-templates/sf-srs/templates/tickets/examples/task.md
@@ -1,0 +1,77 @@
+<!--
+Why this example
+================
+Shows:
+- Objective = the technical deliverable, not a user-facing capability.
+- Context = "why now" — typically duplication, drift, or an upcoming dependency.
+- Scope Included/Excluded is granular — a Task touches a bounded set of files.
+- Completion Criteria = fine-grained contract (each CC ≈ a test you can write).
+- Specifications lists the existing artifacts being modified.
+
+When Task vs Story:
+- Task: refactor, migration, tooling, internal schema change, docs overhaul — no user-observable change.
+- Story: user-facing capability.
+
+Avoid:
+- Turning a Task into a Story by inventing a "user can…" framing to look like feature work.
+- AC tables on a Task (use Completion Criteria).
+- Tasks without a parent — every Task lives under an Epic or is a standalone meta-task.
+
+Title convention:
+  [Parent #<epic-or-story>] <English> — <French>
+  e.g. [Parent #251] Extract shared email validation — Extraire la validation email partagée
+
+Domain chosen: cross-cutting Task under the same workspace-isolation Epic.
+Content is fictional — import the pattern, not the facts.
+-->
+
+## Objective
+
+Extract the email-validation logic duplicated across `auth/register`, `auth/forgot-password`, `users/update-profile`, and the upcoming `workspace/members/invite` into a shared Zod schema at
+`@common/schemas/email.schema.ts`, and migrate the three existing callsites to consume it.
+
+## Context
+
+Today each route re-declares `z.string().email().min(5).max(254)` with slight drift — two callsites forgot `.max(254)`, one uses `.toLowerCase()`, one doesn't. This caused #268 (inconsistent rejection
+of uppercase emails on forgot-password vs register). The upcoming workspace-invite work (FR-422) adds a 4th callsite — we lock the schema before that lands to stop the drift.
+
+## Scope
+
+### Included
+
+- Create `src/common/schemas/email.schema.ts` with the canonical Zod schema.
+- Migrate the 3 existing callsites to import from it.
+- Replace inline DTO validators in the corresponding `*.dto.ts` files.
+- Update unit tests to assert the shared schema is referenced (not reimplemented).
+
+### Excluded
+
+- Password schema extraction (separate Task — scope creep).
+- Frontend-side email validation (React Hook Form resolvers, owned elsewhere).
+- Changing the rules themselves (lowercase, max length) — lift-and-shift only.
+
+## Completion Criteria
+
+| CC  | Criterion                                                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| CC1 | `src/common/schemas/email.schema.ts` exports `emailSchema` with `.toLowerCase().email().max(254)` — matches the pre-existing register-route behavior exactly |
+| CC2 | All 3 callsites import `emailSchema`; no inline `z.string().email()` remains in those files (grep returns 0 hits)                                            |
+| CC3 | Existing unit + e2e tests for the 3 routes still pass unchanged                                                                                              |
+| CC4 | New unit test `email.schema.spec.ts` covers: lowercase normalization, > 254 chars rejected, invalid format rejected, trimmed whitespace rejected             |
+| CC5 | No behavior change observable in the 3 routes (confirmed via existing e2e tests)                                                                             |
+
+## Specifications
+
+- Duplicated today at: `src/modules/auth/dto/register.dto.ts:12`, `src/modules/users/dto/update-profile.dto.ts:8`, `src/modules/auth/dto/forgot-password.dto.ts:5`
+- Zod v4 guidance: prefer `.email()` over custom regex
+- Shared schemas convention: `docs/architecture-modules.md#shared-schemas`
+
+## Dependencies
+
+- None — lift-and-shift only.
+
+## Constraints
+
+- Must land before FR-422 (workspace invite) to avoid introducing a 4th drifted callsite.
+- API response error message stays `"Invalid email"` — no user-visible change.
+- Backward compatibility: callsites that previously accepted uppercase emails keep silently normalizing.

--- a/src/__tests__/unit/skill/tool-skill-drift.spec.ts
+++ b/src/__tests__/unit/skill/tool-skill-drift.spec.ts
@@ -66,6 +66,26 @@ const PAIRS = [
     name: 'sf-srs templates/examples/example-epic.md',
     inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/examples/example-epic.md'),
     scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/examples/example-epic.md')
+  },
+  {
+    name: 'sf-srs templates/tickets/examples/epic.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/tickets/examples/epic.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/tickets/examples/epic.md')
+  },
+  {
+    name: 'sf-srs templates/tickets/examples/story.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/tickets/examples/story.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/tickets/examples/story.md')
+  },
+  {
+    name: 'sf-srs templates/tickets/examples/task.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/tickets/examples/task.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/tickets/examples/task.md')
+  },
+  {
+    name: 'sf-srs templates/tickets/examples/issue.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/tickets/examples/issue.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/tickets/examples/issue.md')
   }
 ]
 

--- a/src/__tests__/unit/srs/templates/examples-contract.spec.ts
+++ b/src/__tests__/unit/srs/templates/examples-contract.spec.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const EXAMPLES_DIR = path.resolve(__dirname, '../../../../../.claude/skills/sf-srs/templates/tickets/examples')
+
+type ExampleContract = {
+  file: string
+  requiredHeadings: string[]
+  forbiddenHeadings?: string[]
+}
+
+const CONTRACTS: ExampleContract[] = [
+  {
+    file: 'epic.md',
+    requiredHeadings: ['## Goal', '## Business Value', '## Dates', '## Scope', '## Specifications', '## Dependencies', '## Constraints', '## Assumptions', '## Definition of Done'],
+    forbiddenHeadings: ['## Acceptance Criteria', '## Completion Criteria', '## Behavior observed']
+  },
+  {
+    file: 'story.md',
+    requiredHeadings: [
+      '## Objective',
+      '## Context (User Requirements)',
+      '## Scope (Functional Requirements)',
+      '## Acceptance Criteria',
+      '## Specifications',
+      '## Dependencies',
+      '## Constraints',
+      '## Design References'
+    ],
+    forbiddenHeadings: ['## Goal', '## Completion Criteria', '## Behavior observed', '## Definition of Done']
+  },
+  {
+    file: 'task.md',
+    requiredHeadings: ['## Objective', '## Context', '## Scope', '## Completion Criteria', '## Specifications', '## Dependencies', '## Constraints'],
+    forbiddenHeadings: ['## Goal', '## Acceptance Criteria', '## Behavior observed', '## Design References', '## Definition of Done']
+  },
+  {
+    file: 'issue.md',
+    requiredHeadings: ['## Behavior observed', '## Expected Behavior', '## Steps to Reproduce / Trigger Conditions', '## Environment / Configuration', '## Impact / Severity', '## Evidence / Data'],
+    forbiddenHeadings: ['## Goal', '## Objective', '## Acceptance Criteria', '## Completion Criteria', '## Definition of Done']
+  }
+]
+
+describe('sf-srs ticket authoring examples — contract', () => {
+  for (const contract of CONTRACTS) {
+    describe(contract.file, () => {
+      const body = readFileSync(path.join(EXAMPLES_DIR, contract.file), 'utf8')
+
+      it('opens with a "Why this example" HTML-comment preamble', () => {
+        expect(body.startsWith('<!--')).toBe(true)
+        expect(body).toMatch(/Why this example/)
+        expect(body).toMatch(/-->/)
+      })
+
+      it.each(contract.requiredHeadings)('contains required heading %s', (heading) => {
+        expect(body).toContain(heading)
+      })
+
+      if (contract.forbiddenHeadings) {
+        it.each(contract.forbiddenHeadings)('does not contain off-contract heading %s', (heading) => {
+          const lines = body.split('\n')
+          expect(lines.includes(heading)).toBe(false)
+        })
+      }
+
+      it('headings appear in the documented order', () => {
+        const found = (body.match(/^## .+$/gm) ?? []).filter((h) => contract.requiredHeadings.includes(h))
+        expect(found).toEqual(contract.requiredHeadings)
+      })
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- Adds 4 filled-in archetypal examples under `.claude/skills/sf-srs/templates/tickets/examples/{epic,story,task,issue}.md` — specimens the AI can skim before drafting a real ticket, so it imports the pattern (tone, density, section usage, title convention) instead of guessing from the empty skeleton.
- Each file opens with a `<!-- Why this example -->` preamble naming the pattern it illustrates and the anti-patterns to avoid. Content is fictional (workspace-isolation domain for epic/story/task, register-form bug for issue) — the examples teach structure, not facts.
- Byte-identical copies under `scaffolds/skills-templates/sf-srs/templates/tickets/examples/`, enforced by `tool-skill-drift.spec.ts` (+4 pairs).
- `examples-contract.spec.ts` asserts each example opens with the preamble and contains the mandatory section headers of its type in the documented order.
- References added from `sf-srs/SKILL.md` directory map and `templates/tickets/README.md`.

**Review loop**: drafts were posted on [#271](https://github.com/DiamondForgeFr/SaaSFoundry/issues/271) and approved by the user for a first pass before implementation (CC5).

## Test plan

- [x] `npm run test:pre-commit` — 1114 passed, 0 failed
- [x] `examples-contract.spec.ts` green (preamble present, headings ordered, off-contract headings excluded)
- [x] Drift guard green (4 new pairs + README.md + SKILL.md byte-identity)
- [ ] Reviewer skims each example and confirms the pattern it teaches is accurate / useful

Closes #271. Depends on #254 (Task/Issue renderer sections are referenced by the `task.md` + `issue.md` contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)