### PR TITLE
refactor(#279): sf-workflow determinism — status YAML + --json parsing

### DIFF
--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -522,14 +522,28 @@ cmd_create_subtask() {
 
 # ───────────────────────────────────────────────────────────────────────────
 # Command: status — read status from Projects V2 board
+# Flags:
+#   --json   Emit machine-parseable JSON: {"ticket","title","state","status","labels"}
+#            Used by workflow-cli.sh get_current_status so parsing stays deterministic
+#            (no more grep|awk on human-oriented output).
 # ───────────────────────────────────────────────────────────────────────────
 
 cmd_status() {
-  if [ "$#" -lt 1 ]; then
-    echo "Usage: $0 status <ticket-number>" >&2
+  local ticket=""
+  local json_mode=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) json_mode=1; shift ;;
+      *)
+        if [ -z "$ticket" ]; then ticket=$1; fi
+        shift
+        ;;
+    esac
+  done
+  if [ -z "$ticket" ]; then
+    echo "Usage: $0 status <ticket-number> [--json]" >&2
     exit 1
   fi
-  local ticket=$1
   load_config
   if [ -z "$PROJECT_OWNER" ] || [ -z "$PROJECT_NUMBER" ]; then
     echo -e "${RED}Error: workflow.projectUrl is missing or malformed in .saasfoundry.json${NC}" >&2
@@ -544,8 +558,27 @@ cmd_status() {
   status=$(echo "$info" | jq -r '.status // ""')
 
   if [ -z "$title" ]; then
+    if [ "$json_mode" = 1 ]; then
+      jq -n --argjson t "$ticket" '{ticket:$t, title:"", state:"", status:"", labels:[], error:"not-found"}'
+      exit 1
+    fi
     echo -e "${RED}Error: Could not find issue #${ticket}${NC}" >&2
     exit 1
+  fi
+
+  if [ "$json_mode" = 1 ]; then
+    # Labels fetched via gh (separate call — cheap) so the JSON payload carries
+    # everything callers need without a second round-trip.
+    local labels_json
+    labels_json=$(gh issue view "$ticket" --json labels --jq '[.labels[].name]' 2>/dev/null || echo '[]')
+    jq -n \
+      --argjson t "$ticket" \
+      --arg title "$title" \
+      --arg state "$state" \
+      --arg status "$status" \
+      --argjson labels "${labels_json:-[]}" \
+      '{ticket:$t, title:$title, state:$state, status:$status, labels:$labels}'
+    return 0
   fi
 
   echo -e "${BLUE}Issue #${ticket}: ${title}${NC}"

--- a/.claude/skills/sf-workflow/statuses/1-backlog.md
+++ b/.claude/skills/sf-workflow/statuses/1-backlog.md
@@ -1,128 +1,53 @@
+---
+status: Backlog
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - Developer mentions a new idea / feature / bug
+  - No branch created, no code written
+mandatory_actions:
+  - Read the ticket thoroughly
+  - Detect complexity — suggestion only
+  - Persist complexity label — MANDATORY (update-status is hard-gated on it)
+  - Analyze (adaptive — skip=bug, minimal=low, 2–4 agents=medium, 6–10 agents=complex)
+  - Plan (adaptive — skip=bug, mental=low, file-by-file=medium, comprehensive=complex)
+  - Challenge the specs (edge cases, questions, alternatives)
+  - Wait for developer validation
+exit_conditions:
+  - Complexity label present — `get-complexity <ticket>` prints one of `bug|low|medium|complex` (not `(none)`)
+  - Analysis complete (if required by complexity)
+  - Plan approved (if required by complexity)
+  - Developer validates specs are complete
+next_status: Ready
+---
+
 # STATUS: Backlog
 
-**ROLE**: Preparation phase - detect complexity, analyze context, plan implementation, validate specs
+Preparation phase — detect complexity, analyze context, plan implementation, validate specs.
 
-## When to Enter This Status
+## Action checklist
 
-- When a new idea/feature/bug is mentioned by the developer
-- Before any branch creation or code writing
+- [ ] **Detect complexity (suggestion):** `.claude/skills/sf-workflow/scripts/detect-complexity.sh <ticket>`
+- [ ] **Persist the label (mandatory):** `.claude/skills/sf-workflow/workflow-cli.sh retag <ticket> <bug|low|medium|complex>`
+- [ ] **Analyze:** `.claude/skills/sf-workflow/scripts/analyze.sh <ticket> <complexity>` — follow its guidance
+- [ ] **Plan:** `.claude/skills/sf-workflow/scripts/plan.sh <ticket> <complexity>` — follow its guidance; post + await approval for medium/complex
+- [ ] **Challenge the specs** — ask questions, surface edge cases, propose alternatives
+- [ ] **Ticket completeness** — problem/need, acceptance criteria, technical context, complexity tag
+- [ ] **Wait for validation** — two approvals: (1) specs complete → Ready, (2) prioritization → In Progress
 
-## Mandatory Actions (in order)
+## Complexity cheat sheet
 
-### 1. READ THE TICKET THOROUGHLY
+| Level      | Analyze     | Plan                     |
+| ---------- | ----------- | ------------------------ |
+| 🐛 bug     | skip        | skip                     |
+| 🟢 low     | minimal     | mental                   |
+| 🟡 medium  | 2–4 agents  | file-by-file + approval  |
+| 🔴 complex | 6–10 agents | comprehensive + approval |
 
-### 2. DETECT COMPLEXITY → THEN WRITE IT TO THE TICKET
+## Errors to avoid
 
-**Step 2a — Run complexity detection (suggestion only):**
-
-```bash
-.claude/skills/sf-workflow/scripts/detect-complexity.sh {ticket-number}
-```
-
-**AI will suggest complexity based on:**
-
-- Number of files potentially impacted
-- Keywords (auth, payment, security → complex)
-- Risk assessment
-- Similar historical tickets
-
-**Complexity levels:**
-
-- 🐛 **bug** - Quick fix, minimal ceremony
-- 🟢 **low** - Simple task (oneshot-style)
-- 🟡 **medium** - Standard feature (apex-free-style)
-- 🔴 **complex** - Critical feature (full apex with review)
-
-**Developer ALWAYS has final say - ask for confirmation or adjustment.**
-
-**Step 2b — Persist the complexity label on the ticket:**
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh retag {ticket-number} {level}
-# level: bug | low | medium | complex
-```
-
-⚠️ **This step is mandatory, not optional.** `detect-complexity.sh` only prints a suggestion; it does NOT write anything to the ticket. Without the `complexity: *` label, the ticket cannot leave
-Backlog — `update-status` is hard-gated on it (see errors to avoid below).
-
-### 3. ANALYZE (adaptive based on complexity)
-
-**Check if analysis required:**
-
-```bash
-.claude/skills/sf-workflow/scripts/analyze.sh {ticket-number} {complexity}
-```
-
-**Skipped for:** 🐛 bug **Minimal for:** 🟢 low (2-3 files, no agents) **Standard for:** 🟡 medium (2-4 parallel agents) **Deep for:** 🔴 complex (6-10 parallel agents)
-
-**Purpose:**
-
-- Gather context about what currently exists
-- Find patterns, files, utilities
-- Identify dependencies and risks
-- Document findings with file:line references
-
-**Follow the guidance from analyze.sh for your complexity level.**
-
-### 4. PLAN (adaptive based on complexity)
-
-**Check if planning required:**
-
-```bash
-.claude/skills/sf-workflow/scripts/plan.sh {ticket-number} {complexity}
-```
-
-**Skipped for:** 🐛 bug **Minimal for:** 🟢 low (mental plan) **Detailed for:** 🟡 medium (file-by-file, requires approval) **Comprehensive for:** 🔴 complex (with dependencies, requires approval)
-
-**Purpose:**
-
-- Create implementation strategy
-- Map acceptance criteria to file changes
-- Identify execution order
-- Plan edge cases and error handling
-
-**If approval required:**
-
-- Post plan as ticket comment
-- Wait for explicit approval before proceeding
-
-**Follow the guidance from plan.sh for your complexity level.**
-
-### 5. CHALLENGE THE SPECS
-
-- Ask questions to clarify requirements
-- Identify uncovered edge cases
-- Suggest improvements or alternatives
-- Validate the proposed technical approach
-
-### 6. ENSURE TICKET CONTAINS
-
-- Clear description of the problem/need
-- Precise acceptance criteria
-- Sufficient technical context
-- Complexity tag set
-
-### 7. WAIT FOR VALIDATION
-
-**Two approvals needed:**
-
-1. **Specs complete** → can move to Ready
-2. **Prioritization** (from Ready) → can move to In Progress
-
-## Exit Conditions
-
-- **Complexity label persisted on the ticket** (run `get-complexity {ticket}` and confirm it prints one of `bug|low|medium|complex`, not `(none)`)
-- Analysis complete (if required by complexity)
-- Plan approved (if required by complexity)
-- Developer validates that specs are complete
-- All identified edge cases are documented
-- Technical approach is validated
-
-## Next Status
-
-**Ready**
-
-## Errors to Avoid
-
-❌ NEVER create a branch from Backlog ❌ NEVER start coding before Ready ❌ NEVER skip complexity detection ❌ NEVER leave Backlog without persisting the `complexity: *` label via `retag` (suggestion
-≠ label; `update-status` is hard-gated) ❌ NEVER skip analysis/planning if required by complexity ❌ NEVER move to Ready without developer validation
+- Creating a branch from Backlog
+- Starting to code before Ready
+- Skipping complexity detection
+- Leaving Backlog without the `complexity: *` label (suggestion ≠ label; hard-gated)
+- Skipping analysis/planning when required
+- Moving to Ready without developer validation

--- a/.claude/skills/sf-workflow/statuses/2-ready.md
+++ b/.claude/skills/sf-workflow/statuses/2-ready.md
@@ -1,29 +1,29 @@
+---
+status: Ready
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - Specs validated in Backlog
+  - Priority assigned
+  - All blockers resolved
+mandatory_actions:
+  - Wait for explicit ticket assignment or confirmation
+  - Do nothing else — this status is a waiting queue
+exit_conditions:
+  - Developer asks you to work on this ticket
+  - OR you receive confirmation to take it
+next_status: In Progress
+---
+
 # STATUS: Ready
 
-**ROLE**: Queue of validated tickets ready for development
+Queue of validated tickets waiting for pickup.
 
-## When to Enter This Status
+## Action checklist
 
-- After specs validation in Backlog
-- Ticket has assigned priority
-- All blockers are resolved
+- [ ] Wait for the developer to assign the ticket (or ask which one to take, respecting priority order)
+- [ ] Otherwise, do nothing — Ready is strictly a waiting queue
 
-## Mandatory Actions
+## Errors to avoid
 
-1. **Wait for ticket assignment:**
-   - Either the developer explicitly assigns the ticket to you
-   - Or you ask which ticket to take (prioritize by order)
-2. **Do nothing else** - this status is a waiting queue
-
-## Exit Conditions
-
-- Developer asks you to work on this ticket
-- OR you get confirmation to take the ticket
-
-## Next Status
-
-**In Progress**
-
-## Errors to Avoid
-
-❌ NEVER take a Ready ticket without confirmation ❌ NEVER skip higher priority tickets
+- Taking a Ready ticket without confirmation
+- Skipping higher-priority tickets

--- a/.claude/skills/sf-workflow/statuses/3-in-progress.md
+++ b/.claude/skills/sf-workflow/statuses/3-in-progress.md
@@ -1,119 +1,55 @@
+---
+status: In Progress
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - Assignment or confirmation received in Ready
+  - Ready to start development
+mandatory_actions:
+  - Create feature branch from `workingBranch` (manifest)
+  - Move ticket to `In Progress`
+  - Create subtasks as real GitHub issues (NOT checkboxes)
+  - Develop iteratively — one commit per subtask, close each subtask right after its commit lands
+  - Final validation — build, lint, unit tests green
+  - Push branch
+exit_conditions:
+  - All subtasks closed on GitHub (`gh issue list --state open --search "parent #<N>"` returns [])
+  - Code compiles without errors
+  - Lint passes
+  - Existing tests pass
+  - Branch pushed to remote
+next_status: AI Testing
+---
+
 # STATUS: In Progress
 
-**ROLE**: Active development with subtasks creation and regular commits
+Active development — subtask creation, iterative commits, final validation.
 
-> **⚠️ SRS drafting tickets** (labelled `srs:drafting | srs:update | srs:new`) do **NOT** follow the steps below. They stay in the `In progress` board column but flow through a separate lifecycle —
-> stop here and read `statuses/3a-ai-drafting.md`. Drive the ticket with `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> <phase>`
-> (`ai-draft | human-review | spawning | done`), never with `update-status` — the SRS guard blocks code-path transitions for those tickets.
+## Ticket type
 
-> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
->
-> - **Epic** (`type: epic`): no branch, no commit, no PR. Skip sections 1, 4, 5 below. Only create children (Stories/Tasks/Issues) via `create-subtask` and coordinate them. Epic status is **derived**
->   from children — it reaches `In progress` automatically when the first child does.
-> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — branch + commits + PR.
-> - **Subtask**: a commit on the current Story/Task branch, not a GitHub issue. Don't create one via `create-subtask`.
+- **Epic** (`type: epic`): no branch, no commit, no PR. Skip "Branch + develop" + "Final validation" below. Only create children via `create-subtask` and coordinate. Epic status is **derived** — moves
+  to `In progress` automatically when the first child does.
+- **Story / Task / Issue**: full flow below.
+- **Subtask**: a commit on the current branch, not a GitHub issue. Do not use `create-subtask`.
 
-## When to Enter This Status
+## SRS drafting tickets (`srs:drafting | srs:update | srs:new`)
 
-- After receiving assignment or confirmation from developer in Ready
-- Ready to start development
+These stay in the `In progress` board column but flow through a **separate lifecycle** — see `statuses/3a-ai-drafting.md`. Drive with
+`workflow-cli.sh transition-drafting <ticket> <ai-draft|human-review|spawning|done>`. Never use `update-status` — the SRS guard blocks code-path transitions.
 
-## Mandatory Actions (in this order)
+## Action checklist — Story / Task / Issue
 
-### 1. CREATE A BRANCH
+- [ ] **Branch** — from `jq -r '.workflow.workingBranch' .saasfoundry.json`, pattern `jq -r '.workflow.branchNaming.feature'`
+  - `git checkout <workingBranch> && git pull --rebase && git checkout -b feature/<N>-<description>`
+- [ ] **Move ticket to "In Progress"** via `workflow-cli.sh update-status <ticket> "In progress"`
+- [ ] **Create subtasks** — `workflow-cli.sh create-subtask <parent> "<title>" ["<body>"]` (auto-links as sub-issue)
+- [ ] **Per subtask:** move to In Progress → code → commit (`<type>(#<N>): <description>`) → `update-status <sub> Done` → `gh issue view <sub> --json state` must print `CLOSED` (never batch closures)
+- [ ] **All subtasks done:** verify zero open children (`gh issue list --state open --search "parent #<N>"` → `[]`) → `npm run build && npm run lint` → `npm test` → push
 
-**Read configuration from `.saasfoundry.json`:**
+## Errors to avoid
 
-```bash
-WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
-BRANCH_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.branchNaming.feature')
-```
-
-**Create feature branch:**
-
-1. Ensure you're on working branch: `git checkout ${WORKING_BRANCH}`
-2. Pull latest with rebase: `git pull origin ${WORKING_BRANCH} --rebase`
-3. Create feature branch: `git checkout -b feature/{N}-{description}`
-   - Format from config: `${BRANCH_PATTERN}` (e.g., `feature/{N}-{description}`)
-   - Replace `{N}` with ticket number
-   - Replace `{description}` with kebab-case description
-
-### 2. MOVE TICKET TO "IN PROGRESS"
-
-- Update status in the project management tool
-
-### 3. CREATE SUBTASKS
-
-**Break down the ticket into atomic sub-tasks.**
-
-**MUST be real GitHub issues** (NOT checkboxes) linked as sub-issues to the parent.
-
-**Use the helper script:**
-
-```bash
-# Create a subtask linked to parent issue
-.claude/skills/sf-workflow/create-subtask.sh <parent-number> "Subtask title" ["Optional body"]
-
-# Example:
-.claude/skills/sf-workflow/create-subtask.sh 9 "Add validation logic"
-.claude/skills/sf-workflow/create-subtask.sh 9 "Write unit tests" "Cover edge cases"
-```
-
-**The script automatically:**
-
-- Prepends `[Parent #{N}]` to the title
-- Creates the GitHub issue
-- Links it as a sub-issue to the parent (via GraphQL API)
-- Outputs the subtask number and URL
-
-**Track subtask status in project board:**
-
-- Backlog → In Progress (when you start) → Done (when complete)
-
-### 4. DEVELOP ITERATIVELY
-
-**Read commit format from config:**
-
-```bash
-COMMIT_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.pattern')
-COMMIT_TYPES=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.types[]')
-```
-
-For each subtask:
-
-- a. Move subtask to "In Progress"
-- b. Write code for this subtask
-- c. Commit with format from config: `${COMMIT_PATTERN}`
-  - Example: `type(#{N}): description`
-  - Use allowed types: `feat`, `fix`, `docs`, `refactor`, etc.
-  - Replace `#{N}` with ticket number
-- d. **Close the subtask immediately** — run `workflow-cli.sh update-status <sub> Done` and **verify** with `gh issue view <sub> --json state` that it prints `CLOSED`. Never batch closures.
-- e. Move to the next one
-
-### 5. WHEN ALL SUBTASKS ARE DONE
-
-- a. **Verify zero open children** — `gh issue list --state open --search "parent #{N}"` must return an empty array before going further. If not, close the remaining children first.
-- b. Run: `npm run build && npm run lint`
-- c. Fix all lint/build errors
-- d. Run existing tests (unit tests)
-- e. Ensure nothing is broken
-- f. Final commit if corrections needed
-- g. Push the branch: `git push -u origin {branch-name}`
-
-## Exit Conditions
-
-- All subtasks are Done
-- Code compiles without errors
-- Lint passes
-- Existing tests pass
-- Code is pushed to remote
-
-## Next Status
-
-**AI Testing**
-
-## Errors to Avoid
-
-❌ NEVER code without creating a branch first ❌ NEVER mix multiple tickets in the same branch ❌ NEVER move to AI Testing with lint errors ❌ NEVER forget to push before moving to AI Testing ❌ NEVER
-batch subtask closures at the end of the parent — close each one right after its commit lands ❌ NEVER start another ticket while this one is still In Progress / AI Testing / Human Testing / In Review
-(unless the developer explicitly asks you to pause)
+- Coding without creating a branch first
+- Mixing multiple tickets in the same branch
+- Moving to AI Testing with lint/build errors
+- Forgetting to push before AI Testing
+- Batching subtask closures at the end — close each one right after its commit lands
+- Starting another ticket while this one is still In Progress / AI Testing / Human Testing / In Review (unless the developer explicitly asks to pause)

--- a/.claude/skills/sf-workflow/statuses/3a-ai-drafting.md
+++ b/.claude/skills/sf-workflow/statuses/3a-ai-drafting.md
@@ -1,51 +1,36 @@
+---
+status: AI Drafting (drafting lifecycle — board column stays "In progress")
+complexity_profiles: [srs-drafting, srs-update, srs-new]
+entry_conditions:
+  - Ticket board status is `In progress`
+  - Ticket carries exactly one `srs:*` label (`srs:drafting | srs:update | srs:new`)
+  - Brainstorm phase complete — ticket body is sharp enough to draft
+mandatory_actions:
+  - Run the drafter via `transition-drafting <ticket> ai-draft`
+  - Post the backend page URL as a ticket comment
+  - Do not touch the board column — it stays `In progress`
+exit_conditions:
+  - `srs-cli.sh draft` exited 0
+  - Backend page URL posted as ticket comment
+  - No backend error left unresolved
+next_status: Human review (see `statuses/3b-human-review.md`)
+---
+
 # STATUS (drafting lifecycle): AI Drafting
 
-**ROLE**: AI produces the first draft of the SRS page in the configured backend (Notion, Confluence, local markdown, …).
+AI produces the first draft of the SRS page in the configured backend (Notion, Confluence, local markdown, …).
 
-> This status is **not** a board column. It's a _logical sub-phase_ of `In progress` reached exclusively by tickets carrying `srs:drafting | srs:update | srs:new`. The board column stays `In progress`
-> throughout the drafting lifecycle.
+## Action checklist
 
-## When to Enter This Status
+- [ ] **Run the drafter:** `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> ai-draft`
+  - dispatches to `.claude/skills/sf-srs/scripts/srs-cli.sh draft --ticket <ticket>`
+  - reads `tools.srs.backend`, resolves the `SrsAdapter`, writes via `createEpicPage` / `createFrPage`
+- [ ] **Post the page URL** as a ticket comment so the reviewer can jump without leaving the board
+- [ ] **Leave the board** — column stays `In progress` until the lifecycle closes with `transition-drafting done`
 
-- Ticket is in board status `In progress`
-- Ticket carries exactly one SRS label (`srs:drafting`, `srs:update`, or `srs:new`)
-- Brainstorm phase is complete — the owner has finished sharpening the ticket body and is ready for AI to draft
+## Errors to avoid
 
-## Mandatory Actions
-
-### 1. RUN THE DRAFTER
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> ai-draft
-```
-
-This dispatches to `.claude/skills/sf-srs/scripts/srs-cli.sh draft --ticket <ticket>`, which:
-
-- Reads `tools.srs.backend` from `.saasfoundry.json`
-- Resolves the matching `SrsAdapter`
-- Produces an `EpicSpec` or `FrSpec` from the ticket body + linked context
-- Writes the draft to the backend via `adapter.createEpicPage` / `createFrPage`
-
-### 2. POST THE DRAFT URL
-
-After `srs-cli.sh draft` succeeds, post the backend page URL as a ticket comment so the human reviewer can find it without leaving the board.
-
-### 3. KEEP THE BOARD STATUS ON `In progress`
-
-Do not touch the board during this phase — the column stays `In progress` until the whole drafting lifecycle closes with `transition-drafting done`.
-
-## Exit Conditions
-
-- `srs-cli.sh draft` exited 0
-- Backend page URL posted as ticket comment
-- No backend error left unresolved
-
-## Next Status (drafting lifecycle)
-
-**Human review** — see `statuses/3b-human-review.md`.
-
-## Errors to Avoid
-
-❌ NEVER hand-draft the spec — always go through the skill CLI so the backend adapter stays the single integration point ❌ NEVER move the ticket to `AI testing` — code-path statuses are blocked by
-the SRS guard ❌ NEVER bypass `srs-cli.sh draft` with direct backend SDK calls ❌ NEVER delete the `srs:*` label until `spawning` succeeds — the label is what keeps the ticket in the drafting
-lifecycle
+- Hand-drafting the spec (always go through the skill CLI — the backend adapter is the single integration point)
+- Moving the ticket to `AI testing` — code-path statuses are blocked by the SRS guard
+- Bypassing `srs-cli.sh draft` with direct backend SDK calls
+- Deleting the `srs:*` label before `spawning` succeeds — the label keeps the ticket in the drafting lifecycle

--- a/.claude/skills/sf-workflow/statuses/3b-human-review.md
+++ b/.claude/skills/sf-workflow/statuses/3b-human-review.md
@@ -1,24 +1,33 @@
+---
+status: Human Review (drafting lifecycle — board column stays "In progress")
+complexity_profiles: [srs-drafting, srs-update, srs-new]
+entry_conditions:
+  - `3a-ai-drafting.md` complete — `srs-cli.sh draft` exited 0
+  - Backend page URL posted as ticket comment
+  - Ticket still carries its `srs:*` label
+mandatory_actions:
+  - Post the review checklist as a ticket comment
+  - Iterate with the owner (re-draft rounds are allowed)
+  - Do not touch the board column — it stays `In progress`
+exit_conditions:
+  - Owner signalled approval (comment `/approve` or team-specific convention)
+  - Backend page reflects the final agreed scope
+  - `srs:*` label still in place (cleared by spawning, not here)
+next_status: Spawning (see `statuses/3c-spawning.md`)
+---
+
 # STATUS (drafting lifecycle): Human Review
 
-**ROLE**: The spec owner reviews the AI-drafted backend page, iterates until it reflects the team's intent, then signals approval.
+Spec owner reviews the AI-drafted backend page, iterates until it reflects the team's intent, signals approval.
 
-> Logical sub-phase of `In progress` — the board column stays `In progress`. Only tickets carrying an `srs:*` label reach this phase (via `ai-draft`).
+## Action checklist
 
-## When to Enter This Status
+- [ ] **Trigger the phase:** `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> human-review`
+- [ ] **Post the review checklist** (template below) as a ticket comment
+- [ ] **Iterate with the owner** — edit the page or request another `ai-draft` round; no round limit
+- [ ] **Leave the board alone** — column stays `In progress`
 
-- `3a-ai-drafting.md` is complete (`srs-cli.sh draft` exited 0)
-- The backend page URL is posted as a ticket comment
-- Ticket still carries its `srs:*` label
-
-## Mandatory Actions
-
-### 1. POST THE REVIEW CHECKLIST
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> human-review
-```
-
-This phase is intentionally _human-only_ — the CLI only prints a reminder of what must happen. Post the review checklist as a ticket comment (copy/paste template below, adjust to the kind of SRS):
+## Review checklist template
 
 ```markdown
 ## Human review — SRS draft
@@ -36,25 +45,8 @@ Review checklist:
 Comment `/approve` (or apply the `srs:reviewed` label if your team uses it) when satisfied.
 ```
 
-### 2. ITERATE WITH THE OWNER
+## Errors to avoid
 
-Edit the backend page directly or ask for a re-draft round (`transition-drafting <ticket> ai-draft` again). There is no hard limit — the point is to stop when the spec is right, not after N rounds.
-
-### 3. DO NOT TOUCH THE BOARD
-
-Board status stays `In progress`.
-
-## Exit Conditions
-
-- Owner has signalled approval (comment `/approve` or team-specific convention)
-- Backend page reflects the final agreed scope
-- `srs:*` label is still in place (cleared by `spawning`, not here)
-
-## Next Status (drafting lifecycle)
-
-**Spawning** — see `statuses/3c-spawning.md`.
-
-## Errors to Avoid
-
-❌ NEVER skip approval — spawning tickets from an unreviewed spec forces the team to reshape work mid-cycle ❌ NEVER advance to `spawning` just because `ai-draft` exited 0 ❌ NEVER remove the `srs:*`
-label to "force" progress — it bypasses the guard and hides the drafting lifecycle from the board
+- Skipping approval — spawning from an unreviewed spec forces mid-cycle reshapes
+- Advancing to `spawning` just because `ai-draft` exited 0
+- Removing the `srs:*` label to "force" progress (bypasses the guard, hides the lifecycle)

--- a/.claude/skills/sf-workflow/statuses/3c-spawning.md
+++ b/.claude/skills/sf-workflow/statuses/3c-spawning.md
@@ -1,63 +1,40 @@
+---
+status: Spawning (drafting lifecycle — board column stays "In progress" → "Done" on transition-drafting done)
+complexity_profiles: [srs-drafting, srs-update, srs-new]
+entry_conditions:
+  - `3b-human-review.md` complete — owner approval signalled
+  - Backend page is stable
+  - Ticket still carries its `srs:*` label
+mandatory_actions:
+  - Run the spawner via `transition-drafting <ticket> spawning`
+  - Verify children (titles, empty complexity tags, back-links to the backend page)
+  - Clear the `srs:*` label on the drafting ticket
+  - Close the drafting ticket via `transition-drafting <ticket> done`
+exit_conditions:
+  - `srs-cli.sh spawn` exited 0
+  - All children exist in Backlog with correct titles and bodies
+  - Parent drafting ticket no longer carries the `srs:*` label
+  - Parent ticket board status is `Done`
+next_status: Done — children follow the normal code-path workflow from Backlog
+---
+
 # STATUS (drafting lifecycle): Spawning
 
-**ROLE**: Turn the approved SRS page into the matching GitHub (or tool-native) tickets that will drive implementation.
+Turn the approved SRS page into the matching tickets that will drive implementation.
 
-> Logical sub-phase of `In progress`. The board column stays `In progress` during this phase, then the `transition-drafting done` call moves the ticket directly to `Done`.
+## Action checklist
 
-## When to Enter This Status
+- [ ] **Run the spawner:** `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> spawning`
+  - dispatches to `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <ticket>`
+  - renders ticket templates from `sf-srs/templates/tickets/` (Epic or Story)
+  - creates children on the configured workflow tool — each lands in **Backlog**, no `srs:*` label
+- [ ] **Verify the children:** `gh issue list --search "parent #<ticket>"` — sanity-check titles, empty complexity tags (detected later), back-links to the backend page
+- [ ] **Clear the SRS label:** once children exist, remove the `srs:*` label (the `done` phase handles this if the adapter supports it; otherwise `gh issue edit <ticket> --remove-label srs:drafting`)
+- [ ] **Close the drafting ticket:** `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> done` — internally calls `update-status <ticket> Done` with
+      `SF_WORKFLOW_BYPASS_SRS_GUARD=1`
 
-- `3b-human-review.md` is complete (owner approval signalled)
-- The backend page is stable
-- Ticket still carries its `srs:*` label
+## Errors to avoid
 
-## Mandatory Actions
-
-### 1. RUN THE SPAWNER
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> spawning
-```
-
-This dispatches to `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <ticket>`, which:
-
-- Reads the approved SRS backend page
-- Renders the ticket templates from `sf-srs/templates/tickets/` (Epic or Story)
-- Creates the corresponding tickets on the configured workflow tool (GitHub Projects, Jira, Linear, …) via the tool adapter — each child lands in **Backlog** with no `srs:*` label
-
-### 2. VERIFY THE CHILDREN
-
-Run `gh issue list --search "parent #<ticket>"` (or your tool equivalent) and sanity-check the fresh Backlog children: titles, complexity tags left empty (they will be detected once the team picks
-them up), cross-links to the backend page visible in the body.
-
-### 3. CLEAR THE SRS LABEL
-
-Once the children exist, remove the `srs:*` label from the parent drafting ticket — the lifecycle is over, the guard can release its grip. The `done` phase takes care of the label when the `sf-srs`
-adapter supports it; otherwise do it manually:
-
-```bash
-gh issue edit <ticket> --remove-label srs:drafting
-```
-
-### 4. CLOSE THE DRAFTING TICKET
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> done
-```
-
-This internally calls `update-status <ticket> Done` with the SRS guard bypassed (via `SF_WORKFLOW_BYPASS_SRS_GUARD=1`) because the transition is legitimate for a closed drafting lifecycle.
-
-## Exit Conditions
-
-- `srs-cli.sh spawn` exited 0
-- All children exist in Backlog with correct titles and body
-- Parent drafting ticket no longer carries the `srs:*` label
-- Parent ticket is in board status `Done`
-
-## Next Status (drafting lifecycle)
-
-**Done** — the ticket is archived. Children follow the normal code-path workflow from Backlog.
-
-## Errors to Avoid
-
-❌ NEVER spawn before approval ❌ NEVER edit child tickets to paste code-path statuses on them — leave them in `Backlog`, the team sequences them like any other ticket ❌ NEVER close the drafting
-ticket by hand with `update-status <ticket> Done` bypassing the CLI — the guard exists to flag broken flows and we want the flag to stay informative
+- Spawning before approval
+- Editing children to paste code-path statuses — leave them in `Backlog`, the team sequences them normally
+- Closing the drafting ticket by hand with `update-status <ticket> Done` bypassing the CLI — the guard must stay informative

--- a/.claude/skills/sf-workflow/statuses/4-ai-testing.md
+++ b/.claude/skills/sf-workflow/statuses/4-ai-testing.md
@@ -1,111 +1,49 @@
+---
+status: AI Testing
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - All subtasks completed in In Progress
+  - All subtasks CLOSED on GitHub (issues closed, not just merged)
+  - Code pushed and ready for testing
+mandatory_actions:
+  - Gate check — zero open children (`gh issue list --state open --search "parent #<N>"` must be `[]`)
+  - Generate test plan and post as ticket comment
+  - Move ticket to `AI Testing`
+  - Run automated tests (build, lint, type-check, unit tests)
+  - Execute the test plan manually (nominal + edge cases)
+  - Adversarial review — only for complexity `complex` (`examine.sh`)
+  - If problems found — fix, commit, push, restart from automated tests
+  - Post test report summary as comment when all green
+exit_conditions:
+  - All automated tests pass
+  - Test plan fully executed and validated
+  - Adversarial review complete (complex tickets only)
+  - All Critical/High findings fixed
+  - Code pushed
+next_status: Human Testing
+---
+
 # STATUS: AI Testing
 
-**ROLE**: First automated validation + test plan execution
+First automated validation + test plan execution.
 
-## When to Enter This Status
+## Action checklist
 
-- After completing all subtasks in In Progress
-- **All subtasks are CLOSED on GitHub** (not just merged — the issues themselves must be closed)
-- Code is pushed and ready to be tested
+- [ ] **Gate:** `gh issue list --state open --search "parent #<N>"` returns `[]`. If not — back to In Progress, close children, then return.
+- [ ] **Test plan** — post a comment covering: setup, nominal + edge scenarios, expected results per scenario, non-regression coverage
+- [ ] **Move ticket** to `AI Testing` via `workflow-cli.sh update-status`
+- [ ] **Automated tests:** `npm run build` → `npm run lint` → `npm run type-check` (if TS) → `npm run test:unit`
+- [ ] **Execute test plan** step by step — verify each scenario, document any failure
+- [ ] **On failure** — document, fix, commit, push, restart from automated tests
+- [ ] **Complex only:** `.claude/skills/sf-workflow/scripts/examine.sh <ticket>` — 3 parallel review agents (security / logic / perf). Fix Critical/High findings. If any fix committed, restart from
+      automated tests.
+- [ ] **On green** — post test report summary (include examine findings if complex), then transition to Human Testing
 
-## Mandatory Actions (in this order)
+## Errors to avoid
 
-### 0. GATE CHECK — ZERO OPEN CHILDREN
-
-Before doing anything else, verify the parent has no open children:
-
-```bash
-gh issue list --state open --search "parent #{N}"
-```
-
-Must return `[]`. If any children are still open, **go back to In Progress**, close them (`workflow-cli.sh update-status <sub> Done`), and only then proceed to step 1. This gate exists because
-merged-code-with-open-issues creates an inconsistent board state.
-
-### 1. GENERATE THE TEST PLAN
-
-- Analyze all changes (git diff, commits)
-- Create a complete test plan with:
-  - Setup instructions
-  - Scenarios to test (all nominal cases + edge cases)
-  - Expected results for each scenario
-  - Non-regression tests
-- Post the test plan as ticket comment
-
-### 2. MOVE TICKET TO "AI TESTING"
-
-- Update status in the project management tool
-
-### 3. RUN AUTOMATED TESTS
-
-- Build: `npm run build`
-- Lint: `npm run lint`
-- Type-check: `npm run type-check` (if TypeScript)
-- Unit tests: `npm run test:unit`
-
-### 4. EXECUTE TEST PLAN MANUALLY
-
-- Follow EACH step of the test plan
-- Verify implemented functionalities
-- Test edge cases
-- Validate expected results
-- Document any problems found
-
-### 5. IF PROBLEMS ARE FOUND:
-
-- a. Document problems in ticket comment
-- b. Fix the problems
-- c. Commit corrections
-- d. Push
-- e. RESTART from step 3 (automated tests)
-
-### 6. ADVERSARIAL REVIEW (if complexity = complex)
-
-**Only for 🔴 complex tickets:**
-
-```bash
-.claude/skills/sf-workflow/scripts/examine.sh {ticket-number}
-```
-
-**Run adversarial code review:**
-
-- Launch 3 parallel review agents
-- Security analysis (OWASP top 10)
-- Logic flaws detection
-- Performance issues identification
-- Classify findings by severity
-- Fix Critical/High findings immediately
-
-**If findings found:**
-
-- Fix Real issues
-- Commit corrections
-- Push
-- RESTART from step 3 (automated tests)
-- Re-run examine if needed
-
-**Follow the guidance from examine.sh.**
-
-### 7. IF ALL TESTS PASS (and examine complete if complex):
-
-- a. Create test report summary as comment
-- b. If examine was run: include findings summary
-- c. Commit and push final corrections (if any)
-- d. Automatically move to Human Testing
-
-## Exit Conditions
-
-- All automated tests pass ✅
-- Entire test plan executed and validated ✅
-- Adversarial review complete (if complex) ✅
-- All Critical/High findings fixed ✅
-- No problems detected
-- Code is pushed
-
-## Next Status
-
-**Human Testing**
-
-## Errors to Avoid
-
-❌ NEVER move to Human Testing with failing tests ❌ NEVER skip test plan steps ❌ NEVER say "it should work" - RUN the tests ❌ If a test fails, do NOT move to Human Testing, FIX it first ❌ NEVER
-skip examine phase for complex tickets ❌ NEVER ignore Critical/High security findings ❌ NEVER enter AI Testing while subtasks are still OPEN on GitHub — close them first (step 0 gate)
+- Moving to Human Testing with failing tests
+- Skipping test plan steps
+- Saying "it should work" — RUN the tests
+- Skipping examine for complex tickets
+- Ignoring Critical/High security findings
+- Entering AI Testing while subtasks are still OPEN on GitHub (gate rule)

--- a/.claude/skills/sf-workflow/statuses/5-human-testing.md
+++ b/.claude/skills/sf-workflow/statuses/5-human-testing.md
@@ -1,91 +1,49 @@
+---
+status: Human Testing
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - All AI Testing steps passed
+  - Test plan ready for human validation
+mandatory_actions:
+  - Wait for developer validation
+  - On bug report — fix, commit, push, return to AI Testing
+  - On approval — create non-regression tests (E2E for complex/critical, unit for edge-case bugs; none for typo/doc/CSS)
+  - Run created tests locally and ensure they pass
+  - Commit and push tests (`test(#<N>): <description>`)
+  - Be transparent when tests are intentionally skipped
+exit_conditions:
+  - Developer validated the feature
+  - Non-regression tests created (when applicable)
+  - Tests pass locally
+  - Code with tests pushed
+next_status: In Review (create PR)
+---
+
 # STATUS: Human Testing
 
-**ROLE**: Manual validation by human developer
+Manual validation by the developer, followed by non-regression test creation.
 
-> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
->
-> - **Epic** (`type: epic`): no manual test, no PR. Epic status is **derived** from children — it only enters `Human testing` when the last child does, and only leaves once every child has moved on.
->   Do not run the steps below for an Epic.
-> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — the developer validates, then E2E tests are written before moving to `In review`.
+## Ticket type
 
-## When to Enter This Status
+- **Epic** — no manual test, no PR. Status is **derived** from children (only enters Human Testing when the last child does). Skip this checklist.
+- **Story / Task / Issue** — full flow below.
 
-- After successfully passing all tests in AI Testing
-- Test plan is ready for human validation
+## Action checklist
 
-## Mandatory Actions
+- [ ] **Wait for validation** — developer tests manually, you stay available to answer
+- [ ] **On bugs reported:**
+  - Read the comments carefully, summarize the fix plan as a reply
+  - Fix, commit, push, then return to **AI Testing** (re-run automated tests)
+- [ ] **On approval** — create non-regression tests:
+  - Complex/critical → E2E tests (Playwright)
+  - Edge-case bug fix → unit non-regression test
+  - Typo/doc/CSS refactor → none (state why in a comment)
+- [ ] **Coverage** — main scenarios validated, edge cases identified, critical workflows
+- [ ] **Verify locally** — `npm run test:e2e` (or relevant runner) must be green
+- [ ] **Commit + push** — `test(#<N>): add E2E tests for <feature>` (pattern from `jq -r '.workflow.commitFormat.pattern' .saasfoundry.json`)
 
-### 1. WAIT FOR DEVELOPER VALIDATION
+## Errors to avoid
 
-- Do nothing, the developer will manually test
-- Stay available to answer questions
-
-### 2. IF DEVELOPER FINDS BUGS:
-
-- a. Read developer comments carefully
-- b. Add comment summarizing what will be fixed
-- c. Fix identified problems
-- d. Commit and push corrections
-- e. RETURN TO "AI TESTING" (re-run all automated tests)
-
-### 3. IF DEVELOPER VALIDATES ✅:
-
-**NOW, BEFORE CREATING THE PR:**
-
-#### a. CREATE NON-REGRESSION TESTS:
-
-- If complex/critical feature: create E2E tests (Playwright)
-- If edge case bug fix: create unit non-regression test
-- If simple feature (typo, doc, CSS): no E2E tests needed
-
-#### b. COVER IN TESTS:
-
-- Main user scenarios validated
-- Identified and fixed edge cases
-- Critical workflows
-
-#### c. VERIFY TESTS LOCALLY:
-
-- Run created E2E tests: `npm run test:e2e`
-- Ensure they all pass ✅
-
-#### d. COMMIT AND PUSH:
-
-**Read commit format from config:**
-
-```bash
-COMMIT_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.pattern')
-```
-
-**Commit and push:**
-
-- `git add .`
-- `git commit -m "test(#{N}): add E2E tests for {feature}"`
-  - Follow pattern from config: `${COMMIT_PATTERN}`
-  - Replace `#N` with ticket number
-  - Use type `test` for test commits
-- `git push`
-
-#### e. TRANSPARENCY:
-
-- If you decide NOT to create E2E tests, inform the developer
-- Explain why (e.g., "no E2E tests as simple CSS fix")
-
-## Exit Conditions
-
-- Developer validated the feature ✅
-- Non-regression tests created (if applicable)
-- Tests pass locally ✅
-- Code with tests is pushed
-
-## Next Status
-
-**In Review** (create PR)
-
-## Common Sense Rule
-
-✅ Create tests if: new feature, edge case bug fix, user workflow, critical code ❌ No need if: typo, docs, simple CSS refactor, experimental feature
-
-## Errors to Avoid
-
-❌ NEVER create tests BEFORE developer validation ❌ NEVER create PR without creating non-regression tests ❌ NEVER push failing tests
+- Creating tests BEFORE developer validation
+- Creating a PR without non-regression coverage
+- Pushing failing tests

--- a/.claude/skills/sf-workflow/statuses/6-in-review.md
+++ b/.claude/skills/sf-workflow/statuses/6-in-review.md
@@ -1,75 +1,44 @@
+---
+status: In Review
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - Human Testing validated
+  - Non-regression tests created and pushed
+  - Ready to open the Pull Request
+mandatory_actions:
+  - Create the Pull Request (title + description + test plan + test list + reviewers + ticket link)
+  - Move ticket to `In Review`
+  - Monitor CI until green
+  - Answer reviewer comments and implement requested changes
+  - Add tests when reviewer asks; verify locally, commit, push, wait for green CI
+  - Wait for approval AND green CI — do NOT merge
+exit_conditions:
+  - PR approved by all required reviewers
+  - CI is green
+  - Developer merged the PR to the target branch
+next_status: Done
+---
+
 # STATUS: In Review
 
-**ROLE**: Code review + mandatory green CI
+Code review with mandatory green CI.
 
-> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
->
-> - **Epic** (`type: epic`): **NEVER produces a PR**. Do not open one, do not attach one. Epic status in `In review` is purely **derived** from children — it reflects that every child Story/Task/Issue
->   is itself in `In review` (one open PR per child). Skip all steps below.
-> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — each one opens its own PR.
+## Ticket type
 
-## When to Enter This Status
+- **Epic** — **never produces a PR**. Status is **derived** — reflects that every child Story/Task/Issue is itself in `In Review` (one open PR per child). Skip the checklist.
+- **Story / Task / Issue** — full flow below, one PR each.
 
-- After validation in Human Testing
-- Non-regression tests created and pushed
-- Ready to create the Pull Request
+## Action checklist
 
-## Mandatory Actions
+- [ ] **Create the PR** — title = ticket title; description = ticket link + change summary + test plan (copy from ticket) + created tests (unit + E2E); assign configured reviewers; link PR to ticket
+- [ ] **Move ticket** to `In Review` via `workflow-cli.sh update-status`
+- [ ] **Monitor CI** — on red: analyze logs, fix, commit, push, wait for green
+- [ ] **Monitor reviews** — answer questions, implement requested changes
+- [ ] **Reviewer asks for extra tests** — create them, run locally, commit, push, wait for green CI, resolve conversation
+- [ ] **Wait for approval + green CI** — do nothing until the developer merges
 
-### 1. CREATE THE PULL REQUEST
+## Errors to avoid
 
-- Title: Repeat the ticket title
-- Description:
-  - Link to the ticket
-  - Summary of changes
-  - Test plan (copy from ticket)
-  - List of created tests (unit + E2E)
-- Assign configured reviewers
-- Link PR to ticket
-
-### 2. MOVE TICKET TO "IN REVIEW"
-
-- Update status in the project management tool
-
-### 3. MONITOR CI
-
-- CI will run the full test suite (unit + E2E)
-- If CI is red 🔴:
-  - a. Analyze error logs
-  - b. Fix problems
-  - c. Commit and push
-  - d. Wait for CI to turn green ✅
-
-### 4. MONITOR REVIEW COMMENTS
-
-- Read all reviewer comments
-- Answer questions
-- Implement requested changes
-
-### 5. IF REVIEWER REQUESTS ADDITIONAL TESTS:
-
-- a. Create requested tests (unit or E2E)
-- b. Run tests locally to verify
-- c. Commit and push tests
-- d. Wait for CI to pass ✅
-- e. Resolve conversation when done
-
-### 6. WAIT FOR APPROVAL AND GREEN CI
-
-- ⚠️ MANDATORY CONDITION: CI must be green ✅
-- Developer will merge ONLY if CI is green
-- Do nothing until merged
-
-## Exit Conditions
-
-- PR approved by all required reviewers
-- CI is green ✅ (all tests pass)
-- Developer has merged the PR to target branch
-
-## Next Status
-
-**Done**
-
-## Errors to Avoid
-
-❌ NEVER ask developer to merge with red CI ❌ NEVER ignore test failures in CI ❌ NEVER merge yourself (unless explicit instruction)
+- Asking the developer to merge with red CI
+- Ignoring test failures in CI
+- Merging yourself (unless explicitly instructed)

--- a/.claude/skills/sf-workflow/statuses/7-done.md
+++ b/.claude/skills/sf-workflow/statuses/7-done.md
@@ -1,62 +1,40 @@
+---
+status: Done
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - PR merged by the developer
+  - Code is on the target branch
+mandatory_actions:
+  - Move ticket to `Done`
+  - Local branch cleanup — checkout working branch, rebase-pull, delete feature branch
+  - Rebase any other in-progress branches on the fresh working branch
+exit_conditions:
+  - Ticket marked `Done`
+  - Local feature branch deleted
+  - Other in-progress branches rebased
+next_status: N/A (end of cycle)
+---
+
 # STATUS: Done
 
-**ROLE**: Finalization and cleanup after merge
+Finalization and cleanup after merge.
 
-> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
->
-> - **Epic** (`type: epic`): `Done` is **derived** — the Epic only moves to `Done` when **every** child Story/Task/Issue has been merged and closed. No branch to delete, no cleanup to run. Just close
->   the Epic issue once the last child reaches `Done`.
-> - **Story / Task / Issue** (`type: story | task | issue`): full cleanup flow below — after the PR is merged by the developer.
+## Ticket type
 
-## When to Enter This Status
+- **Epic** — `Done` is **derived** only when every child Story/Task/Issue is merged and closed. No branch to delete. Close the Epic issue once the last child reaches `Done`.
+- **Story / Task / Issue** — full cleanup flow below.
 
-- PR has been merged by the developer
-- Code is now in the main branch
+## Action checklist
 
-## Mandatory Actions
+- [ ] **Move ticket to Done** via `workflow-cli.sh update-status <ticket> Done`
+- [ ] **Local cleanup** (working branch from `jq -r '.workflow.workingBranch' .saasfoundry.json`):
+  - `git checkout <workingBranch>`
+  - `git pull origin <workingBranch> --rebase`
+  - `git branch -d <feature-branch>`
+- [ ] **Rebase other in-progress branches** on the refreshed working branch:
+  - per branch: `git checkout <other> && git rebase <workingBranch>` → resolve conflicts → `git push --force-with-lease`
 
-### 1. MOVE TICKET TO "DONE"
+## Errors to avoid
 
-- Update status in the project management tool
-
-### 2. LOCAL BRANCH CLEANUP
-
-**Read working branch from config:**
-
-```bash
-WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
-```
-
-**Cleanup:**
-
-1. `git checkout ${WORKING_BRANCH}`
-2. `git pull origin ${WORKING_BRANCH} --rebase`
-3. `git branch -d {feature-branch}`
-
-### 3. IF OTHER BRANCHES ARE IN PROGRESS
-
-**Rebase other branches with updated working branch:**
-
-```bash
-WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
-
-# For each other branch:
-git checkout {other-branch}
-git rebase ${WORKING_BRANCH}
-# Resolve conflicts if necessary
-git push --force-with-lease
-```
-
-## Exit Conditions
-
-- Ticket marked Done
-- Local branch deleted
-- Other branches rebased
-
-## Next Status
-
-N/A (end of cycle)
-
-## Errors to Avoid
-
-❌ NEVER move to Done before actual merge ❌ NEVER forget to rebase other in-progress branches
+- Moving to Done before the actual merge
+- Forgetting to rebase other in-progress branches

--- a/.claude/skills/sf-workflow/workflow-cli.sh
+++ b/.claude/skills/sf-workflow/workflow-cli.sh
@@ -65,29 +65,27 @@ route_to_tool() {
   "$tool_cli" "$@"
 }
 
-# Function to get current status of a ticket
+# Function to get current status of a ticket.
+#
+# Uses the tool CLI's --json flag and parses with jq — no more grep|awk on
+# human-oriented output. Tool CLIs without --json support fall back to the
+# legacy "Status: X" line so installers can upgrade skills independently.
 get_current_status() {
   local ticket=$1
   local status=""
+  local payload
 
   load_config
 
   case "$WORKFLOW_TOOL" in
-    github-projects)
-      # Delegate to GitHub Projects tool CLI
-      status=$(route_to_tool github-projects status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
-      ;;
-    jira)
-      # Delegate to Jira tool CLI
-      status=$(route_to_tool jira status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
-      ;;
-    notion)
-      # Delegate to Notion tool CLI
-      status=$(route_to_tool notion status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
-      ;;
-    linear)
-      # Delegate to Linear tool CLI
-      status=$(route_to_tool linear status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
+    github-projects|jira|notion|linear)
+      payload=$(route_to_tool "$WORKFLOW_TOOL" status "$ticket" --json 2>/dev/null || true)
+      if [[ -n "$payload" ]] && echo "$payload" | jq -e . >/dev/null 2>&1; then
+        status=$(echo "$payload" | jq -r '.status // ""')
+      else
+        # Legacy fallback — tool CLI has no --json yet
+        status=$(route_to_tool "$WORKFLOW_TOOL" status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
+      fi
       ;;
     *)
       echo -e "${RED}Unknown workflow tool: $WORKFLOW_TOOL${NC}" >&2

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -522,14 +522,28 @@ cmd_create_subtask() {
 
 # ───────────────────────────────────────────────────────────────────────────
 # Command: status — read status from Projects V2 board
+# Flags:
+#   --json   Emit machine-parseable JSON: {"ticket","title","state","status","labels"}
+#            Used by workflow-cli.sh get_current_status so parsing stays deterministic
+#            (no more grep|awk on human-oriented output).
 # ───────────────────────────────────────────────────────────────────────────
 
 cmd_status() {
-  if [ "$#" -lt 1 ]; then
-    echo "Usage: $0 status <ticket-number>" >&2
+  local ticket=""
+  local json_mode=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) json_mode=1; shift ;;
+      *)
+        if [ -z "$ticket" ]; then ticket=$1; fi
+        shift
+        ;;
+    esac
+  done
+  if [ -z "$ticket" ]; then
+    echo "Usage: $0 status <ticket-number> [--json]" >&2
     exit 1
   fi
-  local ticket=$1
   load_config
   if [ -z "$PROJECT_OWNER" ] || [ -z "$PROJECT_NUMBER" ]; then
     echo -e "${RED}Error: workflow.projectUrl is missing or malformed in .saasfoundry.json${NC}" >&2
@@ -544,8 +558,27 @@ cmd_status() {
   status=$(echo "$info" | jq -r '.status // ""')
 
   if [ -z "$title" ]; then
+    if [ "$json_mode" = 1 ]; then
+      jq -n --argjson t "$ticket" '{ticket:$t, title:"", state:"", status:"", labels:[], error:"not-found"}'
+      exit 1
+    fi
     echo -e "${RED}Error: Could not find issue #${ticket}${NC}" >&2
     exit 1
+  fi
+
+  if [ "$json_mode" = 1 ]; then
+    # Labels fetched via gh (separate call — cheap) so the JSON payload carries
+    # everything callers need without a second round-trip.
+    local labels_json
+    labels_json=$(gh issue view "$ticket" --json labels --jq '[.labels[].name]' 2>/dev/null || echo '[]')
+    jq -n \
+      --argjson t "$ticket" \
+      --arg title "$title" \
+      --arg state "$state" \
+      --arg status "$status" \
+      --argjson labels "${labels_json:-[]}" \
+      '{ticket:$t, title:$title, state:$state, status:$status, labels:$labels}'
+    return 0
   fi
 
   echo -e "${BLUE}Issue #${ticket}: ${title}${NC}"

--- a/scaffolds/skills-templates/workflow/statuses/1-backlog.md
+++ b/scaffolds/skills-templates/workflow/statuses/1-backlog.md
@@ -1,128 +1,53 @@
+---
+status: Backlog
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - Developer mentions a new idea / feature / bug
+  - No branch created, no code written
+mandatory_actions:
+  - Read the ticket thoroughly
+  - Detect complexity — suggestion only
+  - Persist complexity label — MANDATORY (update-status is hard-gated on it)
+  - Analyze (adaptive — skip=bug, minimal=low, 2–4 agents=medium, 6–10 agents=complex)
+  - Plan (adaptive — skip=bug, mental=low, file-by-file=medium, comprehensive=complex)
+  - Challenge the specs (edge cases, questions, alternatives)
+  - Wait for developer validation
+exit_conditions:
+  - Complexity label present — `get-complexity <ticket>` prints one of `bug|low|medium|complex` (not `(none)`)
+  - Analysis complete (if required by complexity)
+  - Plan approved (if required by complexity)
+  - Developer validates specs are complete
+next_status: Ready
+---
+
 # STATUS: Backlog
 
-**ROLE**: Preparation phase - detect complexity, analyze context, plan implementation, validate specs
+Preparation phase — detect complexity, analyze context, plan implementation, validate specs.
 
-## When to Enter This Status
+## Action checklist
 
-- When a new idea/feature/bug is mentioned by the developer
-- Before any branch creation or code writing
+- [ ] **Detect complexity (suggestion):** `.claude/skills/sf-workflow/scripts/detect-complexity.sh <ticket>`
+- [ ] **Persist the label (mandatory):** `.claude/skills/sf-workflow/workflow-cli.sh retag <ticket> <bug|low|medium|complex>`
+- [ ] **Analyze:** `.claude/skills/sf-workflow/scripts/analyze.sh <ticket> <complexity>` — follow its guidance
+- [ ] **Plan:** `.claude/skills/sf-workflow/scripts/plan.sh <ticket> <complexity>` — follow its guidance; post + await approval for medium/complex
+- [ ] **Challenge the specs** — ask questions, surface edge cases, propose alternatives
+- [ ] **Ticket completeness** — problem/need, acceptance criteria, technical context, complexity tag
+- [ ] **Wait for validation** — two approvals: (1) specs complete → Ready, (2) prioritization → In Progress
 
-## Mandatory Actions (in order)
+## Complexity cheat sheet
 
-### 1. READ THE TICKET THOROUGHLY
+| Level      | Analyze     | Plan                     |
+| ---------- | ----------- | ------------------------ |
+| 🐛 bug     | skip        | skip                     |
+| 🟢 low     | minimal     | mental                   |
+| 🟡 medium  | 2–4 agents  | file-by-file + approval  |
+| 🔴 complex | 6–10 agents | comprehensive + approval |
 
-### 2. DETECT COMPLEXITY → THEN WRITE IT TO THE TICKET
+## Errors to avoid
 
-**Step 2a — Run complexity detection (suggestion only):**
-
-```bash
-.claude/skills/sf-workflow/scripts/detect-complexity.sh {ticket-number}
-```
-
-**AI will suggest complexity based on:**
-
-- Number of files potentially impacted
-- Keywords (auth, payment, security → complex)
-- Risk assessment
-- Similar historical tickets
-
-**Complexity levels:**
-
-- 🐛 **bug** - Quick fix, minimal ceremony
-- 🟢 **low** - Simple task (oneshot-style)
-- 🟡 **medium** - Standard feature (apex-free-style)
-- 🔴 **complex** - Critical feature (full apex with review)
-
-**Developer ALWAYS has final say - ask for confirmation or adjustment.**
-
-**Step 2b — Persist the complexity label on the ticket:**
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh retag {ticket-number} {level}
-# level: bug | low | medium | complex
-```
-
-⚠️ **This step is mandatory, not optional.** `detect-complexity.sh` only prints a suggestion; it does NOT write anything to the ticket. Without the `complexity: *` label, the ticket cannot leave
-Backlog — `update-status` is hard-gated on it (see errors to avoid below).
-
-### 3. ANALYZE (adaptive based on complexity)
-
-**Check if analysis required:**
-
-```bash
-.claude/skills/sf-workflow/scripts/analyze.sh {ticket-number} {complexity}
-```
-
-**Skipped for:** 🐛 bug **Minimal for:** 🟢 low (2-3 files, no agents) **Standard for:** 🟡 medium (2-4 parallel agents) **Deep for:** 🔴 complex (6-10 parallel agents)
-
-**Purpose:**
-
-- Gather context about what currently exists
-- Find patterns, files, utilities
-- Identify dependencies and risks
-- Document findings with file:line references
-
-**Follow the guidance from analyze.sh for your complexity level.**
-
-### 4. PLAN (adaptive based on complexity)
-
-**Check if planning required:**
-
-```bash
-.claude/skills/sf-workflow/scripts/plan.sh {ticket-number} {complexity}
-```
-
-**Skipped for:** 🐛 bug **Minimal for:** 🟢 low (mental plan) **Detailed for:** 🟡 medium (file-by-file, requires approval) **Comprehensive for:** 🔴 complex (with dependencies, requires approval)
-
-**Purpose:**
-
-- Create implementation strategy
-- Map acceptance criteria to file changes
-- Identify execution order
-- Plan edge cases and error handling
-
-**If approval required:**
-
-- Post plan as ticket comment
-- Wait for explicit approval before proceeding
-
-**Follow the guidance from plan.sh for your complexity level.**
-
-### 5. CHALLENGE THE SPECS
-
-- Ask questions to clarify requirements
-- Identify uncovered edge cases
-- Suggest improvements or alternatives
-- Validate the proposed technical approach
-
-### 6. ENSURE TICKET CONTAINS
-
-- Clear description of the problem/need
-- Precise acceptance criteria
-- Sufficient technical context
-- Complexity tag set
-
-### 7. WAIT FOR VALIDATION
-
-**Two approvals needed:**
-
-1. **Specs complete** → can move to Ready
-2. **Prioritization** (from Ready) → can move to In Progress
-
-## Exit Conditions
-
-- **Complexity label persisted on the ticket** (run `get-complexity {ticket}` and confirm it prints one of `bug|low|medium|complex`, not `(none)`)
-- Analysis complete (if required by complexity)
-- Plan approved (if required by complexity)
-- Developer validates that specs are complete
-- All identified edge cases are documented
-- Technical approach is validated
-
-## Next Status
-
-**Ready**
-
-## Errors to Avoid
-
-❌ NEVER create a branch from Backlog ❌ NEVER start coding before Ready ❌ NEVER skip complexity detection ❌ NEVER leave Backlog without persisting the `complexity: *` label via `retag` (suggestion
-≠ label; `update-status` is hard-gated) ❌ NEVER skip analysis/planning if required by complexity ❌ NEVER move to Ready without developer validation
+- Creating a branch from Backlog
+- Starting to code before Ready
+- Skipping complexity detection
+- Leaving Backlog without the `complexity: *` label (suggestion ≠ label; hard-gated)
+- Skipping analysis/planning when required
+- Moving to Ready without developer validation

--- a/scaffolds/skills-templates/workflow/statuses/2-ready.md
+++ b/scaffolds/skills-templates/workflow/statuses/2-ready.md
@@ -1,29 +1,29 @@
+---
+status: Ready
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - Specs validated in Backlog
+  - Priority assigned
+  - All blockers resolved
+mandatory_actions:
+  - Wait for explicit ticket assignment or confirmation
+  - Do nothing else — this status is a waiting queue
+exit_conditions:
+  - Developer asks you to work on this ticket
+  - OR you receive confirmation to take it
+next_status: In Progress
+---
+
 # STATUS: Ready
 
-**ROLE**: Queue of validated tickets ready for development
+Queue of validated tickets waiting for pickup.
 
-## When to Enter This Status
+## Action checklist
 
-- After specs validation in Backlog
-- Ticket has assigned priority
-- All blockers are resolved
+- [ ] Wait for the developer to assign the ticket (or ask which one to take, respecting priority order)
+- [ ] Otherwise, do nothing — Ready is strictly a waiting queue
 
-## Mandatory Actions
+## Errors to avoid
 
-1. **Wait for ticket assignment:**
-   - Either the developer explicitly assigns the ticket to you
-   - Or you ask which ticket to take (prioritize by order)
-2. **Do nothing else** - this status is a waiting queue
-
-## Exit Conditions
-
-- Developer asks you to work on this ticket
-- OR you get confirmation to take the ticket
-
-## Next Status
-
-**In Progress**
-
-## Errors to Avoid
-
-❌ NEVER take a Ready ticket without confirmation ❌ NEVER skip higher priority tickets
+- Taking a Ready ticket without confirmation
+- Skipping higher-priority tickets

--- a/scaffolds/skills-templates/workflow/statuses/3-in-progress.md
+++ b/scaffolds/skills-templates/workflow/statuses/3-in-progress.md
@@ -1,119 +1,55 @@
+---
+status: In Progress
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - Assignment or confirmation received in Ready
+  - Ready to start development
+mandatory_actions:
+  - Create feature branch from `workingBranch` (manifest)
+  - Move ticket to `In Progress`
+  - Create subtasks as real GitHub issues (NOT checkboxes)
+  - Develop iteratively — one commit per subtask, close each subtask right after its commit lands
+  - Final validation — build, lint, unit tests green
+  - Push branch
+exit_conditions:
+  - All subtasks closed on GitHub (`gh issue list --state open --search "parent #<N>"` returns [])
+  - Code compiles without errors
+  - Lint passes
+  - Existing tests pass
+  - Branch pushed to remote
+next_status: AI Testing
+---
+
 # STATUS: In Progress
 
-**ROLE**: Active development with subtasks creation and regular commits
+Active development — subtask creation, iterative commits, final validation.
 
-> **⚠️ SRS drafting tickets** (labelled `srs:drafting | srs:update | srs:new`) do **NOT** follow the steps below. They stay in the `In progress` board column but flow through a separate lifecycle —
-> stop here and read `statuses/3a-ai-drafting.md`. Drive the ticket with `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> <phase>`
-> (`ai-draft | human-review | spawning | done`), never with `update-status` — the SRS guard blocks code-path transitions for those tickets.
+## Ticket type
 
-> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
->
-> - **Epic** (`type: epic`): no branch, no commit, no PR. Skip sections 1, 4, 5 below. Only create children (Stories/Tasks/Issues) via `create-subtask` and coordinate them. Epic status is **derived**
->   from children — it reaches `In progress` automatically when the first child does.
-> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — branch + commits + PR.
-> - **Subtask**: a commit on the current Story/Task branch, not a GitHub issue. Don't create one via `create-subtask`.
+- **Epic** (`type: epic`): no branch, no commit, no PR. Skip "Branch + develop" + "Final validation" below. Only create children via `create-subtask` and coordinate. Epic status is **derived** — moves
+  to `In progress` automatically when the first child does.
+- **Story / Task / Issue**: full flow below.
+- **Subtask**: a commit on the current branch, not a GitHub issue. Do not use `create-subtask`.
 
-## When to Enter This Status
+## SRS drafting tickets (`srs:drafting | srs:update | srs:new`)
 
-- After receiving assignment or confirmation from developer in Ready
-- Ready to start development
+These stay in the `In progress` board column but flow through a **separate lifecycle** — see `statuses/3a-ai-drafting.md`. Drive with
+`workflow-cli.sh transition-drafting <ticket> <ai-draft|human-review|spawning|done>`. Never use `update-status` — the SRS guard blocks code-path transitions.
 
-## Mandatory Actions (in this order)
+## Action checklist — Story / Task / Issue
 
-### 1. CREATE A BRANCH
+- [ ] **Branch** — from `jq -r '.workflow.workingBranch' .saasfoundry.json`, pattern `jq -r '.workflow.branchNaming.feature'`
+  - `git checkout <workingBranch> && git pull --rebase && git checkout -b feature/<N>-<description>`
+- [ ] **Move ticket to "In Progress"** via `workflow-cli.sh update-status <ticket> "In progress"`
+- [ ] **Create subtasks** — `workflow-cli.sh create-subtask <parent> "<title>" ["<body>"]` (auto-links as sub-issue)
+- [ ] **Per subtask:** move to In Progress → code → commit (`<type>(#<N>): <description>`) → `update-status <sub> Done` → `gh issue view <sub> --json state` must print `CLOSED` (never batch closures)
+- [ ] **All subtasks done:** verify zero open children (`gh issue list --state open --search "parent #<N>"` → `[]`) → `npm run build && npm run lint` → `npm test` → push
 
-**Read configuration from `.saasfoundry.json`:**
+## Errors to avoid
 
-```bash
-WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
-BRANCH_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.branchNaming.feature')
-```
-
-**Create feature branch:**
-
-1. Ensure you're on working branch: `git checkout ${WORKING_BRANCH}`
-2. Pull latest with rebase: `git pull origin ${WORKING_BRANCH} --rebase`
-3. Create feature branch: `git checkout -b feature/{N}-{description}`
-   - Format from config: `${BRANCH_PATTERN}` (e.g., `feature/{N}-{description}`)
-   - Replace `{N}` with ticket number
-   - Replace `{description}` with kebab-case description
-
-### 2. MOVE TICKET TO "IN PROGRESS"
-
-- Update status in the project management tool
-
-### 3. CREATE SUBTASKS
-
-**Break down the ticket into atomic sub-tasks.**
-
-**MUST be real GitHub issues** (NOT checkboxes) linked as sub-issues to the parent.
-
-**Use the helper script:**
-
-```bash
-# Create a subtask linked to parent issue
-.claude/skills/sf-workflow/create-subtask.sh <parent-number> "Subtask title" ["Optional body"]
-
-# Example:
-.claude/skills/sf-workflow/create-subtask.sh 9 "Add validation logic"
-.claude/skills/sf-workflow/create-subtask.sh 9 "Write unit tests" "Cover edge cases"
-```
-
-**The script automatically:**
-
-- Prepends `[Parent #{N}]` to the title
-- Creates the GitHub issue
-- Links it as a sub-issue to the parent (via GraphQL API)
-- Outputs the subtask number and URL
-
-**Track subtask status in project board:**
-
-- Backlog → In Progress (when you start) → Done (when complete)
-
-### 4. DEVELOP ITERATIVELY
-
-**Read commit format from config:**
-
-```bash
-COMMIT_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.pattern')
-COMMIT_TYPES=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.types[]')
-```
-
-For each subtask:
-
-- a. Move subtask to "In Progress"
-- b. Write code for this subtask
-- c. Commit with format from config: `${COMMIT_PATTERN}`
-  - Example: `type(#{N}): description`
-  - Use allowed types: `feat`, `fix`, `docs`, `refactor`, etc.
-  - Replace `#{N}` with ticket number
-- d. **Close the subtask immediately** — run `workflow-cli.sh update-status <sub> Done` and **verify** with `gh issue view <sub> --json state` that it prints `CLOSED`. Never batch closures.
-- e. Move to the next one
-
-### 5. WHEN ALL SUBTASKS ARE DONE
-
-- a. **Verify zero open children** — `gh issue list --state open --search "parent #{N}"` must return an empty array before going further. If not, close the remaining children first.
-- b. Run: `npm run build && npm run lint`
-- c. Fix all lint/build errors
-- d. Run existing tests (unit tests)
-- e. Ensure nothing is broken
-- f. Final commit if corrections needed
-- g. Push the branch: `git push -u origin {branch-name}`
-
-## Exit Conditions
-
-- All subtasks are Done
-- Code compiles without errors
-- Lint passes
-- Existing tests pass
-- Code is pushed to remote
-
-## Next Status
-
-**AI Testing**
-
-## Errors to Avoid
-
-❌ NEVER code without creating a branch first ❌ NEVER mix multiple tickets in the same branch ❌ NEVER move to AI Testing with lint errors ❌ NEVER forget to push before moving to AI Testing ❌ NEVER
-batch subtask closures at the end of the parent — close each one right after its commit lands ❌ NEVER start another ticket while this one is still In Progress / AI Testing / Human Testing / In Review
-(unless the developer explicitly asks you to pause)
+- Coding without creating a branch first
+- Mixing multiple tickets in the same branch
+- Moving to AI Testing with lint/build errors
+- Forgetting to push before AI Testing
+- Batching subtask closures at the end — close each one right after its commit lands
+- Starting another ticket while this one is still In Progress / AI Testing / Human Testing / In Review (unless the developer explicitly asks to pause)

--- a/scaffolds/skills-templates/workflow/statuses/3a-ai-drafting.md
+++ b/scaffolds/skills-templates/workflow/statuses/3a-ai-drafting.md
@@ -1,51 +1,36 @@
+---
+status: AI Drafting (drafting lifecycle — board column stays "In progress")
+complexity_profiles: [srs-drafting, srs-update, srs-new]
+entry_conditions:
+  - Ticket board status is `In progress`
+  - Ticket carries exactly one `srs:*` label (`srs:drafting | srs:update | srs:new`)
+  - Brainstorm phase complete — ticket body is sharp enough to draft
+mandatory_actions:
+  - Run the drafter via `transition-drafting <ticket> ai-draft`
+  - Post the backend page URL as a ticket comment
+  - Do not touch the board column — it stays `In progress`
+exit_conditions:
+  - `srs-cli.sh draft` exited 0
+  - Backend page URL posted as ticket comment
+  - No backend error left unresolved
+next_status: Human review (see `statuses/3b-human-review.md`)
+---
+
 # STATUS (drafting lifecycle): AI Drafting
 
-**ROLE**: AI produces the first draft of the SRS page in the configured backend (Notion, Confluence, local markdown, …).
+AI produces the first draft of the SRS page in the configured backend (Notion, Confluence, local markdown, …).
 
-> This status is **not** a board column. It's a _logical sub-phase_ of `In progress` reached exclusively by tickets carrying `srs:drafting | srs:update | srs:new`. The board column stays `In progress`
-> throughout the drafting lifecycle.
+## Action checklist
 
-## When to Enter This Status
+- [ ] **Run the drafter:** `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> ai-draft`
+  - dispatches to `.claude/skills/sf-srs/scripts/srs-cli.sh draft --ticket <ticket>`
+  - reads `tools.srs.backend`, resolves the `SrsAdapter`, writes via `createEpicPage` / `createFrPage`
+- [ ] **Post the page URL** as a ticket comment so the reviewer can jump without leaving the board
+- [ ] **Leave the board** — column stays `In progress` until the lifecycle closes with `transition-drafting done`
 
-- Ticket is in board status `In progress`
-- Ticket carries exactly one SRS label (`srs:drafting`, `srs:update`, or `srs:new`)
-- Brainstorm phase is complete — the owner has finished sharpening the ticket body and is ready for AI to draft
+## Errors to avoid
 
-## Mandatory Actions
-
-### 1. RUN THE DRAFTER
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> ai-draft
-```
-
-This dispatches to `.claude/skills/sf-srs/scripts/srs-cli.sh draft --ticket <ticket>`, which:
-
-- Reads `tools.srs.backend` from `.saasfoundry.json`
-- Resolves the matching `SrsAdapter`
-- Produces an `EpicSpec` or `FrSpec` from the ticket body + linked context
-- Writes the draft to the backend via `adapter.createEpicPage` / `createFrPage`
-
-### 2. POST THE DRAFT URL
-
-After `srs-cli.sh draft` succeeds, post the backend page URL as a ticket comment so the human reviewer can find it without leaving the board.
-
-### 3. KEEP THE BOARD STATUS ON `In progress`
-
-Do not touch the board during this phase — the column stays `In progress` until the whole drafting lifecycle closes with `transition-drafting done`.
-
-## Exit Conditions
-
-- `srs-cli.sh draft` exited 0
-- Backend page URL posted as ticket comment
-- No backend error left unresolved
-
-## Next Status (drafting lifecycle)
-
-**Human review** — see `statuses/3b-human-review.md`.
-
-## Errors to Avoid
-
-❌ NEVER hand-draft the spec — always go through the skill CLI so the backend adapter stays the single integration point ❌ NEVER move the ticket to `AI testing` — code-path statuses are blocked by
-the SRS guard ❌ NEVER bypass `srs-cli.sh draft` with direct backend SDK calls ❌ NEVER delete the `srs:*` label until `spawning` succeeds — the label is what keeps the ticket in the drafting
-lifecycle
+- Hand-drafting the spec (always go through the skill CLI — the backend adapter is the single integration point)
+- Moving the ticket to `AI testing` — code-path statuses are blocked by the SRS guard
+- Bypassing `srs-cli.sh draft` with direct backend SDK calls
+- Deleting the `srs:*` label before `spawning` succeeds — the label keeps the ticket in the drafting lifecycle

--- a/scaffolds/skills-templates/workflow/statuses/3b-human-review.md
+++ b/scaffolds/skills-templates/workflow/statuses/3b-human-review.md
@@ -1,24 +1,33 @@
+---
+status: Human Review (drafting lifecycle — board column stays "In progress")
+complexity_profiles: [srs-drafting, srs-update, srs-new]
+entry_conditions:
+  - `3a-ai-drafting.md` complete — `srs-cli.sh draft` exited 0
+  - Backend page URL posted as ticket comment
+  - Ticket still carries its `srs:*` label
+mandatory_actions:
+  - Post the review checklist as a ticket comment
+  - Iterate with the owner (re-draft rounds are allowed)
+  - Do not touch the board column — it stays `In progress`
+exit_conditions:
+  - Owner signalled approval (comment `/approve` or team-specific convention)
+  - Backend page reflects the final agreed scope
+  - `srs:*` label still in place (cleared by spawning, not here)
+next_status: Spawning (see `statuses/3c-spawning.md`)
+---
+
 # STATUS (drafting lifecycle): Human Review
 
-**ROLE**: The spec owner reviews the AI-drafted backend page, iterates until it reflects the team's intent, then signals approval.
+Spec owner reviews the AI-drafted backend page, iterates until it reflects the team's intent, signals approval.
 
-> Logical sub-phase of `In progress` — the board column stays `In progress`. Only tickets carrying an `srs:*` label reach this phase (via `ai-draft`).
+## Action checklist
 
-## When to Enter This Status
+- [ ] **Trigger the phase:** `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> human-review`
+- [ ] **Post the review checklist** (template below) as a ticket comment
+- [ ] **Iterate with the owner** — edit the page or request another `ai-draft` round; no round limit
+- [ ] **Leave the board alone** — column stays `In progress`
 
-- `3a-ai-drafting.md` is complete (`srs-cli.sh draft` exited 0)
-- The backend page URL is posted as a ticket comment
-- Ticket still carries its `srs:*` label
-
-## Mandatory Actions
-
-### 1. POST THE REVIEW CHECKLIST
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> human-review
-```
-
-This phase is intentionally _human-only_ — the CLI only prints a reminder of what must happen. Post the review checklist as a ticket comment (copy/paste template below, adjust to the kind of SRS):
+## Review checklist template
 
 ```markdown
 ## Human review — SRS draft
@@ -36,25 +45,8 @@ Review checklist:
 Comment `/approve` (or apply the `srs:reviewed` label if your team uses it) when satisfied.
 ```
 
-### 2. ITERATE WITH THE OWNER
+## Errors to avoid
 
-Edit the backend page directly or ask for a re-draft round (`transition-drafting <ticket> ai-draft` again). There is no hard limit — the point is to stop when the spec is right, not after N rounds.
-
-### 3. DO NOT TOUCH THE BOARD
-
-Board status stays `In progress`.
-
-## Exit Conditions
-
-- Owner has signalled approval (comment `/approve` or team-specific convention)
-- Backend page reflects the final agreed scope
-- `srs:*` label is still in place (cleared by `spawning`, not here)
-
-## Next Status (drafting lifecycle)
-
-**Spawning** — see `statuses/3c-spawning.md`.
-
-## Errors to Avoid
-
-❌ NEVER skip approval — spawning tickets from an unreviewed spec forces the team to reshape work mid-cycle ❌ NEVER advance to `spawning` just because `ai-draft` exited 0 ❌ NEVER remove the `srs:*`
-label to "force" progress — it bypasses the guard and hides the drafting lifecycle from the board
+- Skipping approval — spawning from an unreviewed spec forces mid-cycle reshapes
+- Advancing to `spawning` just because `ai-draft` exited 0
+- Removing the `srs:*` label to "force" progress (bypasses the guard, hides the lifecycle)

--- a/scaffolds/skills-templates/workflow/statuses/3c-spawning.md
+++ b/scaffolds/skills-templates/workflow/statuses/3c-spawning.md
@@ -1,63 +1,40 @@
+---
+status: Spawning (drafting lifecycle — board column stays "In progress" → "Done" on transition-drafting done)
+complexity_profiles: [srs-drafting, srs-update, srs-new]
+entry_conditions:
+  - `3b-human-review.md` complete — owner approval signalled
+  - Backend page is stable
+  - Ticket still carries its `srs:*` label
+mandatory_actions:
+  - Run the spawner via `transition-drafting <ticket> spawning`
+  - Verify children (titles, empty complexity tags, back-links to the backend page)
+  - Clear the `srs:*` label on the drafting ticket
+  - Close the drafting ticket via `transition-drafting <ticket> done`
+exit_conditions:
+  - `srs-cli.sh spawn` exited 0
+  - All children exist in Backlog with correct titles and bodies
+  - Parent drafting ticket no longer carries the `srs:*` label
+  - Parent ticket board status is `Done`
+next_status: Done — children follow the normal code-path workflow from Backlog
+---
+
 # STATUS (drafting lifecycle): Spawning
 
-**ROLE**: Turn the approved SRS page into the matching GitHub (or tool-native) tickets that will drive implementation.
+Turn the approved SRS page into the matching tickets that will drive implementation.
 
-> Logical sub-phase of `In progress`. The board column stays `In progress` during this phase, then the `transition-drafting done` call moves the ticket directly to `Done`.
+## Action checklist
 
-## When to Enter This Status
+- [ ] **Run the spawner:** `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> spawning`
+  - dispatches to `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <ticket>`
+  - renders ticket templates from `sf-srs/templates/tickets/` (Epic or Story)
+  - creates children on the configured workflow tool — each lands in **Backlog**, no `srs:*` label
+- [ ] **Verify the children:** `gh issue list --search "parent #<ticket>"` — sanity-check titles, empty complexity tags (detected later), back-links to the backend page
+- [ ] **Clear the SRS label:** once children exist, remove the `srs:*` label (the `done` phase handles this if the adapter supports it; otherwise `gh issue edit <ticket> --remove-label srs:drafting`)
+- [ ] **Close the drafting ticket:** `.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> done` — internally calls `update-status <ticket> Done` with
+      `SF_WORKFLOW_BYPASS_SRS_GUARD=1`
 
-- `3b-human-review.md` is complete (owner approval signalled)
-- The backend page is stable
-- Ticket still carries its `srs:*` label
+## Errors to avoid
 
-## Mandatory Actions
-
-### 1. RUN THE SPAWNER
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> spawning
-```
-
-This dispatches to `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <ticket>`, which:
-
-- Reads the approved SRS backend page
-- Renders the ticket templates from `sf-srs/templates/tickets/` (Epic or Story)
-- Creates the corresponding tickets on the configured workflow tool (GitHub Projects, Jira, Linear, …) via the tool adapter — each child lands in **Backlog** with no `srs:*` label
-
-### 2. VERIFY THE CHILDREN
-
-Run `gh issue list --search "parent #<ticket>"` (or your tool equivalent) and sanity-check the fresh Backlog children: titles, complexity tags left empty (they will be detected once the team picks
-them up), cross-links to the backend page visible in the body.
-
-### 3. CLEAR THE SRS LABEL
-
-Once the children exist, remove the `srs:*` label from the parent drafting ticket — the lifecycle is over, the guard can release its grip. The `done` phase takes care of the label when the `sf-srs`
-adapter supports it; otherwise do it manually:
-
-```bash
-gh issue edit <ticket> --remove-label srs:drafting
-```
-
-### 4. CLOSE THE DRAFTING TICKET
-
-```bash
-.claude/skills/sf-workflow/workflow-cli.sh transition-drafting <ticket> done
-```
-
-This internally calls `update-status <ticket> Done` with the SRS guard bypassed (via `SF_WORKFLOW_BYPASS_SRS_GUARD=1`) because the transition is legitimate for a closed drafting lifecycle.
-
-## Exit Conditions
-
-- `srs-cli.sh spawn` exited 0
-- All children exist in Backlog with correct titles and body
-- Parent drafting ticket no longer carries the `srs:*` label
-- Parent ticket is in board status `Done`
-
-## Next Status (drafting lifecycle)
-
-**Done** — the ticket is archived. Children follow the normal code-path workflow from Backlog.
-
-## Errors to Avoid
-
-❌ NEVER spawn before approval ❌ NEVER edit child tickets to paste code-path statuses on them — leave them in `Backlog`, the team sequences them like any other ticket ❌ NEVER close the drafting
-ticket by hand with `update-status <ticket> Done` bypassing the CLI — the guard exists to flag broken flows and we want the flag to stay informative
+- Spawning before approval
+- Editing children to paste code-path statuses — leave them in `Backlog`, the team sequences them normally
+- Closing the drafting ticket by hand with `update-status <ticket> Done` bypassing the CLI — the guard must stay informative

--- a/scaffolds/skills-templates/workflow/statuses/4-ai-testing.md
+++ b/scaffolds/skills-templates/workflow/statuses/4-ai-testing.md
@@ -1,111 +1,49 @@
+---
+status: AI Testing
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - All subtasks completed in In Progress
+  - All subtasks CLOSED on GitHub (issues closed, not just merged)
+  - Code pushed and ready for testing
+mandatory_actions:
+  - Gate check — zero open children (`gh issue list --state open --search "parent #<N>"` must be `[]`)
+  - Generate test plan and post as ticket comment
+  - Move ticket to `AI Testing`
+  - Run automated tests (build, lint, type-check, unit tests)
+  - Execute the test plan manually (nominal + edge cases)
+  - Adversarial review — only for complexity `complex` (`examine.sh`)
+  - If problems found — fix, commit, push, restart from automated tests
+  - Post test report summary as comment when all green
+exit_conditions:
+  - All automated tests pass
+  - Test plan fully executed and validated
+  - Adversarial review complete (complex tickets only)
+  - All Critical/High findings fixed
+  - Code pushed
+next_status: Human Testing
+---
+
 # STATUS: AI Testing
 
-**ROLE**: First automated validation + test plan execution
+First automated validation + test plan execution.
 
-## When to Enter This Status
+## Action checklist
 
-- After completing all subtasks in In Progress
-- **All subtasks are CLOSED on GitHub** (not just merged — the issues themselves must be closed)
-- Code is pushed and ready to be tested
+- [ ] **Gate:** `gh issue list --state open --search "parent #<N>"` returns `[]`. If not — back to In Progress, close children, then return.
+- [ ] **Test plan** — post a comment covering: setup, nominal + edge scenarios, expected results per scenario, non-regression coverage
+- [ ] **Move ticket** to `AI Testing` via `workflow-cli.sh update-status`
+- [ ] **Automated tests:** `npm run build` → `npm run lint` → `npm run type-check` (if TS) → `npm run test:unit`
+- [ ] **Execute test plan** step by step — verify each scenario, document any failure
+- [ ] **On failure** — document, fix, commit, push, restart from automated tests
+- [ ] **Complex only:** `.claude/skills/sf-workflow/scripts/examine.sh <ticket>` — 3 parallel review agents (security / logic / perf). Fix Critical/High findings. If any fix committed, restart from
+      automated tests.
+- [ ] **On green** — post test report summary (include examine findings if complex), then transition to Human Testing
 
-## Mandatory Actions (in this order)
+## Errors to avoid
 
-### 0. GATE CHECK — ZERO OPEN CHILDREN
-
-Before doing anything else, verify the parent has no open children:
-
-```bash
-gh issue list --state open --search "parent #{N}"
-```
-
-Must return `[]`. If any children are still open, **go back to In Progress**, close them (`workflow-cli.sh update-status <sub> Done`), and only then proceed to step 1. This gate exists because
-merged-code-with-open-issues creates an inconsistent board state.
-
-### 1. GENERATE THE TEST PLAN
-
-- Analyze all changes (git diff, commits)
-- Create a complete test plan with:
-  - Setup instructions
-  - Scenarios to test (all nominal cases + edge cases)
-  - Expected results for each scenario
-  - Non-regression tests
-- Post the test plan as ticket comment
-
-### 2. MOVE TICKET TO "AI TESTING"
-
-- Update status in the project management tool
-
-### 3. RUN AUTOMATED TESTS
-
-- Build: `npm run build`
-- Lint: `npm run lint`
-- Type-check: `npm run type-check` (if TypeScript)
-- Unit tests: `npm run test:unit`
-
-### 4. EXECUTE TEST PLAN MANUALLY
-
-- Follow EACH step of the test plan
-- Verify implemented functionalities
-- Test edge cases
-- Validate expected results
-- Document any problems found
-
-### 5. IF PROBLEMS ARE FOUND:
-
-- a. Document problems in ticket comment
-- b. Fix the problems
-- c. Commit corrections
-- d. Push
-- e. RESTART from step 3 (automated tests)
-
-### 6. ADVERSARIAL REVIEW (if complexity = complex)
-
-**Only for 🔴 complex tickets:**
-
-```bash
-.claude/skills/sf-workflow/scripts/examine.sh {ticket-number}
-```
-
-**Run adversarial code review:**
-
-- Launch 3 parallel review agents
-- Security analysis (OWASP top 10)
-- Logic flaws detection
-- Performance issues identification
-- Classify findings by severity
-- Fix Critical/High findings immediately
-
-**If findings found:**
-
-- Fix Real issues
-- Commit corrections
-- Push
-- RESTART from step 3 (automated tests)
-- Re-run examine if needed
-
-**Follow the guidance from examine.sh.**
-
-### 7. IF ALL TESTS PASS (and examine complete if complex):
-
-- a. Create test report summary as comment
-- b. If examine was run: include findings summary
-- c. Commit and push final corrections (if any)
-- d. Automatically move to Human Testing
-
-## Exit Conditions
-
-- All automated tests pass ✅
-- Entire test plan executed and validated ✅
-- Adversarial review complete (if complex) ✅
-- All Critical/High findings fixed ✅
-- No problems detected
-- Code is pushed
-
-## Next Status
-
-**Human Testing**
-
-## Errors to Avoid
-
-❌ NEVER move to Human Testing with failing tests ❌ NEVER skip test plan steps ❌ NEVER say "it should work" - RUN the tests ❌ If a test fails, do NOT move to Human Testing, FIX it first ❌ NEVER
-skip examine phase for complex tickets ❌ NEVER ignore Critical/High security findings ❌ NEVER enter AI Testing while subtasks are still OPEN on GitHub — close them first (step 0 gate)
+- Moving to Human Testing with failing tests
+- Skipping test plan steps
+- Saying "it should work" — RUN the tests
+- Skipping examine for complex tickets
+- Ignoring Critical/High security findings
+- Entering AI Testing while subtasks are still OPEN on GitHub (gate rule)

--- a/scaffolds/skills-templates/workflow/statuses/5-human-testing.md
+++ b/scaffolds/skills-templates/workflow/statuses/5-human-testing.md
@@ -1,91 +1,49 @@
+---
+status: Human Testing
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - All AI Testing steps passed
+  - Test plan ready for human validation
+mandatory_actions:
+  - Wait for developer validation
+  - On bug report — fix, commit, push, return to AI Testing
+  - On approval — create non-regression tests (E2E for complex/critical, unit for edge-case bugs; none for typo/doc/CSS)
+  - Run created tests locally and ensure they pass
+  - Commit and push tests (`test(#<N>): <description>`)
+  - Be transparent when tests are intentionally skipped
+exit_conditions:
+  - Developer validated the feature
+  - Non-regression tests created (when applicable)
+  - Tests pass locally
+  - Code with tests pushed
+next_status: In Review (create PR)
+---
+
 # STATUS: Human Testing
 
-**ROLE**: Manual validation by human developer
+Manual validation by the developer, followed by non-regression test creation.
 
-> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
->
-> - **Epic** (`type: epic`): no manual test, no PR. Epic status is **derived** from children — it only enters `Human testing` when the last child does, and only leaves once every child has moved on.
->   Do not run the steps below for an Epic.
-> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — the developer validates, then E2E tests are written before moving to `In review`.
+## Ticket type
 
-## When to Enter This Status
+- **Epic** — no manual test, no PR. Status is **derived** from children (only enters Human Testing when the last child does). Skip this checklist.
+- **Story / Task / Issue** — full flow below.
 
-- After successfully passing all tests in AI Testing
-- Test plan is ready for human validation
+## Action checklist
 
-## Mandatory Actions
+- [ ] **Wait for validation** — developer tests manually, you stay available to answer
+- [ ] **On bugs reported:**
+  - Read the comments carefully, summarize the fix plan as a reply
+  - Fix, commit, push, then return to **AI Testing** (re-run automated tests)
+- [ ] **On approval** — create non-regression tests:
+  - Complex/critical → E2E tests (Playwright)
+  - Edge-case bug fix → unit non-regression test
+  - Typo/doc/CSS refactor → none (state why in a comment)
+- [ ] **Coverage** — main scenarios validated, edge cases identified, critical workflows
+- [ ] **Verify locally** — `npm run test:e2e` (or relevant runner) must be green
+- [ ] **Commit + push** — `test(#<N>): add E2E tests for <feature>` (pattern from `jq -r '.workflow.commitFormat.pattern' .saasfoundry.json`)
 
-### 1. WAIT FOR DEVELOPER VALIDATION
+## Errors to avoid
 
-- Do nothing, the developer will manually test
-- Stay available to answer questions
-
-### 2. IF DEVELOPER FINDS BUGS:
-
-- a. Read developer comments carefully
-- b. Add comment summarizing what will be fixed
-- c. Fix identified problems
-- d. Commit and push corrections
-- e. RETURN TO "AI TESTING" (re-run all automated tests)
-
-### 3. IF DEVELOPER VALIDATES ✅:
-
-**NOW, BEFORE CREATING THE PR:**
-
-#### a. CREATE NON-REGRESSION TESTS:
-
-- If complex/critical feature: create E2E tests (Playwright)
-- If edge case bug fix: create unit non-regression test
-- If simple feature (typo, doc, CSS): no E2E tests needed
-
-#### b. COVER IN TESTS:
-
-- Main user scenarios validated
-- Identified and fixed edge cases
-- Critical workflows
-
-#### c. VERIFY TESTS LOCALLY:
-
-- Run created E2E tests: `npm run test:e2e`
-- Ensure they all pass ✅
-
-#### d. COMMIT AND PUSH:
-
-**Read commit format from config:**
-
-```bash
-COMMIT_PATTERN=$(cat .saasfoundry.json | jq -r '.workflow.commitFormat.pattern')
-```
-
-**Commit and push:**
-
-- `git add .`
-- `git commit -m "test(#{N}): add E2E tests for {feature}"`
-  - Follow pattern from config: `${COMMIT_PATTERN}`
-  - Replace `#N` with ticket number
-  - Use type `test` for test commits
-- `git push`
-
-#### e. TRANSPARENCY:
-
-- If you decide NOT to create E2E tests, inform the developer
-- Explain why (e.g., "no E2E tests as simple CSS fix")
-
-## Exit Conditions
-
-- Developer validated the feature ✅
-- Non-regression tests created (if applicable)
-- Tests pass locally ✅
-- Code with tests is pushed
-
-## Next Status
-
-**In Review** (create PR)
-
-## Common Sense Rule
-
-✅ Create tests if: new feature, edge case bug fix, user workflow, critical code ❌ No need if: typo, docs, simple CSS refactor, experimental feature
-
-## Errors to Avoid
-
-❌ NEVER create tests BEFORE developer validation ❌ NEVER create PR without creating non-regression tests ❌ NEVER push failing tests
+- Creating tests BEFORE developer validation
+- Creating a PR without non-regression coverage
+- Pushing failing tests

--- a/scaffolds/skills-templates/workflow/statuses/6-in-review.md
+++ b/scaffolds/skills-templates/workflow/statuses/6-in-review.md
@@ -1,75 +1,44 @@
+---
+status: In Review
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - Human Testing validated
+  - Non-regression tests created and pushed
+  - Ready to open the Pull Request
+mandatory_actions:
+  - Create the Pull Request (title + description + test plan + test list + reviewers + ticket link)
+  - Move ticket to `In Review`
+  - Monitor CI until green
+  - Answer reviewer comments and implement requested changes
+  - Add tests when reviewer asks; verify locally, commit, push, wait for green CI
+  - Wait for approval AND green CI — do NOT merge
+exit_conditions:
+  - PR approved by all required reviewers
+  - CI is green
+  - Developer merged the PR to the target branch
+next_status: Done
+---
+
 # STATUS: In Review
 
-**ROLE**: Code review + mandatory green CI
+Code review with mandatory green CI.
 
-> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
->
-> - **Epic** (`type: epic`): **NEVER produces a PR**. Do not open one, do not attach one. Epic status in `In review` is purely **derived** from children — it reflects that every child Story/Task/Issue
->   is itself in `In review` (one open PR per child). Skip all steps below.
-> - **Story / Task / Issue** (`type: story | task | issue`): full flow below — each one opens its own PR.
+## Ticket type
 
-## When to Enter This Status
+- **Epic** — **never produces a PR**. Status is **derived** — reflects that every child Story/Task/Issue is itself in `In Review` (one open PR per child). Skip the checklist.
+- **Story / Task / Issue** — full flow below, one PR each.
 
-- After validation in Human Testing
-- Non-regression tests created and pushed
-- Ready to create the Pull Request
+## Action checklist
 
-## Mandatory Actions
+- [ ] **Create the PR** — title = ticket title; description = ticket link + change summary + test plan (copy from ticket) + created tests (unit + E2E); assign configured reviewers; link PR to ticket
+- [ ] **Move ticket** to `In Review` via `workflow-cli.sh update-status`
+- [ ] **Monitor CI** — on red: analyze logs, fix, commit, push, wait for green
+- [ ] **Monitor reviews** — answer questions, implement requested changes
+- [ ] **Reviewer asks for extra tests** — create them, run locally, commit, push, wait for green CI, resolve conversation
+- [ ] **Wait for approval + green CI** — do nothing until the developer merges
 
-### 1. CREATE THE PULL REQUEST
+## Errors to avoid
 
-- Title: Repeat the ticket title
-- Description:
-  - Link to the ticket
-  - Summary of changes
-  - Test plan (copy from ticket)
-  - List of created tests (unit + E2E)
-- Assign configured reviewers
-- Link PR to ticket
-
-### 2. MOVE TICKET TO "IN REVIEW"
-
-- Update status in the project management tool
-
-### 3. MONITOR CI
-
-- CI will run the full test suite (unit + E2E)
-- If CI is red 🔴:
-  - a. Analyze error logs
-  - b. Fix problems
-  - c. Commit and push
-  - d. Wait for CI to turn green ✅
-
-### 4. MONITOR REVIEW COMMENTS
-
-- Read all reviewer comments
-- Answer questions
-- Implement requested changes
-
-### 5. IF REVIEWER REQUESTS ADDITIONAL TESTS:
-
-- a. Create requested tests (unit or E2E)
-- b. Run tests locally to verify
-- c. Commit and push tests
-- d. Wait for CI to pass ✅
-- e. Resolve conversation when done
-
-### 6. WAIT FOR APPROVAL AND GREEN CI
-
-- ⚠️ MANDATORY CONDITION: CI must be green ✅
-- Developer will merge ONLY if CI is green
-- Do nothing until merged
-
-## Exit Conditions
-
-- PR approved by all required reviewers
-- CI is green ✅ (all tests pass)
-- Developer has merged the PR to target branch
-
-## Next Status
-
-**Done**
-
-## Errors to Avoid
-
-❌ NEVER ask developer to merge with red CI ❌ NEVER ignore test failures in CI ❌ NEVER merge yourself (unless explicit instruction)
+- Asking the developer to merge with red CI
+- Ignoring test failures in CI
+- Merging yourself (unless explicitly instructed)

--- a/scaffolds/skills-templates/workflow/statuses/7-done.md
+++ b/scaffolds/skills-templates/workflow/statuses/7-done.md
@@ -1,62 +1,40 @@
+---
+status: Done
+complexity_profiles: [bug, low, medium, complex]
+entry_conditions:
+  - PR merged by the developer
+  - Code is on the target branch
+mandatory_actions:
+  - Move ticket to `Done`
+  - Local branch cleanup — checkout working branch, rebase-pull, delete feature branch
+  - Rebase any other in-progress branches on the fresh working branch
+exit_conditions:
+  - Ticket marked `Done`
+  - Local feature branch deleted
+  - Other in-progress branches rebased
+next_status: N/A (end of cycle)
+---
+
 # STATUS: Done
 
-**ROLE**: Finalization and cleanup after merge
+Finalization and cleanup after merge.
 
-> **ℹ️ Ticket type matters** (see `SKILL.md` → "Ticket Hierarchy"):
->
-> - **Epic** (`type: epic`): `Done` is **derived** — the Epic only moves to `Done` when **every** child Story/Task/Issue has been merged and closed. No branch to delete, no cleanup to run. Just close
->   the Epic issue once the last child reaches `Done`.
-> - **Story / Task / Issue** (`type: story | task | issue`): full cleanup flow below — after the PR is merged by the developer.
+## Ticket type
 
-## When to Enter This Status
+- **Epic** — `Done` is **derived** only when every child Story/Task/Issue is merged and closed. No branch to delete. Close the Epic issue once the last child reaches `Done`.
+- **Story / Task / Issue** — full cleanup flow below.
 
-- PR has been merged by the developer
-- Code is now in the main branch
+## Action checklist
 
-## Mandatory Actions
+- [ ] **Move ticket to Done** via `workflow-cli.sh update-status <ticket> Done`
+- [ ] **Local cleanup** (working branch from `jq -r '.workflow.workingBranch' .saasfoundry.json`):
+  - `git checkout <workingBranch>`
+  - `git pull origin <workingBranch> --rebase`
+  - `git branch -d <feature-branch>`
+- [ ] **Rebase other in-progress branches** on the refreshed working branch:
+  - per branch: `git checkout <other> && git rebase <workingBranch>` → resolve conflicts → `git push --force-with-lease`
 
-### 1. MOVE TICKET TO "DONE"
+## Errors to avoid
 
-- Update status in the project management tool
-
-### 2. LOCAL BRANCH CLEANUP
-
-**Read working branch from config:**
-
-```bash
-WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
-```
-
-**Cleanup:**
-
-1. `git checkout ${WORKING_BRANCH}`
-2. `git pull origin ${WORKING_BRANCH} --rebase`
-3. `git branch -d {feature-branch}`
-
-### 3. IF OTHER BRANCHES ARE IN PROGRESS
-
-**Rebase other branches with updated working branch:**
-
-```bash
-WORKING_BRANCH=$(cat .saasfoundry.json | jq -r '.workflow.workingBranch')
-
-# For each other branch:
-git checkout {other-branch}
-git rebase ${WORKING_BRANCH}
-# Resolve conflicts if necessary
-git push --force-with-lease
-```
-
-## Exit Conditions
-
-- Ticket marked Done
-- Local branch deleted
-- Other branches rebased
-
-## Next Status
-
-N/A (end of cycle)
-
-## Errors to Avoid
-
-❌ NEVER move to Done before actual merge ❌ NEVER forget to rebase other in-progress branches
+- Moving to Done before the actual merge
+- Forgetting to rebase other in-progress branches

--- a/scaffolds/skills-templates/workflow/workflow-cli.sh
+++ b/scaffolds/skills-templates/workflow/workflow-cli.sh
@@ -65,29 +65,27 @@ route_to_tool() {
   "$tool_cli" "$@"
 }
 
-# Function to get current status of a ticket
+# Function to get current status of a ticket.
+#
+# Uses the tool CLI's --json flag and parses with jq — no more grep|awk on
+# human-oriented output. Tool CLIs without --json support fall back to the
+# legacy "Status: X" line so installers can upgrade skills independently.
 get_current_status() {
   local ticket=$1
   local status=""
+  local payload
 
   load_config
 
   case "$WORKFLOW_TOOL" in
-    github-projects)
-      # Delegate to GitHub Projects tool CLI
-      status=$(route_to_tool github-projects status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
-      ;;
-    jira)
-      # Delegate to Jira tool CLI
-      status=$(route_to_tool jira status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
-      ;;
-    notion)
-      # Delegate to Notion tool CLI
-      status=$(route_to_tool notion status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
-      ;;
-    linear)
-      # Delegate to Linear tool CLI
-      status=$(route_to_tool linear status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
+    github-projects|jira|notion|linear)
+      payload=$(route_to_tool "$WORKFLOW_TOOL" status "$ticket" --json 2>/dev/null || true)
+      if [[ -n "$payload" ]] && echo "$payload" | jq -e . >/dev/null 2>&1; then
+        status=$(echo "$payload" | jq -r '.status // ""')
+      else
+        # Legacy fallback — tool CLI has no --json yet
+        status=$(route_to_tool "$WORKFLOW_TOOL" status "$ticket" 2>&1 | grep "^Status:" | awk -F': ' '{print $2}')
+      fi
       ;;
     *)
       echo -e "${RED}Unknown workflow tool: $WORKFLOW_TOOL${NC}" >&2

--- a/src/__tests__/unit/skill/github-projects-cli.status-json.spec.ts
+++ b/src/__tests__/unit/skill/github-projects-cli.status-json.spec.ts
@@ -1,0 +1,163 @@
+import { execFile } from 'node:child_process'
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileP = promisify(execFile)
+
+// Regression guard for PR #283 (Story #279): the `status --json` mode is the
+// machine-readable interface that `workflow-cli.sh get_current_status` now
+// parses via jq instead of grep/awk. If the JSON shape drifts, the workflow
+// skill silently breaks — so we pin the contract here (ticket/title/state/
+// status/labels) and the flag-order behavior (the reviewer of PR #283 claimed
+// `status <n> --json` would lose the ticket number; proving them wrong is part
+// of the contract).
+const CLI = path.resolve(__dirname, '../../../../.claude/skills/sf-tool-github-projects/github-projects-cli.sh')
+const BASH = '/bin/bash'
+
+async function buildSandbox(): Promise<{ dir: string; env: NodeJS.ProcessEnv; cleanup: () => Promise<void> }> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sf-gh-status-json-'))
+  const binDir = path.join(dir, 'bin')
+  await mkdir(binDir, { recursive: true })
+
+  await writeFile(
+    path.join(dir, '.saasfoundry.json'),
+    JSON.stringify({
+      workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' }
+    })
+  )
+
+  // gh shim:
+  //  - `repo view --json nameWithOwner --jq '.nameWithOwner'` → FakeOrg/FakeRepo
+  //  - `api graphql ...` → issue #277 found on project 42 with status "In progress";
+  //    issue #999 returns null (not-found path).
+  //  - `issue view <n> --json labels --jq '[.labels[].name]'` → array of labels
+  const shim = `#!/bin/bash
+case "$1" in
+  repo)
+    # gh repo view --json nameWithOwner --jq '.nameWithOwner'
+    echo "FakeOrg/FakeRepo"
+    ;;
+  api)
+    # Only graphql is used here. Grab the -F "n=<ticket>" arg to decide which
+    # issue to emulate.
+    ticket=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -F)
+          case "$2" in
+            n=*) ticket=\${2#n=} ;;
+          esac
+          shift 2
+          ;;
+        *) shift ;;
+      esac
+    done
+    if [ "$ticket" = "999" ]; then
+      echo '{"data":{"repository":{"issue":null}}}'
+    else
+      cat <<EOF
+{"data":{"repository":{"issue":{"title":"Sample ticket","state":"OPEN","projectItems":{"nodes":[{"id":"PVTI_ABC","project":{"number":42},"fieldValueByName":{"name":"In progress"}}]}}}}}
+EOF
+    fi
+    ;;
+  issue)
+    # gh issue view <num> --json labels --jq '[.labels[].name]'
+    case "$2" in
+      view)
+        echo '["bug","priority:high"]'
+        ;;
+      *) echo '{}' ;;
+    esac
+    ;;
+  *)
+    echo '{}'
+    ;;
+esac
+`
+  const shimPath = path.join(binDir, 'gh')
+  writeFileSync(shimPath, shim)
+  chmodSync(shimPath, 0o755)
+
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    PWD: dir
+  }
+
+  return { dir, env, cleanup: () => rm(dir, { recursive: true, force: true }) }
+}
+
+async function runCli(args: string[], sandbox: { dir: string; env: NodeJS.ProcessEnv }): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await execFileP(BASH, [CLI, ...args], { cwd: sandbox.dir, env: sandbox.env })
+    return { stdout, stderr, code: 0 }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; code?: number }
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: typeof e.code === 'number' ? e.code : 1 }
+  }
+}
+
+describe('sf-tool-github-projects — status --json contract', () => {
+  let sandbox: Awaited<ReturnType<typeof buildSandbox>>
+
+  beforeEach(async () => {
+    sandbox = await buildSandbox()
+  })
+
+  afterEach(async () => {
+    await sandbox.cleanup()
+  })
+
+  it('returns the documented JSON shape with --json after the ticket', async () => {
+    const res = await runCli(['status', '277', '--json'], sandbox)
+    expect(res.code).toBe(0)
+    const payload = JSON.parse(res.stdout)
+    expect(payload).toEqual({
+      ticket: 277,
+      title: 'Sample ticket',
+      state: 'OPEN',
+      status: 'In progress',
+      labels: ['bug', 'priority:high']
+    })
+  })
+
+  it('returns the same shape with --json before the ticket (flag-order independence)', async () => {
+    const res = await runCli(['status', '--json', '277'], sandbox)
+    expect(res.code).toBe(0)
+    const payload = JSON.parse(res.stdout)
+    expect(payload.ticket).toBe(277)
+    expect(payload.title).toBe('Sample ticket')
+    expect(payload.status).toBe('In progress')
+  })
+
+  it('emits not-found error JSON with exit code 1 when the issue does not resolve', async () => {
+    const res = await runCli(['status', '999', '--json'], sandbox)
+    expect(res.code).toBe(1)
+    const payload = JSON.parse(res.stdout)
+    expect(payload).toEqual({
+      ticket: 999,
+      title: '',
+      state: '',
+      status: '',
+      labels: [],
+      error: 'not-found'
+    })
+  })
+
+  it('falls back to human-readable output when --json is omitted', async () => {
+    const res = await runCli(['status', '277'], sandbox)
+    expect(res.code).toBe(0)
+    expect(res.stdout).toContain('Issue #277: Sample ticket')
+    expect(res.stdout).toContain('State: OPEN')
+    expect(res.stdout).toContain('Status: In progress')
+  })
+
+  it('exits 1 with usage message when no ticket is provided', async () => {
+    const res = await runCli(['status', '--json'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stderr).toMatch(/Usage: .* status <ticket-number> \[--json\]/)
+  })
+})


### PR DESCRIPTION
## Summary

Makes `sf-workflow` status reads deterministic across agent runs by swapping prose-heavy status docs for YAML frontmatter + bullet checklists, and by parsing tool-CLI output as JSON instead of grep|awk.

- `statuses/*.md` (10 files) rewritten with YAML frontmatter (`status`, `complexity_profiles`, `entry_conditions`, `exit_conditions`, `mandatory_actions`, `next_status`) + bullet action checklists. No narrative paragraphs; intent sentence at top.
- `github-projects-cli.sh status` gains `--json` flag emitting `{ticket, title, state, status, labels}`.
- `workflow-cli.sh get_current_status`: `grep "Status:" | awk ...` replaced by `route_to_tool ... --json | jq -r '.status'`. Legacy path preserved as fallback.
- ~630 lines dropped across status files (counted as -1438 / +816 diff lines covering both dogfood + scaffold copies).
- Drift guard green on all 23 pairs.

Closes #279. Part of Epic #277.

## Test plan

- [x] `npx jest src/__tests__/unit/skill/tool-skill-drift.spec.ts` — 23 pairs pass
- [x] `npm test` — 1152 tests pass, 0 failures
- [x] Pre-commit + pre-push Docker tests green
- [x] Smoke test: `.claude/skills/sf-workflow/workflow-cli.sh status 277` returns the new YAML-framed description with correct current status
- [x] Smoke test: `.../github-projects-cli.sh status 277 --json` emits the documented JSON shape
- [ ] Human review: confirm YAML frontmatter + bullets read clearly vs old prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)