### PR TITLE
docs(#252): document three-level ticket hierarchy in sf-workflow

### DIFF
--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -19,6 +19,67 @@ This workflow adapts its rigor based on ticket complexity:
 
 **Key principle:** Higher complexity = more rigor (analysis depth, planning detail, adversarial review, test coverage)
 
+## 🧩 Ticket Hierarchy (Epic / Story / Task / Subtask)
+
+SaaSFoundry uses a **three-level ticket hierarchy**. Each level has a distinct role, lifecycle, and deliverable. Agents must treat them differently — notably, **Epics produce no PR** and **Subtasks
+are not GitHub issues**.
+
+```
+(Epic)          optional grouper — SRS feature, bug batch, transverse refactor
+ └─ Story/Task  mandatory — branch + PR + full workflow
+     └─ Subtask optional — commit of the action plan on the Story/Task branch
+```
+
+### Level 1 — Epic (optional parent)
+
+- **Role**: groups related Stories/Tasks under a single banner (an SRS feature, a batch of related bugs, a transverse refactor).
+- **Deliverable**: **NONE directly**. An Epic has no branch, no commit, no PR.
+- **GitHub**: a regular issue, labeled `type: epic`, with child Story/Task issues linked via `addSubIssue`.
+- **Status**: **derived from children** (see derivation rule below).
+
+### Level 2 — Story or Task (the unit of work)
+
+**Both Story and Task are first-class GitHub issues with full workflow lifecycle** (branch + PR + statuses). They differ only in the **nature of their acceptance**:
+
+|                   | Story                            | Task                                              |
+| ----------------- | -------------------------------- | ------------------------------------------------- |
+| **Delivers**      | user-observable value            | a technical action                                |
+| **Acceptance**    | Acceptance Criteria (functional) | Completion Criteria (action-oriented)             |
+| **Typical title** | _"User can export CSV"_          | _"Extract CSV generator into `shared/exporters`"_ |
+| **Template**      | `story.tpl.ts`                   | `task.tpl.ts`                                     |
+
+**Issue** is a variant of Task for bugs — same lifecycle, different body template (`issue.tpl.ts`: Behavior Observed / Expected / Repro / Environment / Impact / Evidence).
+
+### Level 3 — Subtask (commit on the Story/Task branch)
+
+- **Role**: step in the action plan of a Story/Task, executed as a commit on the Story/Task branch.
+- **Deliverable**: a single commit. **Never a GitHub issue, never a branch, never a PR.**
+- **Granularity**: one coherent change that could be reverted atomically.
+
+**⚠️ Naming warning**: the `create-subtask` CLI misnames its output — it actually creates **Story tickets** (GitHub issues linked to a parent). True Subtasks (commits) are not tracked on the board.
+
+### Epic status derivation rule
+
+An Epic's board status is **computed from its children**, not set directly:
+
+- **Ascent** (Backlog → Ready → In progress) : Epic = **earliest** status among children. As soon as the first child advances, the Epic moves with it.
+- **Descent** (In progress → AI testing → Human testing → In review → Done) : Epic = **latest** status among children. Epic reaches a later stage only when **all** children have reached it.
+
+**Consequence**: an Epic in `Done` is a strong contract — every child has been merged.
+
+**Example**: Epic #100 has 3 children #101, #102, #103.
+
+- #101 → `In progress`, #102 → `Ready`, #103 → `Backlog` ⇒ Epic `Ready` (earliest: Ready is reached when any child crosses Ready)
+- #101 → `Done`, #102 → `In review`, #103 → `In review` ⇒ Epic `In review` (latest: Epic moves to Done only when #102 and #103 also reach Done)
+
+### Where each level flows
+
+| Level                    | Backlog  | Ready    | In progress            | AI testing | Human testing | In review | Done     |
+| ------------------------ | -------- | -------- | ---------------------- | ---------- | ------------- | --------- | -------- |
+| **Epic**                 | derived  | derived  | derived                | derived    | derived       | derived   | derived  |
+| **Story / Task / Issue** | explicit | explicit | explicit               | explicit   | explicit      | explicit  | explicit |
+| **Subtask (commit)**     | —        | —        | commit lands on branch | —          | —             | —         | —        |
+
 ## How to use this skill
 
 **FIRST TIME on a ticket:**
@@ -202,10 +263,12 @@ see its `## Conversational eval hook (SUB-10)` section. This skill only referenc
 2. **NEVER skip steps** described in a status
 3. **NEVER move to the next status** without meeting all exit conditions
 4. **ASK if uncertain** - don't assume or guess
-5. **CLOSE SUBTASKS AS YOU GO** — after a subtask's commit lands, immediately run `workflow-cli.sh update-status <sub> Done` and verify `gh issue view <sub> --json state` prints `CLOSED` before
-   starting the next one. Never batch closures at the end of the parent ticket.
-6. **GATE PARENT TRANSITIONS ON OPEN CHILDREN** — before any parent transition (`AI Testing` → `Human Testing` → `In Review` → `Done`), run `gh issue list --state open --search "parent #<N>"` and
-   ensure it returns empty. If not, go back and close the children first.
+5. **CLOSE CHILD TICKETS AS THEY LAND** — after a child Story/Task/Issue's final commit is merged, immediately run `workflow-cli.sh update-status <child> Done` and verify
+   `gh issue view <child> --json state` prints `CLOSED` before starting the next sibling. Never batch closures at the end of an Epic. (A true Subtask is a commit, not a GitHub issue — there is no
+   status to close.)
+6. **EPIC STATUS FOLLOWS CHILDREN** — an Epic's board status is derived from its children (earliest for ascent Backlog→In progress, latest for descent In progress→Done — see "Epic status derivation
+   rule" above). Before advancing an Epic, run `gh issue list --state open --search "parent #<N>"` and confirm the target status is consistent with all children. An Epic can only reach `Done` when
+   every child is `Done`.
 7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only
    override is an explicit developer request to pause.
 8. **TICKETS FROM SRS** — when `tools.srs.backend` is set in `.saasfoundry.json`, Story sub-tickets under an SRS Epic must be spawned from the canonical FR pages, not hand-written. Use

--- a/.claude/skills/sf-workflow/statuses/3-in-progress.md
+++ b/.claude/skills/sf-workflow/statuses/3-in-progress.md
@@ -6,6 +6,13 @@
 > stop here and read `statuses/3a-ai-drafting.md`. Drive the ticket with `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> <phase>`
 > (`ai-draft | human-review | spawning | done`), never with `update-status` — the SRS guard blocks code-path transitions for those tickets.
 
+> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
+>
+> - **Epic** (`type: epic`): no branch, no commit, no PR. Skip sections 1, 4, 5 below. Only create children (Stories/Tasks/Issues) via `create-subtask` and coordinate them. Epic status is **derived**
+>   from children — it reaches `In progress` automatically when the first child does.
+> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — branch + commits + PR.
+> - **Subtask**: a commit on the current Story/Task branch, not a GitHub issue. Don't create one via `create-subtask`.
+
 ## When to Enter This Status
 
 - After receiving assignment or confirmation from developer in Ready

--- a/.claude/skills/sf-workflow/statuses/5-human-testing.md
+++ b/.claude/skills/sf-workflow/statuses/5-human-testing.md
@@ -2,6 +2,12 @@
 
 **ROLE**: Manual validation by human developer
 
+> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
+>
+> - **Epic** (`type: epic`): no manual test, no PR. Epic status is **derived** from children — it only enters `Human testing` when the last child does, and only leaves once every child has moved on.
+>   Do not run the steps below for an Epic.
+> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — the developer validates, then E2E tests are written before moving to `In review`.
+
 ## When to Enter This Status
 
 - After successfully passing all tests in AI Testing

--- a/.claude/skills/sf-workflow/statuses/6-in-review.md
+++ b/.claude/skills/sf-workflow/statuses/6-in-review.md
@@ -2,6 +2,12 @@
 
 **ROLE**: Code review + mandatory green CI
 
+> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
+>
+> - **Epic** (`type: epic`): **NEVER produces a PR**. Do not open one, do not attach one. Epic status in `In review` is purely **derived** from children — it reflects that every child Story/Task/Issue
+>   is itself in `In review` (one open PR per child). Skip all steps below.
+> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — each one opens its own PR.
+
 ## When to Enter This Status
 
 - After validation in Human Testing

--- a/.claude/skills/sf-workflow/statuses/7-done.md
+++ b/.claude/skills/sf-workflow/statuses/7-done.md
@@ -2,6 +2,12 @@
 
 **ROLE**: Finalization and cleanup after merge
 
+> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
+>
+> - **Epic** (`type: epic`): `Done` is **derived** — the Epic only moves to `Done` when **every** child Story/Task/Issue has been merged and closed. No branch to delete, no cleanup to run. Just close
+>   the Epic issue once the last child reaches `Done`.
+> - **Story / Task / Issue** (`type: story | task | issue`): full cleanup flow below — after the PR is merged by the developer.
+
 ## When to Enter This Status
 
 - PR has been merged by the developer

--- a/scaffolds/skills-templates/workflow/SKILL.md
+++ b/scaffolds/skills-templates/workflow/SKILL.md
@@ -18,6 +18,66 @@ This workflow adapts its rigor based on ticket complexity:
 
 **Key principle:** Higher complexity = more rigor (analysis depth, planning detail, adversarial review, test coverage)
 
+## 🧩 Ticket Hierarchy (Epic / Story / Task / Subtask)
+
+{{WORKFLOW_NAME}} uses a **three-level ticket hierarchy**. Each level has a distinct role, lifecycle, and deliverable. Agents must treat them differently — notably, **Epics produce no PR** and **Subtasks are not {{TOOL}} issues**.
+
+```
+(Epic)          optional grouper — SRS feature, bug batch, transverse refactor
+ └─ Story/Task  mandatory — branch + PR + full workflow
+     └─ Subtask optional — commit of the action plan on the Story/Task branch
+```
+
+### Level 1 — Epic (optional parent)
+
+- **Role**: groups related Stories/Tasks under a single banner (an SRS feature, a batch of related bugs, a transverse refactor).
+- **Deliverable**: **NONE directly**. An Epic has no branch, no commit, no PR.
+- **Tracking**: a regular ticket, labeled `type: epic`, with child Story/Task tickets linked as sub-issues.
+- **Status**: **derived from children** (see derivation rule below).
+
+### Level 2 — Story or Task (the unit of work)
+
+**Both Story and Task are first-class tickets with full workflow lifecycle** (branch + PR + statuses). They differ only in the **nature of their acceptance**:
+
+|                   | Story                            | Task                                              |
+| ----------------- | -------------------------------- | ------------------------------------------------- |
+| **Delivers**      | user-observable value            | a technical action                                |
+| **Acceptance**    | Acceptance Criteria (functional) | Completion Criteria (action-oriented)             |
+| **Typical title** | _"User can export CSV"_          | _"Extract CSV generator into `shared/exporters`"_ |
+| **Template**      | `story.tpl.ts`                   | `task.tpl.ts`                                     |
+
+**Issue** is a variant of Task for bugs — same lifecycle, different body template (`issue.tpl.ts`: Behavior Observed / Expected / Repro / Environment / Impact / Evidence).
+
+### Level 3 — Subtask (commit on the Story/Task branch)
+
+- **Role**: step in the action plan of a Story/Task, executed as a commit on the Story/Task branch.
+- **Deliverable**: a single commit. **Never a ticket, never a branch, never a PR.**
+- **Granularity**: one coherent change that could be reverted atomically.
+
+**⚠️ Naming warning**: the `create-subtask` CLI misnames its output — it actually creates **Story tickets** (linked to a parent). True Subtasks (commits) are not tracked on the board.
+
+### Epic status derivation rule
+
+An Epic's board status is **computed from its children**, not set directly:
+
+- **Ascent** (Backlog → Ready → In progress) : Epic = **earliest** status among children. As soon as the first child advances, the Epic moves with it.
+- **Descent** (In progress → AI testing → Human testing → In review → Done) : Epic = **latest** status among children. Epic reaches a later stage only when **all** children have reached it.
+
+**Consequence**: an Epic in `Done` is a strong contract — every child has been merged.
+
+**Example**: Epic #100 has 3 children #101, #102, #103.
+
+- #101 → `In progress`, #102 → `Ready`, #103 → `Backlog` ⇒ Epic `Ready` (earliest: Ready is reached when any child crosses Ready)
+- #101 → `Done`, #102 → `In review`, #103 → `In review` ⇒ Epic `In review` (latest: Epic moves to Done only when #102 and #103 also reach Done)
+
+### Where each level flows
+
+| Level                    | Backlog  | Ready    | In progress            | AI testing | Human testing | In review | Done     |
+| ------------------------ | -------- | -------- | ---------------------- | ---------- | ------------- | --------- | -------- |
+| **Epic**                 | derived  | derived  | derived                | derived    | derived       | derived   | derived  |
+| **Story / Task / Issue** | explicit | explicit | explicit               | explicit   | explicit      | explicit  | explicit |
+| **Subtask (commit)**     | —        | —        | commit lands on branch | —          | —             | —         | —        |
+
 ## How to use this skill
 
 **FIRST TIME on a ticket:**
@@ -190,8 +250,8 @@ When `tools.srs.enabled = true`, Claude must interject during conversation turns
 2. **NEVER skip steps** described in a status
 3. **NEVER move to the next status** without meeting all exit conditions
 4. **ASK if uncertain** - don't assume or guess
-5. **CLOSE SUBTASKS AS YOU GO** — after a subtask's commit lands, immediately run `workflow-cli.sh update-status <sub> Done` and verify `gh issue view <sub> --json state` prints `CLOSED` before starting the next one. Never batch closures at the end of the parent ticket.
-6. **GATE PARENT TRANSITIONS ON OPEN CHILDREN** — before any parent transition (`AI Testing` → `Human Testing` → `In Review` → `Done`), run `gh issue list --state open --search "parent #<N>"` and ensure it returns empty. If not, go back and close the children first.
+5. **CLOSE CHILD TICKETS AS THEY LAND** — after a child Story/Task/Issue's final commit is merged, immediately run `workflow-cli.sh update-status <child> Done` and verify `gh issue view <child> --json state` prints `CLOSED` before starting the next sibling. Never batch closures at the end of an Epic. (A true Subtask is a commit, not a {{TOOL}} issue — there is no status to close.)
+6. **EPIC STATUS FOLLOWS CHILDREN** — an Epic's board status is derived from its children (earliest for ascent Backlog→In progress, latest for descent In progress→Done — see "Epic status derivation rule" above). Before advancing an Epic, run `gh issue list --state open --search "parent #<N>"` and confirm the target status is consistent with all children. An Epic can only reach `Done` when every child is `Done`.
 7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only override is an explicit developer request to pause.
 8. **TICKETS FROM SRS** — when `tools.srs.backend` is set in `.saasfoundry.json`, Story sub-tickets under an SRS Epic must be spawned from the canonical FR pages, not hand-written. Use `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody`. The `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section above. The escape hatch exists for meta tickets (SRS refactors, tooling) but must never be used to duplicate an FR that already has a page.
 

--- a/scaffolds/skills-templates/workflow/statuses/1-backlog.md
+++ b/scaffolds/skills-templates/workflow/statuses/1-backlog.md
@@ -11,20 +11,23 @@
 
 ### 1. READ THE TICKET THOROUGHLY
 
-### 2. DETECT COMPLEXITY
+### 2. DETECT COMPLEXITY → THEN WRITE IT TO THE TICKET
 
-**Run complexity detection:**
+**Step 2a — Run complexity detection (suggestion only):**
+
 ```bash
 .claude/skills/sf-workflow/scripts/detect-complexity.sh {ticket-number}
 ```
 
 **AI will suggest complexity based on:**
+
 - Number of files potentially impacted
 - Keywords (auth, payment, security → complex)
 - Risk assessment
 - Similar historical tickets
 
 **Complexity levels:**
+
 - 🐛 **bug** - Quick fix, minimal ceremony
 - 🟢 **low** - Simple task (oneshot-style)
 - 🟡 **medium** - Standard feature (apex-free-style)
@@ -32,19 +35,28 @@
 
 **Developer ALWAYS has final say - ask for confirmation or adjustment.**
 
+**Step 2b — Persist the complexity label on the ticket:**
+
+```bash
+.claude/skills/sf-workflow/workflow-cli.sh retag {ticket-number} {level}
+# level: bug | low | medium | complex
+```
+
+⚠️ **This step is mandatory, not optional.** `detect-complexity.sh` only prints a suggestion; it does NOT write anything to the ticket. Without the `complexity: *` label, the ticket cannot leave
+Backlog — `update-status` is hard-gated on it (see errors to avoid below).
+
 ### 3. ANALYZE (adaptive based on complexity)
 
 **Check if analysis required:**
+
 ```bash
 .claude/skills/sf-workflow/scripts/analyze.sh {ticket-number} {complexity}
 ```
 
-**Skipped for:** 🐛 bug
-**Minimal for:** 🟢 low (2-3 files, no agents)
-**Standard for:** 🟡 medium (2-4 parallel agents)
-**Deep for:** 🔴 complex (6-10 parallel agents)
+**Skipped for:** 🐛 bug **Minimal for:** 🟢 low (2-3 files, no agents) **Standard for:** 🟡 medium (2-4 parallel agents) **Deep for:** 🔴 complex (6-10 parallel agents)
 
 **Purpose:**
+
 - Gather context about what currently exists
 - Find patterns, files, utilities
 - Identify dependencies and risks
@@ -55,22 +67,22 @@
 ### 4. PLAN (adaptive based on complexity)
 
 **Check if planning required:**
+
 ```bash
 .claude/skills/sf-workflow/scripts/plan.sh {ticket-number} {complexity}
 ```
 
-**Skipped for:** 🐛 bug
-**Minimal for:** 🟢 low (mental plan)
-**Detailed for:** 🟡 medium (file-by-file, requires approval)
-**Comprehensive for:** 🔴 complex (with dependencies, requires approval)
+**Skipped for:** 🐛 bug **Minimal for:** 🟢 low (mental plan) **Detailed for:** 🟡 medium (file-by-file, requires approval) **Comprehensive for:** 🔴 complex (with dependencies, requires approval)
 
 **Purpose:**
+
 - Create implementation strategy
 - Map acceptance criteria to file changes
 - Identify execution order
 - Plan edge cases and error handling
 
 **If approval required:**
+
 - Post plan as ticket comment
 - Wait for explicit approval before proceeding
 
@@ -93,12 +105,13 @@
 ### 7. WAIT FOR VALIDATION
 
 **Two approvals needed:**
+
 1. **Specs complete** → can move to Ready
 2. **Prioritization** (from Ready) → can move to In Progress
 
 ## Exit Conditions
 
-- Complexity tag is set
+- **Complexity label persisted on the ticket** (run `get-complexity {ticket}` and confirm it prints one of `bug|low|medium|complex`, not `(none)`)
 - Analysis complete (if required by complexity)
 - Plan approved (if required by complexity)
 - Developer validates that specs are complete
@@ -111,8 +124,5 @@
 
 ## Errors to Avoid
 
-❌ NEVER create a branch from Backlog
-❌ NEVER start coding before Ready
-❌ NEVER skip complexity detection
-❌ NEVER skip analysis/planning if required by complexity
-❌ NEVER move to Ready without developer validation
+❌ NEVER create a branch from Backlog ❌ NEVER start coding before Ready ❌ NEVER skip complexity detection ❌ NEVER leave Backlog without persisting the `complexity: *` label via `retag` (suggestion
+≠ label; `update-status` is hard-gated) ❌ NEVER skip analysis/planning if required by complexity ❌ NEVER move to Ready without developer validation

--- a/scaffolds/skills-templates/workflow/statuses/2-ready.md
+++ b/scaffolds/skills-templates/workflow/statuses/2-ready.md
@@ -26,5 +26,4 @@
 
 ## Errors to Avoid
 
-❌ NEVER take a Ready ticket without confirmation
-❌ NEVER skip higher priority tickets
+❌ NEVER take a Ready ticket without confirmation ❌ NEVER skip higher priority tickets

--- a/scaffolds/skills-templates/workflow/statuses/3-in-progress.md
+++ b/scaffolds/skills-templates/workflow/statuses/3-in-progress.md
@@ -6,6 +6,13 @@
 > stop here and read `statuses/3a-ai-drafting.md`. Drive the ticket with `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> <phase>`
 > (`ai-draft | human-review | spawning | done`), never with `update-status` — the SRS guard blocks code-path transitions for those tickets.
 
+> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
+>
+> - **Epic** (`type: epic`): no branch, no commit, no PR. Skip sections 1, 4, 5 below. Only create children (Stories/Tasks/Issues) via `create-subtask` and coordinate them. Epic status is **derived**
+>   from children — it reaches `In progress` automatically when the first child does.
+> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — branch + commits + PR.
+> - **Subtask**: a commit on the current Story/Task branch, not a GitHub issue. Don't create one via `create-subtask`.
+
 ## When to Enter This Status
 
 - After receiving assignment or confirmation from developer in Ready

--- a/scaffolds/skills-templates/workflow/statuses/4-ai-testing.md
+++ b/scaffolds/skills-templates/workflow/statuses/4-ai-testing.md
@@ -18,27 +18,32 @@ Before doing anything else, verify the parent has no open children:
 gh issue list --state open --search "parent #{N}"
 ```
 
-Must return `[]`. If any children are still open, **go back to In Progress**, close them (`workflow-cli.sh update-status <sub> Done`), and only then proceed to step 1. This gate exists because merged-code-with-open-issues creates an inconsistent board state.
+Must return `[]`. If any children are still open, **go back to In Progress**, close them (`workflow-cli.sh update-status <sub> Done`), and only then proceed to step 1. This gate exists because
+merged-code-with-open-issues creates an inconsistent board state.
 
 ### 1. GENERATE THE TEST PLAN
+
 - Analyze all changes (git diff, commits)
 - Create a complete test plan with:
-  * Setup instructions
-  * Scenarios to test (all nominal cases + edge cases)
-  * Expected results for each scenario
-  * Non-regression tests
+  - Setup instructions
+  - Scenarios to test (all nominal cases + edge cases)
+  - Expected results for each scenario
+  - Non-regression tests
 - Post the test plan as ticket comment
 
 ### 2. MOVE TICKET TO "AI TESTING"
+
 - Update status in the project management tool
 
 ### 3. RUN AUTOMATED TESTS
+
 - Build: `npm run build`
 - Lint: `npm run lint`
 - Type-check: `npm run type-check` (if TypeScript)
 - Unit tests: `npm run test:unit`
 
 ### 4. EXECUTE TEST PLAN MANUALLY
+
 - Follow EACH step of the test plan
 - Verify implemented functionalities
 - Test edge cases
@@ -46,6 +51,7 @@ Must return `[]`. If any children are still open, **go back to In Progress**, cl
 - Document any problems found
 
 ### 5. IF PROBLEMS ARE FOUND:
+
 - a. Document problems in ticket comment
 - b. Fix the problems
 - c. Commit corrections
@@ -61,6 +67,7 @@ Must return `[]`. If any children are still open, **go back to In Progress**, cl
 ```
 
 **Run adversarial code review:**
+
 - Launch 3 parallel review agents
 - Security analysis (OWASP top 10)
 - Logic flaws detection
@@ -69,6 +76,7 @@ Must return `[]`. If any children are still open, **go back to In Progress**, cl
 - Fix Critical/High findings immediately
 
 **If findings found:**
+
 - Fix Real issues
 - Commit corrections
 - Push
@@ -78,6 +86,7 @@ Must return `[]`. If any children are still open, **go back to In Progress**, cl
 **Follow the guidance from examine.sh.**
 
 ### 7. IF ALL TESTS PASS (and examine complete if complex):
+
 - a. Create test report summary as comment
 - b. If examine was run: include findings summary
 - c. Commit and push final corrections (if any)
@@ -98,10 +107,5 @@ Must return `[]`. If any children are still open, **go back to In Progress**, cl
 
 ## Errors to Avoid
 
-❌ NEVER move to Human Testing with failing tests
-❌ NEVER skip test plan steps
-❌ NEVER say "it should work" - RUN the tests
-❌ If a test fails, do NOT move to Human Testing, FIX it first
-❌ NEVER skip examine phase for complex tickets
-❌ NEVER ignore Critical/High security findings
-❌ NEVER enter AI Testing while subtasks are still OPEN on GitHub — close them first (step 0 gate)
+❌ NEVER move to Human Testing with failing tests ❌ NEVER skip test plan steps ❌ NEVER say "it should work" - RUN the tests ❌ If a test fails, do NOT move to Human Testing, FIX it first ❌ NEVER
+skip examine phase for complex tickets ❌ NEVER ignore Critical/High security findings ❌ NEVER enter AI Testing while subtasks are still OPEN on GitHub — close them first (step 0 gate)

--- a/scaffolds/skills-templates/workflow/statuses/5-human-testing.md
+++ b/scaffolds/skills-templates/workflow/statuses/5-human-testing.md
@@ -2,6 +2,12 @@
 
 **ROLE**: Manual validation by human developer
 
+> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
+>
+> - **Epic** (`type: epic`): no manual test, no PR. Epic status is **derived** from children — it only enters `Human testing` when the last child does, and only leaves once every child has moved on.
+>   Do not run the steps below for an Epic.
+> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — the developer validates, then E2E tests are written before moving to `In review`.
+
 ## When to Enter This Status
 
 - After successfully passing all tests in AI Testing
@@ -10,10 +16,12 @@
 ## Mandatory Actions
 
 ### 1. WAIT FOR DEVELOPER VALIDATION
+
 - Do nothing, the developer will manually test
 - Stay available to answer questions
 
 ### 2. IF DEVELOPER FINDS BUGS:
+
 - a. Read developer comments carefully
 - b. Add comment summarizing what will be fixed
 - c. Fix identified problems
@@ -25,27 +33,32 @@
 **NOW, BEFORE CREATING THE PR:**
 
 #### a. CREATE NON-REGRESSION TESTS:
+
 - If complex/critical feature: create E2E tests (Playwright)
 - If edge case bug fix: create unit non-regression test
 - If simple feature (typo, doc, CSS): no E2E tests needed
 
 #### b. COVER IN TESTS:
+
 - Main user scenarios validated
 - Identified and fixed edge cases
 - Critical workflows
 
 #### c. VERIFY TESTS LOCALLY:
+
 - Run created E2E tests: `npm run test:e2e`
 - Ensure they all pass ✅
 
 #### d. COMMIT AND PUSH:
 
 **Read commit format from config:**
+
 ```bash
 COMMIT_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.pattern')
 ```
 
 **Commit and push:**
+
 - `git add .`
 - `git commit -m "test(#{N}): add E2E tests for {feature}"`
   - Follow pattern from config: `${COMMIT_PATTERN}`
@@ -54,6 +67,7 @@ COMMIT_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.pattern')
 - `git push`
 
 #### e. TRANSPARENCY:
+
 - If you decide NOT to create E2E tests, inform the developer
 - Explain why (e.g., "no E2E tests as simple CSS fix")
 
@@ -70,11 +84,8 @@ COMMIT_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.pattern')
 
 ## Common Sense Rule
 
-✅ Create tests if: new feature, edge case bug fix, user workflow, critical code
-❌ No need if: typo, docs, simple CSS refactor, experimental feature
+✅ Create tests if: new feature, edge case bug fix, user workflow, critical code ❌ No need if: typo, docs, simple CSS refactor, experimental feature
 
 ## Errors to Avoid
 
-❌ NEVER create tests BEFORE developer validation
-❌ NEVER create PR without creating non-regression tests
-❌ NEVER push failing tests
+❌ NEVER create tests BEFORE developer validation ❌ NEVER create PR without creating non-regression tests ❌ NEVER push failing tests

--- a/scaffolds/skills-templates/workflow/statuses/6-in-review.md
+++ b/scaffolds/skills-templates/workflow/statuses/6-in-review.md
@@ -2,6 +2,12 @@
 
 **ROLE**: Code review + mandatory green CI
 
+> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
+>
+> - **Epic** (`type: epic`): **NEVER produces a PR**. Do not open one, do not attach one. Epic status in `In review` is purely **derived** from children — it reflects that every child Story/Task/Issue
+>   is itself in `In review` (one open PR per child). Skip all steps below.
+> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — each one opens its own PR.
+
 ## When to Enter This Status
 
 - After validation in Human Testing
@@ -11,19 +17,22 @@
 ## Mandatory Actions
 
 ### 1. CREATE THE PULL REQUEST
+
 - Title: Repeat the ticket title
 - Description:
-  * Link to the ticket
-  * Summary of changes
-  * Test plan (copy from ticket)
-  * List of created tests (unit + E2E)
+  - Link to the ticket
+  - Summary of changes
+  - Test plan (copy from ticket)
+  - List of created tests (unit + E2E)
 - Assign configured reviewers
 - Link PR to ticket
 
 ### 2. MOVE TICKET TO "IN REVIEW"
+
 - Update status in the project management tool
 
 ### 3. MONITOR CI
+
 - CI will run the full test suite (unit + E2E)
 - If CI is red 🔴:
   - a. Analyze error logs
@@ -32,11 +41,13 @@
   - d. Wait for CI to turn green ✅
 
 ### 4. MONITOR REVIEW COMMENTS
+
 - Read all reviewer comments
 - Answer questions
 - Implement requested changes
 
 ### 5. IF REVIEWER REQUESTS ADDITIONAL TESTS:
+
 - a. Create requested tests (unit or E2E)
 - b. Run tests locally to verify
 - c. Commit and push tests
@@ -44,6 +55,7 @@
 - e. Resolve conversation when done
 
 ### 6. WAIT FOR APPROVAL AND GREEN CI
+
 - ⚠️ MANDATORY CONDITION: CI must be green ✅
 - Developer will merge ONLY if CI is green
 - Do nothing until merged
@@ -60,6 +72,4 @@
 
 ## Errors to Avoid
 
-❌ NEVER ask developer to merge with red CI
-❌ NEVER ignore test failures in CI
-❌ NEVER merge yourself (unless explicit instruction)
+❌ NEVER ask developer to merge with red CI ❌ NEVER ignore test failures in CI ❌ NEVER merge yourself (unless explicit instruction)

--- a/scaffolds/skills-templates/workflow/statuses/7-done.md
+++ b/scaffolds/skills-templates/workflow/statuses/7-done.md
@@ -2,6 +2,12 @@
 
 **ROLE**: Finalization and cleanup after merge
 
+> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
+>
+> - **Epic** (`type: epic`): `Done` is **derived** — the Epic only moves to `Done` when **every** child Story/Task/Issue has been merged and closed. No branch to delete, no cleanup to run. Just close
+>   the Epic issue once the last child reaches `Done`.
+> - **Story / Task / Issue** (`type: story | task | issue`): full cleanup flow below — after the PR is merged by the developer.
+
 ## When to Enter This Status
 
 - PR has been merged by the developer
@@ -10,16 +16,19 @@
 ## Mandatory Actions
 
 ### 1. MOVE TICKET TO "DONE"
+
 - Update status in the project management tool
 
 ### 2. LOCAL BRANCH CLEANUP
 
 **Read working branch from config:**
+
 ```bash
 WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
 ```
 
 **Cleanup:**
+
 1. `git checkout ${WORKING_BRANCH}`
 2. `git pull origin ${WORKING_BRANCH} --rebase`
 3. `git branch -d {feature-branch}`
@@ -27,6 +36,7 @@ WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
 ### 3. IF OTHER BRANCHES ARE IN PROGRESS
 
 **Rebase other branches with updated working branch:**
+
 ```bash
 WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
 
@@ -49,5 +59,4 @@ N/A (end of cycle)
 
 ## Errors to Avoid
 
-❌ NEVER move to Done before actual merge
-❌ NEVER forget to rebase other in-progress branches
+❌ NEVER move to Done before actual merge ❌ NEVER forget to rebase other in-progress branches

--- a/src/__tests__/unit/skill/tool-skill-drift.spec.ts
+++ b/src/__tests__/unit/skill/tool-skill-drift.spec.ts
@@ -22,6 +22,26 @@ const PAIRS = [
     inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/workflow-cli.sh'),
     scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/workflow-cli.sh')
   },
+  // Note: sf-workflow/SKILL.md intentionally NOT in this drift set.
+  // The scaffolded copy carries `{{WORKFLOW_NAME}}` / `{{TOOL}}` / `{{STATUSES_LIST}}`
+  // placeholders that `workflow-skill.installer.ts` substitutes at project creation —
+  // byte-identity would break those substitutions. Status files (`statuses/*.md`) have
+  // no placeholders so they stay byte-identical.
+  {
+    name: 'sf-workflow statuses/1-backlog.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/1-backlog.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/statuses/1-backlog.md')
+  },
+  {
+    name: 'sf-workflow statuses/2-ready.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/2-ready.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/statuses/2-ready.md')
+  },
+  {
+    name: 'sf-workflow statuses/3-in-progress.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/3-in-progress.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/statuses/3-in-progress.md')
+  },
   {
     name: 'sf-workflow statuses/3a-ai-drafting.md',
     inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/3a-ai-drafting.md'),
@@ -36,6 +56,26 @@ const PAIRS = [
     name: 'sf-workflow statuses/3c-spawning.md',
     inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/3c-spawning.md'),
     scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/statuses/3c-spawning.md')
+  },
+  {
+    name: 'sf-workflow statuses/4-ai-testing.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/4-ai-testing.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/statuses/4-ai-testing.md')
+  },
+  {
+    name: 'sf-workflow statuses/5-human-testing.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/5-human-testing.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/statuses/5-human-testing.md')
+  },
+  {
+    name: 'sf-workflow statuses/6-in-review.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/6-in-review.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/statuses/6-in-review.md')
+  },
+  {
+    name: 'sf-workflow statuses/7-done.md',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-workflow/statuses/7-done.md'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/workflow/statuses/7-done.md')
   },
   {
     name: 'sf-srs SKILL.md',


### PR DESCRIPTION
## Summary

- Adds "🧩 Ticket Hierarchy" section to `.claude/skills/sf-workflow/SKILL.md` with the 3-level diagram (Epic / Story-Task-Issue / Subtask) and the status-derivation rule (earliest for ascent, latest for descent).
- Adds `> **ℹ️ Ticket type matters**` callouts on statuses `3-in-progress.md`, `5-human-testing.md`, `6-in-review.md`, `7-done.md` to distinguish Epic vs Story/Task/Issue vs Subtask handling.
- Byte-identical mirror in `scaffolds/skills-templates/workflow/` so new projects inherit the same guidance.

Closes #252.

## Test plan

- [x] `npm run test:pre-commit` — 1040 passed (91 suites across 4 projects)
- [x] `tool-skill-drift` — 19 pairs byte-identical
- [x] `test:pre-push` Docker scenarios (multirepo-minimal + monorepo-minimal)
- [x] Manual: hierarchy section renders between "Auto-trigger keywords" and "Complexity-Based Adaptive Workflow"
- [x] Manual: scaffold copy keeps `{{WORKFLOW_NAME}}` / `{{TOOL}}` / `{{STATUSES_LIST}}` placeholders intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)