### PR TITLE
refactor(#280): sf-srs determinism — extract clustering rules + eval hook heuristics

### DIFF
--- a/.claude/skills/sf-srs/SKILL.md
+++ b/.claude/skills/sf-srs/SKILL.md
@@ -330,145 +330,17 @@ Output example:
 }
 ```
 
-Five scanner kinds fire today (see `docs/srs/scanner-findings.md` for the full JSON shape) :
+Scanner kinds, clustering steps, DS/TC/NFR seeding rules, coverage-table template, and review-loop prompt shape live as structured data in [`data/clustering-rules.json`](data/clustering-rules.json).
+Read that file once per drafting session — it is the source of truth. The JSON replaces prose that used to span ~180 lines of this SKILL.md.
 
-| Kind          | Source of truth                                | Area heuristic                                      |
-| ------------- | ---------------------------------------------- | --------------------------------------------------- |
-| `endpoint`    | NestJS `@Controller` + method decorators       | nearest `src/modules/<area>/`                       |
-| `ui-flow`     | React pages linked from `routes.tsx`           | `src/pages/<area>/<PageName>`                       |
-| `entity`      | Prisma `model` blocks                          | model-name dictionary (User→users, Session→auth, …) |
-| `test`        | Jest `describe` / `it` / `test` in `*.spec.ts` | `src/modules/<area>/` or filename stem              |
-| `doc-context` | `README.md` / `CLAUDE.md` / `docs/**/*.md`     | folder name (`docs`, `modules`, …)                  |
+Operational quick-reference (full detail in the JSON):
 
-### Reading the findings[] output
-
-For each finding :
-
-- **Every shape has `kind` + `title`** — use them for first-pass clustering.
-- **`area`** is the glue : findings that share an `area` usually belong to the same Epic / FR cluster.
-- **`file`** is the authoritative path — quote it back to the user when proposing a cluster ("FR-Auth — based on `api/src/modules/auth/auth.controller.ts` + `api/prisma/schema/auth.prisma`").
-- **`endpoint.hasTests`** flags `true` when the same `area` has at least one test finding — use it to prime the TC section of the proposed FR.
-- **`ui-flow.linkedEndpointGuess`** is a soft hint (filename / route substring match against endpoint paths) — verify it against the actual endpoint list before trusting it.
-- **`doc-context.excerpt`** is capped at 280 chars — treat it as a **summary seed**, not the full text.
-
-### Clustering into `DraftCandidate[]`
-
-The skill's job is to convert raw findings into publishable draft candidates. Work **Epic-by-Epic, then FR-by-FR** :
-
-1. **Group by area.** Collect every finding whose `area` matches. Add `doc-context` findings that share the area name or a parent folder.
-2. **Pick the Epic level.** One Epic per coherent area (e.g. `auth`, `storage`, `accounts`). Title + narrative come from the richest `doc-context` in the group, or from the user's wording.
-3. **Propose the FRs.**
-   - One FR per `endpoint` (or per tight endpoint cluster — e.g. CRUD on the same resource collapses into one FR).
-   - Reuse `ui-flow` routes as acceptance criteria on the user-facing FR.
-   - Populate `dsRefs` / `tcRefs` from the items seeded in step 4 so the FR page surfaces the traceability links.
-4. **Seed the Epic-level DS / TC / NFR sections.** Every Epic carries the SRS five-category shape (UR + FR + DS + TC + NFR) — see the canonical example at `templates/examples/example-epic.md`
-   (rendered) / `templates/examples/example-epic.spec.json` (machine-readable) for the exact layout. The seeding rules below turn scanner findings into initial items the reviewer accepts / edits /
-   rejects.
-5. **Flag gaps.** Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a **TODO** TC item (title `"{METHOD} {PATH} — happy path"`, `expectedResult: "to write"`), not silently.
-
-### Seeding DS / TC / NFR (five-category completeness)
-
-These three sections are **interpretive** — scanners surface the raw material, the agent synthesises the items. Reuse the L1+L2+L3 pattern from the eval (`docs/srs/scanner-findings.md`): deterministic
-findings feed AI prompts, the agent always runs, the user always validates before write.
-
-#### DS items (Design Specifications)
-
-One `DsItem` per material design decision visible in code. Source findings → seeded `DsItem`:
-
-| Finding                                                      | Seeded `DsItem.title`            | Seeded `description` source                                                |
-| ------------------------------------------------------------ | -------------------------------- | -------------------------------------------------------------------------- |
-| `entity` (Prisma model)                                      | `Data model — <EntityName>`      | fields + `@unique` / `@id` / `@relation` + `deletedAt` flag                |
-| `endpoint` with non-trivial DTO (POST/PATCH body ≥ 2 fields) | `API contract — <METHOD> <path>` | DTO field list + validation rules surfaced by `class-validator` decorators |
-| `ui-flow` with `formFields.length ≥ 2`                       | `UI form — <PageName>`           | form field list + `linkedEndpointGuess` if present                         |
-
-Group by the Epic's area; set `frRefs` to every FR in the group whose endpoint/entity/UI flow matches. Deduplicate by title prefix — if two entities share the same core name (e.g. `User` +
-`UserProfile`), collapse them into a single DS item with both sub-models listed in the description.
-
-#### TC items (Test Cases)
-
-One `TcItem` per `test.cases[]` entry. Source mapping:
-
-| Source                                   | Seeded `TcItem` field                                                                                |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `test.cases[i].title`                    | `title` (the `it(...)` / `test(...)` string verbatim)                                                |
-| `test.cases[i]` structure                | `steps` — parse Given/When/Then from the title if phrased that way, else bullet the `describe` chain |
-| assertion in the test body (if readable) | `expectedResult`; if not parseable, use `"see <test.file>"`                                          |
-| `test.area` or `endpoint.area`           | `frRefs` — every FR whose area matches                                                               |
-
-**Untested endpoints** — for each `endpoint` with `hasTests=false`, emit a **TODO** TC item so the drift is auditable, not invisible:
-
-```jsonc
-{
-  "id": "TC-<area>-<slug>-todo",
-  "title": "<METHOD> <path> — happy path",
-  "expectedResult": "to write",
-  "frRefs": ["<FR-id>"]
-}
-```
-
-The reviewer can either accept the TODO (making the gap part of the public contract) or reject it and flag it upstream.
-
-#### NFR items (Non-Functional Requirements)
-
-NFRs are **proposed, not derived** — every seeded item must be marked for explicit human validation. Build the candidate list from two layers:
-
-**Layer 1 — stack signals** (present in `.saasfoundry.json` or inferred from findings):
-
-| Signal                                                                                       | Seeded NFR(s)                                                                                                                                             |
-| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `auth` module present (endpoints under `/auth/*` or Prisma `Session` / `RefreshToken` model) | `Security — JWT access token expiry ≤ 15 min`; `Security — refresh token rotation on every use`; `Security — login rate limit ≤ 5 attempts / minute / IP` |
-| `i18n` module (`src/locales/` folder or `i18next` dep)                                       | `i18n — all user-facing strings translated in FR + EN`; `a11y — locale switchable without page reload`                                                    |
-| Prisma + Postgres detected                                                                   | `Data — soft delete via deletedAt on user-owned entities`; `Data — all migrations reversible (up + down)`                                                 |
-| `docker-compose*.yml` + `/health` endpoint present                                           | `Ops — API health check p95 ≤ 1 s`                                                                                                                        |
-| Playwright or e2e spec files present                                                         | `Quality — e2e coverage on critical user flows (login, signup, checkout when applicable)`                                                                 |
-| `@nestjs/swagger` + `docs/openapi.json` generated                                            | `Docs — OpenAPI spec regenerated on every API change (CI guard)`                                                                                          |
-
-**Layer 2 — standard SaaS catalogue** (always propose, mark low-confidence):
-
-- `Perf — p95 API latency ≤ 500 ms at 100 req/s sustained`
-- `Availability — uptime target 99.5% (excluding scheduled maintenance)`
-- `Security — all user-uploaded files virus-scanned before persistence` (only if storage module present)
-- `Privacy — PII fields encrypted at rest` (only if the schema carries `email`, `phone`, `address`)
-
-Always emit NFRs with `priority: 'P3'` and `target: '<proposed — needs human validation>'`. The reviewer lifts priority / refines target before accepting.
-
-#### Coverage table (pre-accept)
-
-Before firing the review prompt on an Epic cluster, emit a one-shot **coverage table** so the reviewer sees what got seeded per category and where it came from:
-
-```
-SRS coverage for Epic: <title>
-┌──────┬───────────────┬──────────────────────────────────────────────┐
-│ Cat  │ Items proposed│ Source                                       │
-├──────┼───────────────┼──────────────────────────────────────────────┤
-│ UR   │ 3             │ doc-context + inferred from FRs              │
-│ FR   │ 5             │ 5 endpoint clusters                          │
-│ DS   │ 4             │ 2 entities + 1 endpoint + 1 UI form          │
-│ TC   │ 8 (+ 2 TODO)  │ test.cases[] across 3 spec files             │
-│ NFR  │ 4 (proposed)  │ auth + i18n + prisma + playwright signals    │
-└──────┴───────────────┴──────────────────────────────────────────────┘
-```
-
-A cluster with **zero DS or zero TC** is a red flag — either the area is genuinely pure UI glue (no data model, no tests yet) or the scanners missed something. Surface the anomaly in the review prompt
-rather than silently proposing an Epic with empty sections.
-
-### Review-loop prompts
-
-Never write to Notion without confirmation. Drive the loop one cluster at a time :
-
-```
-🔍 J'ai trouvé <N> éléments dans le scanner pour le domaine `<area>`. Je te propose de créer :
-
-  📘 Epic : <title>
-     ├─ FR : <title 1>  (based on: <file-1>, <file-2>)
-     ├─ FR : <title 2>  (based on: <file-3>)
-     └─ gaps : <endpoint without tests>, <page without linked endpoint>
-
-Je pars sur cette structure, ou tu veux retailler l'Epic ? [accept / edit / reject / skip-area]
-```
-
-On **accept** → serialise the cluster as `DraftCandidate[]` and call `srs-cli.sh write --spec <tmp.json>`. On **edit** → negotiate the title / narrative / FR split and re-confirm. On **skip-area** →
-park the area and continue with the next. Never batch-accept more than **one Epic per prompt** — the reviewer has to be able to course-correct cluster by cluster.
+- **Five scanner kinds** (`endpoint`, `ui-flow`, `entity`, `test`, `doc-context`) — see `docs/srs/scanner-findings.md` for the JSON shape.
+- **Clustering**: work Epic-by-Epic, then FR-by-FR. Group by `area`, one Epic per coherent area, one FR per endpoint (or tight endpoint cluster).
+- **Five-category seeding** (UR + FR + DS + TC + NFR): scanners surface raw material, the agent synthesises, the user validates before write. NFRs are always marked `priority: P3` and
+  `target: '<proposed — needs human validation>'` until the reviewer accepts.
+- **Untested endpoints** emit a TODO TC item so drift is auditable — never silently drop them.
+- **Review loop**: one Epic per prompt, branches `[accept / edit / reject / skip-area]`. Never batch-accept. Never write without confirmation.
 
 ### Exit codes
 
@@ -484,65 +356,20 @@ park the area and continue with the next. Never batch-accept more than **one Epi
 
 ## Conversational eval hook (SUB-10)
 
-When the project declares `tools.srs.enabled = true` in `.saasfoundry.json`, Claude is responsible for **interjecting** during conversation turns whose content looks like a new Software Requirement.
-There is no message parser and no standalone script — the "hook" is Claude reading the heuristics below and self-invoking. The `sf-workflow` skill's SKILL.md references this section and stays out of
-the way.
+When the project declares `tools.srs.enabled = true` in `.saasfoundry.json`, Claude interjects during conversation turns whose content looks like a new Software Requirement. There is no message parser
+baked into the runtime — the "hook" is Claude reading the rules and self-invoking. The `sf-workflow` skill's SKILL.md references this section and stays out of the way.
 
-### Detection heuristics — when to fire
+Detection heuristics, confirmation prompt, patch shape, and v1 scope limits live as structured rules in [`scripts/detect-eval-signals.sh`](scripts/detect-eval-signals.sh). Two modes:
 
-Fire at most **once per conversation turn**. Skip trivial turns (pure tool invocations, "ok", "thanks", "read X", "what does this do"). Fire when the user's message matches **any** of the following
-signals :
+- `detect-eval-signals.sh --rules` — emits the full rules + patch shape as JSON. Read this once per session; it is the source of truth.
+- `detect-eval-signals.sh --classify "<text>"` (or stdin) — crude regex prefilter over a turn, returns `{signal, confidence, target}`. Use it to cheap-skip trivial turns; the agent still has the final
+  say on whether to fire.
 
-| Signal                                   | Target                              | Example utterance                                               |
-| ---------------------------------------- | ----------------------------------- | --------------------------------------------------------------- |
-| Describes a **user need / outcome**      | new **UR** on the Epic page         | "users should be able to log in with SSO"                       |
-| Defines a new **feature or rule**        | new **FR** page under the Epic      | "we need a feature that lets admins export audit logs as CSV"   |
-| Clarifies an **implementation decision** | new **DS** on the relevant FR page  | "let's use BCrypt with cost factor 12 for password hashing"     |
-| Adds an **acceptance / test condition**  | new **TC** on the relevant FR page  | "and a test that proves unicode passwords are accepted"         |
-| Reopens a **previously closed decision** | likely an **FR** or **DS** revision | "on reconsidère la règle : finalement on autorise les chiffres" |
+Fire at most **once per conversation turn**. On a signal hit, propose a diff in plain text, wait for `accept / edit / reject`, and — on accept — pipe the patch through
+`.claude/skills/sf-srs/scripts/srs-cli.sh apply-update`. v1 is ADD-only and appends to an "Added …" heading on the target page; the reviewer folds it back into the canonical section during the next
+human SRS review.
 
-Treat as **trivial and skip** : formatting nitpicks, small bug reports already covered by an existing FR, performance tweaks without observable user impact, pure refactor requests.
-
-### Confirmation flow
-
-When a signal fires, **pause before coding** and propose a diff in plain text :
-
-```
-💡 Ce que tu viens de décrire ressemble à <UR / FR / DS / TC>. Proposition :
-  • <target page> — add <item id> : <narrative | title>
-  • (if TC)        steps : ...
-
-J'applique via `srs-cli.sh apply-update` ? [accept / edit / reject]
-```
-
-- **accept** → build the patch JSON (see shape below) and run `.claude/skills/sf-srs/scripts/srs-cli.sh apply-update < patch.json` (or pipe via stdin). On exit 0, continue with the coding task.
-- **edit** → rework the proposed item text with the user, then re-confirm.
-- **reject** → drop the proposal and continue. Do **not** re-propose the same item in the same conversation.
-
-### Patch shape consumed by `apply-update`
-
-```jsonc
-{
-  "kind": "add-ur" | "add-fr" | "add-ds" | "add-tc",
-  "pageId": "<epic page id for add-ur / add-fr, FR page id for add-ds / add-tc>",
-  "item": { /* UrItem | FrSpec | DsItem | TcItem, same shapes as src/builders/srs/types.ts */ },
-  "note": "optional free-text annotation appended as a paragraph"
-}
-```
-
-### Scope limits (v1, intentional)
-
-- **ADD-only.** Modifying an existing item (e.g. tightening FR-012's acceptance criteria) is **out of scope** — the current `SrsAdapter.updatePage` is append-only on Notion, so surgical section
-  replacement is not available through the contract. A follow-up SUB will extend the adapter with replace/delete semantics.
-- **Append placement.** `add-ur` / `add-ds` / `add-tc` append new blocks to the **end** of the target page under an "Added …" heading2. The canonical section (User Requirements / Design / Test Cases)
-  is _not_ updated in-place. Reviewers must fold the appended block back into the right section during the next human SRS review. The limitation is deliberate and documented.
-- **`add-fr`** creates a brand-new child page under the Epic via `adapter.createFrPage`. The Epic page's "Traceability" table is **not** refreshed (same append-only limitation) — the new FR is still
-  discoverable as a child page.
-- **Throttling.** 1 proposal maximum per conversation turn. No persistent dedup cache (the turn boundary is sufficient — Claude's own judgment avoids re-proposing within the same turn).
-
-### Dogfood checklist
-
-After any change to the heuristics above, run a short manual session : drop 5 utterances (one per signal row + one trivial control) and confirm the hook fires exactly on the four signals and skips the
+After any change to the rules or classifier, run a short dogfood session: 5 utterances (one per signal row + one trivial control), confirm the hook fires exactly on the four signals and skips the
 trivial one.
 
 ## How other skills hand off to `sf-srs`

--- a/.claude/skills/sf-srs/data/clustering-rules.json
+++ b/.claude/skills/sf-srs/data/clustering-rules.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./clustering-rules.schema.json",
+  "version": 1,
   "description": "Structured clustering & seeding rules consumed by the sf-srs drafting flow (`srs-cli.sh draft --from codebase`). SKILL.md points to this file; edit here, not in prose.",
   "finding_kinds": [
     {

--- a/.claude/skills/sf-srs/data/clustering-rules.json
+++ b/.claude/skills/sf-srs/data/clustering-rules.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "./clustering-rules.schema.json",
+  "description": "Structured clustering & seeding rules consumed by the sf-srs drafting flow (`srs-cli.sh draft --from codebase`). SKILL.md points to this file; edit here, not in prose.",
+  "finding_kinds": [
+    {
+      "kind": "endpoint",
+      "source": "NestJS @Controller + method decorators",
+      "area_heuristic": "nearest src/modules/<area>/"
+    },
+    {
+      "kind": "ui-flow",
+      "source": "React pages linked from routes.tsx",
+      "area_heuristic": "src/pages/<area>/<PageName>"
+    },
+    {
+      "kind": "entity",
+      "source": "Prisma `model` blocks",
+      "area_heuristic": "model-name dictionary (User→users, Session→auth, …)"
+    },
+    {
+      "kind": "test",
+      "source": "Jest describe / it / test in *.spec.ts",
+      "area_heuristic": "src/modules/<area>/ or filename stem"
+    },
+    {
+      "kind": "doc-context",
+      "source": "README.md / CLAUDE.md / docs/**/*.md",
+      "area_heuristic": "folder name (docs, modules, …)"
+    }
+  ],
+  "reading_findings": [
+    "Every shape has `kind` + `title` — use them for first-pass clustering.",
+    "`area` is the glue: findings that share an `area` usually belong to the same Epic / FR cluster.",
+    "`file` is the authoritative path — quote it back to the user when proposing a cluster.",
+    "`endpoint.hasTests` flags `true` when the same `area` has at least one test finding — use it to prime the TC section.",
+    "`ui-flow.linkedEndpointGuess` is a soft hint (filename / route substring match) — verify before trusting.",
+    "`doc-context.excerpt` is capped at 280 chars — treat it as a summary seed, not the full text."
+  ],
+  "epic_fr_clustering": {
+    "order": "Epic-by-Epic, then FR-by-FR",
+    "steps": [
+      {
+        "id": 1,
+        "name": "Group by area",
+        "action": "Collect every finding whose `area` matches. Add `doc-context` findings that share the area name or a parent folder."
+      },
+      {
+        "id": 2,
+        "name": "Pick the Epic level",
+        "action": "One Epic per coherent area (e.g. `auth`, `storage`, `accounts`). Title + narrative come from the richest `doc-context` in the group, or from the user's wording."
+      },
+      {
+        "id": 3,
+        "name": "Propose the FRs",
+        "rules": [
+          "One FR per `endpoint` (or per tight endpoint cluster — CRUD on the same resource collapses into one FR).",
+          "Reuse `ui-flow` routes as acceptance criteria on the user-facing FR.",
+          "Populate `dsRefs` / `tcRefs` from the items seeded in step 4 so the FR surfaces traceability links."
+        ]
+      },
+      {
+        "id": 4,
+        "name": "Seed the Epic-level DS / TC / NFR sections",
+        "action": "Every Epic carries the SRS five-category shape (UR + FR + DS + TC + NFR). See `templates/examples/example-epic.md` (rendered) and `templates/examples/example-epic.spec.json` (machine-readable) for the exact layout. Apply the `seeding` rules below."
+      },
+      {
+        "id": 5,
+        "name": "Flag gaps",
+        "action": "Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a **TODO** TC item (title `\"{METHOD} {PATH} — happy path\"`, `expectedResult: \"to write\"`), not silently."
+      }
+    ]
+  },
+  "seeding": {
+    "philosophy": "Scanners surface raw material, the agent synthesises items. Reuse the L1+L2+L3 pattern from the eval: deterministic findings feed AI prompts, the agent always runs, the user always validates before write.",
+    "ds_items": {
+      "description": "One `DsItem` per material design decision visible in code.",
+      "mappings": [
+        {
+          "finding": "entity (Prisma model)",
+          "title": "Data model — <EntityName>",
+          "description_source": "fields + @unique / @id / @relation + deletedAt flag"
+        },
+        {
+          "finding": "endpoint with non-trivial DTO (POST/PATCH body ≥ 2 fields)",
+          "title": "API contract — <METHOD> <path>",
+          "description_source": "DTO field list + validation rules surfaced by class-validator decorators"
+        },
+        {
+          "finding": "ui-flow with formFields.length ≥ 2",
+          "title": "UI form — <PageName>",
+          "description_source": "form field list + linkedEndpointGuess if present"
+        }
+      ],
+      "grouping_rules": [
+        "Group by the Epic's area.",
+        "Set `frRefs` to every FR in the group whose endpoint/entity/UI flow matches.",
+        "Deduplicate by title prefix — if two entities share the same core name (e.g. `User` + `UserProfile`), collapse into a single DS item with both sub-models listed in the description."
+      ]
+    },
+    "tc_items": {
+      "description": "One `TcItem` per `test.cases[]` entry.",
+      "mappings": [
+        {
+          "source": "test.cases[i].title",
+          "target_field": "title",
+          "rule": "the `it(...)` / `test(...)` string verbatim"
+        },
+        {
+          "source": "test.cases[i] structure",
+          "target_field": "steps",
+          "rule": "parse Given/When/Then from the title if phrased that way, else bullet the `describe` chain"
+        },
+        {
+          "source": "assertion in the test body (if readable)",
+          "target_field": "expectedResult",
+          "rule": "if not parseable, use `\"see <test.file>\"`"
+        },
+        {
+          "source": "test.area or endpoint.area",
+          "target_field": "frRefs",
+          "rule": "every FR whose area matches"
+        }
+      ],
+      "todo_for_untested_endpoints": {
+        "when": "endpoint with hasTests=false",
+        "emit_as": "TODO TC item (the drift is auditable, not invisible)",
+        "shape": {
+          "id": "TC-<area>-<slug>-todo",
+          "title": "<METHOD> <path> — happy path",
+          "expectedResult": "to write",
+          "frRefs": ["<FR-id>"]
+        },
+        "reviewer_options": ["accept the TODO (making the gap part of the public contract)", "reject it and flag upstream"]
+      }
+    },
+    "nfr_items": {
+      "description": "NFRs are **proposed, not derived** — every seeded item must be marked for explicit human validation. Always emit with `priority: 'P3'` and `target: '<proposed — needs human validation>'`. The reviewer lifts priority / refines target before accepting.",
+      "layer1_stack_signals": [
+        {
+          "signal": "auth module present (endpoints under /auth/* or Prisma Session / RefreshToken model)",
+          "seeded_nfrs": ["Security — JWT access token expiry ≤ 15 min", "Security — refresh token rotation on every use", "Security — login rate limit ≤ 5 attempts / minute / IP"]
+        },
+        {
+          "signal": "i18n module (src/locales/ folder or i18next dep)",
+          "seeded_nfrs": ["i18n — all user-facing strings translated in FR + EN", "a11y — locale switchable without page reload"]
+        },
+        {
+          "signal": "Prisma + Postgres detected",
+          "seeded_nfrs": ["Data — soft delete via deletedAt on user-owned entities", "Data — all migrations reversible (up + down)"]
+        },
+        {
+          "signal": "docker-compose*.yml + /health endpoint present",
+          "seeded_nfrs": ["Ops — API health check p95 ≤ 1 s"]
+        },
+        {
+          "signal": "Playwright or e2e spec files present",
+          "seeded_nfrs": ["Quality — e2e coverage on critical user flows (login, signup, checkout when applicable)"]
+        },
+        {
+          "signal": "@nestjs/swagger + docs/openapi.json generated",
+          "seeded_nfrs": ["Docs — OpenAPI spec regenerated on every API change (CI guard)"]
+        }
+      ],
+      "layer2_standard_saas_catalogue": [
+        {
+          "nfr": "Perf — p95 API latency ≤ 500 ms at 100 req/s sustained",
+          "always_propose": true
+        },
+        {
+          "nfr": "Availability — uptime target 99.5% (excluding scheduled maintenance)",
+          "always_propose": true
+        },
+        {
+          "nfr": "Security — all user-uploaded files virus-scanned before persistence",
+          "condition": "only if storage module present"
+        },
+        {
+          "nfr": "Privacy — PII fields encrypted at rest",
+          "condition": "only if schema carries email, phone, address"
+        }
+      ]
+    }
+  },
+  "coverage_table": {
+    "purpose": "Before firing the review prompt on an Epic cluster, emit a one-shot coverage table so the reviewer sees what got seeded per category and where it came from.",
+    "template": [
+      "SRS coverage for Epic: <title>",
+      "┌──────┬───────────────┬──────────────────────────────────────────────┐",
+      "│ Cat  │ Items proposed│ Source                                       │",
+      "├──────┼───────────────┼──────────────────────────────────────────────┤",
+      "│ UR   │ 3             │ doc-context + inferred from FRs              │",
+      "│ FR   │ 5             │ 5 endpoint clusters                          │",
+      "│ DS   │ 4             │ 2 entities + 1 endpoint + 1 UI form          │",
+      "│ TC   │ 8 (+ 2 TODO)  │ test.cases[] across 3 spec files             │",
+      "│ NFR  │ 4 (proposed)  │ auth + i18n + prisma + playwright signals    │",
+      "└──────┴───────────────┴──────────────────────────────────────────────┘"
+    ],
+    "red_flag": "A cluster with **zero DS or zero TC** is a red flag — either the area is genuinely pure UI glue (no data model, no tests yet) or the scanners missed something. Surface the anomaly in the review prompt rather than silently proposing an Epic with empty sections."
+  },
+  "review_loop": {
+    "rule": "Never write to Notion without confirmation. Drive the loop one cluster at a time.",
+    "prompt_template": [
+      "🔍 J'ai trouvé <N> éléments dans le scanner pour le domaine `<area>`. Je te propose de créer :",
+      "",
+      "  📘 Epic : <title>",
+      "     ├─ FR : <title 1>  (based on: <file-1>, <file-2>)",
+      "     ├─ FR : <title 2>  (based on: <file-3>)",
+      "     └─ gaps : <endpoint without tests>, <page without linked endpoint>",
+      "",
+      "Je pars sur cette structure, ou tu veux retailler l'Epic ? [accept / edit / reject / skip-area]"
+    ],
+    "branches": {
+      "accept": "serialise the cluster as DraftCandidate[] and call `srs-cli.sh write --spec <tmp.json>`",
+      "edit": "negotiate the title / narrative / FR split and re-confirm",
+      "reject": "drop the cluster and continue",
+      "skip-area": "park the area and continue with the next"
+    },
+    "throttle": "Never batch-accept more than one Epic per prompt — the reviewer has to be able to course-correct cluster by cluster."
+  }
+}

--- a/.claude/skills/sf-srs/scripts/detect-eval-signals.sh
+++ b/.claude/skills/sf-srs/scripts/detect-eval-signals.sh
@@ -167,7 +167,7 @@ classify_text() {
     echo '{"signal":"trivial","confidence":"medium","target":"acknowledgement"}'
     return 0
   fi
-  if [[ "$lowered" =~ ^(read |show me |what does |explain |describe ) ]]; then
+  if [[ "$lowered" =~ ^(read |show me |what does |explain |describe |montre-moi |montre moi |explique |peux-tu |peux tu |qu\'est-ce que |qu\ est-ce que ) ]]; then
     echo '{"signal":"trivial","confidence":"low","target":"read-only request"}'
     return 0
   fi

--- a/.claude/skills/sf-srs/scripts/detect-eval-signals.sh
+++ b/.claude/skills/sf-srs/scripts/detect-eval-signals.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# detect-eval-signals.sh — conversational eval hook helper (SUB-10 companion).
+#
+# The sf-srs skill reads this script (not SKILL.md prose) when it needs to decide
+# whether a conversation turn carries a new SRS signal worth proposing via
+# `srs-cli.sh apply-update`. The script ships two modes:
+#
+#   --rules         Emit the detection rules + patch shape as JSON on stdout.
+#                   The agent loads this once per session and reasons against it.
+#                   This is the deterministic source of truth — SKILL.md only
+#                   points here.
+#
+#   --classify      Apply crude regex heuristics to a turn (text on stdin or as
+#                   a single argument) and emit {signal, confidence, target}.
+#                   Intended as a prefilter — the agent still has the final say,
+#                   but a low-confidence classification saves a round of thought
+#                   on trivial turns.
+#
+# Exit codes: 0 = clean output on stdout. 2 = bad input / unknown mode.
+#
+# The regex layer is intentionally conservative: false negatives (skip a real
+# signal) are cheaper than false positives (interrupt the user on a trivial
+# turn). Edit the rules JSON when the taxonomy shifts; edit the classifier
+# regexes only to tighten or widen a single signal row.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<EOF
+Usage: detect-eval-signals.sh [--rules | --classify [<text>]]
+
+Modes:
+  --rules                Emit detection rules + patch shape as JSON.
+  --classify [<text>]    Classify a turn. Reads stdin if <text> omitted.
+
+Output (classify): one JSON object
+  {"signal":"ur|fr|ds|tc|revision|trivial|none","confidence":"low|medium","target":"..."}
+EOF
+}
+
+emit_rules() {
+  cat <<'JSON'
+{
+  "description": "Detection heuristics + patch shape for the sf-srs conversational eval hook. SKILL.md points here; edit JSON, not prose.",
+  "precondition": {
+    "manifest_key": "tools.srs.enabled",
+    "expected_value": true,
+    "behavior_when_disabled": "Do nothing — the hook is dormant until the SRS module is installed."
+  },
+  "throttle": {
+    "max_proposals_per_turn": 1,
+    "dedup_window": "conversation-turn boundary (no persistent cache)"
+  },
+  "trivial_skip": [
+    "pure tool invocations",
+    "'ok' / 'thanks' / acknowledgements",
+    "'read X' / 'show me Y' / 'what does this do'",
+    "formatting nitpicks",
+    "small bug reports already covered by an existing FR",
+    "performance tweaks without observable user impact",
+    "pure refactor requests"
+  ],
+  "signals": [
+    {
+      "id": "ur",
+      "meaning": "Describes a user need / outcome",
+      "target": "new UR on the Epic page",
+      "patch_kind": "add-ur",
+      "example": "users should be able to log in with SSO",
+      "regex_hints": [
+        "(?i)\\busers? (should|need|want|must)\\b",
+        "(?i)\\bas a [a-z ]+,? i (want|need)\\b",
+        "(?i)\\bl'utilisateur (doit|veut|a besoin)\\b"
+      ]
+    },
+    {
+      "id": "fr",
+      "meaning": "Defines a new feature or rule",
+      "target": "new FR page under the Epic",
+      "patch_kind": "add-fr",
+      "example": "we need a feature that lets admins export audit logs as CSV",
+      "regex_hints": [
+        "(?i)\\b(new feature|add a feature|feature that|functionality to)\\b",
+        "(?i)\\b(allow|enable|support) [a-z]+ to\\b",
+        "(?i)\\bon (doit|veut) (pouvoir|permettre)\\b"
+      ]
+    },
+    {
+      "id": "ds",
+      "meaning": "Clarifies an implementation decision",
+      "target": "new DS on the relevant FR page",
+      "patch_kind": "add-ds",
+      "example": "let's use BCrypt with cost factor 12 for password hashing",
+      "regex_hints": [
+        "(?i)\\b(let's use|we('ll| will) use|on va utiliser)\\b",
+        "(?i)\\b(decision|choix technique|on part sur)\\b",
+        "(?i)\\b(implemented? with|via|using) [A-Z][a-z]"
+      ]
+    },
+    {
+      "id": "tc",
+      "meaning": "Adds an acceptance / test condition",
+      "target": "new TC on the relevant FR page",
+      "patch_kind": "add-tc",
+      "example": "and a test that proves unicode passwords are accepted",
+      "regex_hints": [
+        "(?i)\\b(a test that|test case|we should test|assert that|il faut tester)\\b",
+        "(?i)\\b(acceptance criteri(on|a)|given .* when .* then)\\b"
+      ]
+    },
+    {
+      "id": "revision",
+      "meaning": "Reopens a previously closed decision",
+      "target": "likely an FR or DS revision",
+      "patch_kind": "add-ds",
+      "note": "v1 is ADD-only — propose an appended item documenting the reversal rather than modifying the existing one in place.",
+      "example": "on reconsidère la règle : finalement on autorise les chiffres",
+      "regex_hints": [
+        "(?i)\\b(reconsider|revisit|on change d'avis|finalement on)\\b",
+        "(?i)\\b(actually|in fact|scratch that)\\b"
+      ]
+    }
+  ],
+  "confirmation_flow": {
+    "before_coding": true,
+    "prompt_template": [
+      "💡 Ce que tu viens de décrire ressemble à <UR / FR / DS / TC>. Proposition :",
+      "  • <target page> — add <item id> : <narrative | title>",
+      "  • (if TC)        steps : ...",
+      "",
+      "J'applique via `srs-cli.sh apply-update` ? [accept / edit / reject]"
+    ],
+    "branches": {
+      "accept": "build patch JSON (see shape below) and run `.claude/skills/sf-srs/scripts/srs-cli.sh apply-update < patch.json` (or pipe via stdin). On exit 0, continue with the coding task.",
+      "edit": "rework the proposed item text with the user, then re-confirm.",
+      "reject": "drop the proposal and continue. Do NOT re-propose the same item in the same conversation."
+    }
+  },
+  "patch_shape": {
+    "kind": "add-ur | add-fr | add-ds | add-tc",
+    "pageId": "<epic page id for add-ur / add-fr, FR page id for add-ds / add-tc>",
+    "item": "UrItem | FrSpec | DsItem | TcItem — same shapes as src/builders/srs/types.ts",
+    "note": "optional free-text annotation appended as a paragraph"
+  },
+  "scope_limits_v1": {
+    "add_only": "Modifying an existing item (e.g. tightening FR-012) is out of scope — SrsAdapter.updatePage is append-only on Notion. A follow-up SUB will extend the adapter with replace/delete semantics.",
+    "append_placement": "add-ur / add-ds / add-tc append new blocks to the END of the target page under an 'Added …' heading2. The canonical section (User Requirements / Design / Test Cases) is NOT updated in-place. Reviewers fold the appended block back during the next human SRS review.",
+    "add_fr": "Creates a brand-new child page under the Epic via adapter.createFrPage. The Epic page's 'Traceability' table is NOT refreshed (same append-only limitation) — the new FR is still discoverable as a child page."
+  },
+  "dogfood_checklist": "After any change to the rules, run a short manual session: drop 5 utterances (one per signal row + one trivial control) and confirm the hook fires exactly on the four signals and skips the trivial one."
+}
+JSON
+}
+
+classify_text() {
+  local text="$1"
+  local lowered
+  lowered=$(echo "$text" | tr '[:upper:]' '[:lower:]')
+
+  # Trivial short-circuit — common acknowledgements and noise.
+  # Fail-closed so an empty / ack turn does not fire a proposal.
+  if [[ -z "${text//[[:space:]]/}" ]]; then
+    echo '{"signal":"none","confidence":"medium","target":"empty turn"}'
+    return 0
+  fi
+  if [[ "$lowered" =~ ^(ok|okay|thanks?|ok[[:space:]]+thanks?|thx|merci|ty|yes|no|yep|nope|got[[:space:]]+it|sounds[[:space:]]+good|lgtm)[[:punct:][:space:]]*$ ]]; then
+    echo '{"signal":"trivial","confidence":"medium","target":"acknowledgement"}'
+    return 0
+  fi
+  if [[ "$lowered" =~ ^(read |show me |what does |explain |describe ) ]]; then
+    echo '{"signal":"trivial","confidence":"low","target":"read-only request"}'
+    return 0
+  fi
+
+  # TC wins over FR when both match — explicit acceptance criteria are rarer
+  # and more specific than a general feature ask.
+  if [[ "$lowered" =~ (a\ test\ that|test\ case|we\ should\ test|assert\ that|il\ faut\ tester|acceptance\ criteri(on|a)|given.*when.*then) ]]; then
+    echo '{"signal":"tc","confidence":"medium","target":"new TC on the relevant FR page"}'
+    return 0
+  fi
+
+  # DS — "let's use X", "we'll use X", technical choice language.
+  if [[ "$lowered" =~ (let\'s\ use|we\'ll\ use|we\ will\ use|on\ va\ utiliser|on\ part\ sur|implemented\ with|implemented\ via|decision:) ]]; then
+    echo '{"signal":"ds","confidence":"medium","target":"new DS on the relevant FR page"}'
+    return 0
+  fi
+
+  # Revision markers — reopening a closed decision.
+  if [[ "$lowered" =~ (reconsider|revisit|on\ change\ d\'avis|finalement\ on|actually|in\ fact|scratch\ that) ]]; then
+    echo '{"signal":"revision","confidence":"low","target":"FR or DS revision (ADD-only in v1)"}'
+    return 0
+  fi
+
+  # FR — feature/rule language.
+  if [[ "$lowered" =~ (new\ feature|add\ a\ feature|feature\ that|functionality\ to|allow\ .*\ to|enable\ .*\ to|support\ .*\ to|on\ doit\ pouvoir|on\ veut\ permettre) ]]; then
+    echo '{"signal":"fr","confidence":"medium","target":"new FR page under the Epic"}'
+    return 0
+  fi
+
+  # UR — user-need language.
+  if [[ "$lowered" =~ (users?\ (should|need|want|must)|as\ a\ [a-z\ ]+\ i\ (want|need)|l\'utilisateur\ (doit|veut|a\ besoin)) ]]; then
+    echo '{"signal":"ur","confidence":"medium","target":"new UR on the Epic page"}'
+    return 0
+  fi
+
+  echo '{"signal":"none","confidence":"low","target":"no matching heuristic — agent may still judge manually"}'
+}
+
+MODE=${1:---rules}
+shift || true
+
+case "$MODE" in
+  --rules)
+    emit_rules
+    ;;
+  --classify)
+    if [[ $# -gt 0 ]]; then
+      classify_text "$*"
+    else
+      TEXT=$(cat)
+      classify_text "$TEXT"
+    fi
+    ;;
+  -h|--help)
+    usage
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/scaffolds/skills-templates/sf-srs/SKILL.md
+++ b/scaffolds/skills-templates/sf-srs/SKILL.md
@@ -330,145 +330,17 @@ Output example:
 }
 ```
 
-Five scanner kinds fire today (see `docs/srs/scanner-findings.md` for the full JSON shape) :
+Scanner kinds, clustering steps, DS/TC/NFR seeding rules, coverage-table template, and review-loop prompt shape live as structured data in [`data/clustering-rules.json`](data/clustering-rules.json).
+Read that file once per drafting session — it is the source of truth. The JSON replaces prose that used to span ~180 lines of this SKILL.md.
 
-| Kind          | Source of truth                                | Area heuristic                                      |
-| ------------- | ---------------------------------------------- | --------------------------------------------------- |
-| `endpoint`    | NestJS `@Controller` + method decorators       | nearest `src/modules/<area>/`                       |
-| `ui-flow`     | React pages linked from `routes.tsx`           | `src/pages/<area>/<PageName>`                       |
-| `entity`      | Prisma `model` blocks                          | model-name dictionary (User→users, Session→auth, …) |
-| `test`        | Jest `describe` / `it` / `test` in `*.spec.ts` | `src/modules/<area>/` or filename stem              |
-| `doc-context` | `README.md` / `CLAUDE.md` / `docs/**/*.md`     | folder name (`docs`, `modules`, …)                  |
+Operational quick-reference (full detail in the JSON):
 
-### Reading the findings[] output
-
-For each finding :
-
-- **Every shape has `kind` + `title`** — use them for first-pass clustering.
-- **`area`** is the glue : findings that share an `area` usually belong to the same Epic / FR cluster.
-- **`file`** is the authoritative path — quote it back to the user when proposing a cluster ("FR-Auth — based on `api/src/modules/auth/auth.controller.ts` + `api/prisma/schema/auth.prisma`").
-- **`endpoint.hasTests`** flags `true` when the same `area` has at least one test finding — use it to prime the TC section of the proposed FR.
-- **`ui-flow.linkedEndpointGuess`** is a soft hint (filename / route substring match against endpoint paths) — verify it against the actual endpoint list before trusting it.
-- **`doc-context.excerpt`** is capped at 280 chars — treat it as a **summary seed**, not the full text.
-
-### Clustering into `DraftCandidate[]`
-
-The skill's job is to convert raw findings into publishable draft candidates. Work **Epic-by-Epic, then FR-by-FR** :
-
-1. **Group by area.** Collect every finding whose `area` matches. Add `doc-context` findings that share the area name or a parent folder.
-2. **Pick the Epic level.** One Epic per coherent area (e.g. `auth`, `storage`, `accounts`). Title + narrative come from the richest `doc-context` in the group, or from the user's wording.
-3. **Propose the FRs.**
-   - One FR per `endpoint` (or per tight endpoint cluster — e.g. CRUD on the same resource collapses into one FR).
-   - Reuse `ui-flow` routes as acceptance criteria on the user-facing FR.
-   - Populate `dsRefs` / `tcRefs` from the items seeded in step 4 so the FR page surfaces the traceability links.
-4. **Seed the Epic-level DS / TC / NFR sections.** Every Epic carries the SRS five-category shape (UR + FR + DS + TC + NFR) — see the canonical example at `templates/examples/example-epic.md`
-   (rendered) / `templates/examples/example-epic.spec.json` (machine-readable) for the exact layout. The seeding rules below turn scanner findings into initial items the reviewer accepts / edits /
-   rejects.
-5. **Flag gaps.** Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a **TODO** TC item (title `"{METHOD} {PATH} — happy path"`, `expectedResult: "to write"`), not silently.
-
-### Seeding DS / TC / NFR (five-category completeness)
-
-These three sections are **interpretive** — scanners surface the raw material, the agent synthesises the items. Reuse the L1+L2+L3 pattern from the eval (`docs/srs/scanner-findings.md`): deterministic
-findings feed AI prompts, the agent always runs, the user always validates before write.
-
-#### DS items (Design Specifications)
-
-One `DsItem` per material design decision visible in code. Source findings → seeded `DsItem`:
-
-| Finding                                                      | Seeded `DsItem.title`            | Seeded `description` source                                                |
-| ------------------------------------------------------------ | -------------------------------- | -------------------------------------------------------------------------- |
-| `entity` (Prisma model)                                      | `Data model — <EntityName>`      | fields + `@unique` / `@id` / `@relation` + `deletedAt` flag                |
-| `endpoint` with non-trivial DTO (POST/PATCH body ≥ 2 fields) | `API contract — <METHOD> <path>` | DTO field list + validation rules surfaced by `class-validator` decorators |
-| `ui-flow` with `formFields.length ≥ 2`                       | `UI form — <PageName>`           | form field list + `linkedEndpointGuess` if present                         |
-
-Group by the Epic's area; set `frRefs` to every FR in the group whose endpoint/entity/UI flow matches. Deduplicate by title prefix — if two entities share the same core name (e.g. `User` +
-`UserProfile`), collapse them into a single DS item with both sub-models listed in the description.
-
-#### TC items (Test Cases)
-
-One `TcItem` per `test.cases[]` entry. Source mapping:
-
-| Source                                   | Seeded `TcItem` field                                                                                |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `test.cases[i].title`                    | `title` (the `it(...)` / `test(...)` string verbatim)                                                |
-| `test.cases[i]` structure                | `steps` — parse Given/When/Then from the title if phrased that way, else bullet the `describe` chain |
-| assertion in the test body (if readable) | `expectedResult`; if not parseable, use `"see <test.file>"`                                          |
-| `test.area` or `endpoint.area`           | `frRefs` — every FR whose area matches                                                               |
-
-**Untested endpoints** — for each `endpoint` with `hasTests=false`, emit a **TODO** TC item so the drift is auditable, not invisible:
-
-```jsonc
-{
-  "id": "TC-<area>-<slug>-todo",
-  "title": "<METHOD> <path> — happy path",
-  "expectedResult": "to write",
-  "frRefs": ["<FR-id>"]
-}
-```
-
-The reviewer can either accept the TODO (making the gap part of the public contract) or reject it and flag it upstream.
-
-#### NFR items (Non-Functional Requirements)
-
-NFRs are **proposed, not derived** — every seeded item must be marked for explicit human validation. Build the candidate list from two layers:
-
-**Layer 1 — stack signals** (present in `.saasfoundry.json` or inferred from findings):
-
-| Signal                                                                                       | Seeded NFR(s)                                                                                                                                             |
-| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `auth` module present (endpoints under `/auth/*` or Prisma `Session` / `RefreshToken` model) | `Security — JWT access token expiry ≤ 15 min`; `Security — refresh token rotation on every use`; `Security — login rate limit ≤ 5 attempts / minute / IP` |
-| `i18n` module (`src/locales/` folder or `i18next` dep)                                       | `i18n — all user-facing strings translated in FR + EN`; `a11y — locale switchable without page reload`                                                    |
-| Prisma + Postgres detected                                                                   | `Data — soft delete via deletedAt on user-owned entities`; `Data — all migrations reversible (up + down)`                                                 |
-| `docker-compose*.yml` + `/health` endpoint present                                           | `Ops — API health check p95 ≤ 1 s`                                                                                                                        |
-| Playwright or e2e spec files present                                                         | `Quality — e2e coverage on critical user flows (login, signup, checkout when applicable)`                                                                 |
-| `@nestjs/swagger` + `docs/openapi.json` generated                                            | `Docs — OpenAPI spec regenerated on every API change (CI guard)`                                                                                          |
-
-**Layer 2 — standard SaaS catalogue** (always propose, mark low-confidence):
-
-- `Perf — p95 API latency ≤ 500 ms at 100 req/s sustained`
-- `Availability — uptime target 99.5% (excluding scheduled maintenance)`
-- `Security — all user-uploaded files virus-scanned before persistence` (only if storage module present)
-- `Privacy — PII fields encrypted at rest` (only if the schema carries `email`, `phone`, `address`)
-
-Always emit NFRs with `priority: 'P3'` and `target: '<proposed — needs human validation>'`. The reviewer lifts priority / refines target before accepting.
-
-#### Coverage table (pre-accept)
-
-Before firing the review prompt on an Epic cluster, emit a one-shot **coverage table** so the reviewer sees what got seeded per category and where it came from:
-
-```
-SRS coverage for Epic: <title>
-┌──────┬───────────────┬──────────────────────────────────────────────┐
-│ Cat  │ Items proposed│ Source                                       │
-├──────┼───────────────┼──────────────────────────────────────────────┤
-│ UR   │ 3             │ doc-context + inferred from FRs              │
-│ FR   │ 5             │ 5 endpoint clusters                          │
-│ DS   │ 4             │ 2 entities + 1 endpoint + 1 UI form          │
-│ TC   │ 8 (+ 2 TODO)  │ test.cases[] across 3 spec files             │
-│ NFR  │ 4 (proposed)  │ auth + i18n + prisma + playwright signals    │
-└──────┴───────────────┴──────────────────────────────────────────────┘
-```
-
-A cluster with **zero DS or zero TC** is a red flag — either the area is genuinely pure UI glue (no data model, no tests yet) or the scanners missed something. Surface the anomaly in the review prompt
-rather than silently proposing an Epic with empty sections.
-
-### Review-loop prompts
-
-Never write to Notion without confirmation. Drive the loop one cluster at a time :
-
-```
-🔍 J'ai trouvé <N> éléments dans le scanner pour le domaine `<area>`. Je te propose de créer :
-
-  📘 Epic : <title>
-     ├─ FR : <title 1>  (based on: <file-1>, <file-2>)
-     ├─ FR : <title 2>  (based on: <file-3>)
-     └─ gaps : <endpoint without tests>, <page without linked endpoint>
-
-Je pars sur cette structure, ou tu veux retailler l'Epic ? [accept / edit / reject / skip-area]
-```
-
-On **accept** → serialise the cluster as `DraftCandidate[]` and call `srs-cli.sh write --spec <tmp.json>`. On **edit** → negotiate the title / narrative / FR split and re-confirm. On **skip-area** →
-park the area and continue with the next. Never batch-accept more than **one Epic per prompt** — the reviewer has to be able to course-correct cluster by cluster.
+- **Five scanner kinds** (`endpoint`, `ui-flow`, `entity`, `test`, `doc-context`) — see `docs/srs/scanner-findings.md` for the JSON shape.
+- **Clustering**: work Epic-by-Epic, then FR-by-FR. Group by `area`, one Epic per coherent area, one FR per endpoint (or tight endpoint cluster).
+- **Five-category seeding** (UR + FR + DS + TC + NFR): scanners surface raw material, the agent synthesises, the user validates before write. NFRs are always marked `priority: P3` and
+  `target: '<proposed — needs human validation>'` until the reviewer accepts.
+- **Untested endpoints** emit a TODO TC item so drift is auditable — never silently drop them.
+- **Review loop**: one Epic per prompt, branches `[accept / edit / reject / skip-area]`. Never batch-accept. Never write without confirmation.
 
 ### Exit codes
 
@@ -484,65 +356,20 @@ park the area and continue with the next. Never batch-accept more than **one Epi
 
 ## Conversational eval hook (SUB-10)
 
-When the project declares `tools.srs.enabled = true` in `.saasfoundry.json`, Claude is responsible for **interjecting** during conversation turns whose content looks like a new Software Requirement.
-There is no message parser and no standalone script — the "hook" is Claude reading the heuristics below and self-invoking. The `sf-workflow` skill's SKILL.md references this section and stays out of
-the way.
+When the project declares `tools.srs.enabled = true` in `.saasfoundry.json`, Claude interjects during conversation turns whose content looks like a new Software Requirement. There is no message parser
+baked into the runtime — the "hook" is Claude reading the rules and self-invoking. The `sf-workflow` skill's SKILL.md references this section and stays out of the way.
 
-### Detection heuristics — when to fire
+Detection heuristics, confirmation prompt, patch shape, and v1 scope limits live as structured rules in [`scripts/detect-eval-signals.sh`](scripts/detect-eval-signals.sh). Two modes:
 
-Fire at most **once per conversation turn**. Skip trivial turns (pure tool invocations, "ok", "thanks", "read X", "what does this do"). Fire when the user's message matches **any** of the following
-signals :
+- `detect-eval-signals.sh --rules` — emits the full rules + patch shape as JSON. Read this once per session; it is the source of truth.
+- `detect-eval-signals.sh --classify "<text>"` (or stdin) — crude regex prefilter over a turn, returns `{signal, confidence, target}`. Use it to cheap-skip trivial turns; the agent still has the final
+  say on whether to fire.
 
-| Signal                                   | Target                              | Example utterance                                               |
-| ---------------------------------------- | ----------------------------------- | --------------------------------------------------------------- |
-| Describes a **user need / outcome**      | new **UR** on the Epic page         | "users should be able to log in with SSO"                       |
-| Defines a new **feature or rule**        | new **FR** page under the Epic      | "we need a feature that lets admins export audit logs as CSV"   |
-| Clarifies an **implementation decision** | new **DS** on the relevant FR page  | "let's use BCrypt with cost factor 12 for password hashing"     |
-| Adds an **acceptance / test condition**  | new **TC** on the relevant FR page  | "and a test that proves unicode passwords are accepted"         |
-| Reopens a **previously closed decision** | likely an **FR** or **DS** revision | "on reconsidère la règle : finalement on autorise les chiffres" |
+Fire at most **once per conversation turn**. On a signal hit, propose a diff in plain text, wait for `accept / edit / reject`, and — on accept — pipe the patch through
+`.claude/skills/sf-srs/scripts/srs-cli.sh apply-update`. v1 is ADD-only and appends to an "Added …" heading on the target page; the reviewer folds it back into the canonical section during the next
+human SRS review.
 
-Treat as **trivial and skip** : formatting nitpicks, small bug reports already covered by an existing FR, performance tweaks without observable user impact, pure refactor requests.
-
-### Confirmation flow
-
-When a signal fires, **pause before coding** and propose a diff in plain text :
-
-```
-💡 Ce que tu viens de décrire ressemble à <UR / FR / DS / TC>. Proposition :
-  • <target page> — add <item id> : <narrative | title>
-  • (if TC)        steps : ...
-
-J'applique via `srs-cli.sh apply-update` ? [accept / edit / reject]
-```
-
-- **accept** → build the patch JSON (see shape below) and run `.claude/skills/sf-srs/scripts/srs-cli.sh apply-update < patch.json` (or pipe via stdin). On exit 0, continue with the coding task.
-- **edit** → rework the proposed item text with the user, then re-confirm.
-- **reject** → drop the proposal and continue. Do **not** re-propose the same item in the same conversation.
-
-### Patch shape consumed by `apply-update`
-
-```jsonc
-{
-  "kind": "add-ur" | "add-fr" | "add-ds" | "add-tc",
-  "pageId": "<epic page id for add-ur / add-fr, FR page id for add-ds / add-tc>",
-  "item": { /* UrItem | FrSpec | DsItem | TcItem, same shapes as src/builders/srs/types.ts */ },
-  "note": "optional free-text annotation appended as a paragraph"
-}
-```
-
-### Scope limits (v1, intentional)
-
-- **ADD-only.** Modifying an existing item (e.g. tightening FR-012's acceptance criteria) is **out of scope** — the current `SrsAdapter.updatePage` is append-only on Notion, so surgical section
-  replacement is not available through the contract. A follow-up SUB will extend the adapter with replace/delete semantics.
-- **Append placement.** `add-ur` / `add-ds` / `add-tc` append new blocks to the **end** of the target page under an "Added …" heading2. The canonical section (User Requirements / Design / Test Cases)
-  is _not_ updated in-place. Reviewers must fold the appended block back into the right section during the next human SRS review. The limitation is deliberate and documented.
-- **`add-fr`** creates a brand-new child page under the Epic via `adapter.createFrPage`. The Epic page's "Traceability" table is **not** refreshed (same append-only limitation) — the new FR is still
-  discoverable as a child page.
-- **Throttling.** 1 proposal maximum per conversation turn. No persistent dedup cache (the turn boundary is sufficient — Claude's own judgment avoids re-proposing within the same turn).
-
-### Dogfood checklist
-
-After any change to the heuristics above, run a short manual session : drop 5 utterances (one per signal row + one trivial control) and confirm the hook fires exactly on the four signals and skips the
+After any change to the rules or classifier, run a short dogfood session: 5 utterances (one per signal row + one trivial control), confirm the hook fires exactly on the four signals and skips the
 trivial one.
 
 ## How other skills hand off to `sf-srs`

--- a/scaffolds/skills-templates/sf-srs/data/clustering-rules.json
+++ b/scaffolds/skills-templates/sf-srs/data/clustering-rules.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./clustering-rules.schema.json",
+  "version": 1,
   "description": "Structured clustering & seeding rules consumed by the sf-srs drafting flow (`srs-cli.sh draft --from codebase`). SKILL.md points to this file; edit here, not in prose.",
   "finding_kinds": [
     {

--- a/scaffolds/skills-templates/sf-srs/data/clustering-rules.json
+++ b/scaffolds/skills-templates/sf-srs/data/clustering-rules.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "./clustering-rules.schema.json",
+  "description": "Structured clustering & seeding rules consumed by the sf-srs drafting flow (`srs-cli.sh draft --from codebase`). SKILL.md points to this file; edit here, not in prose.",
+  "finding_kinds": [
+    {
+      "kind": "endpoint",
+      "source": "NestJS @Controller + method decorators",
+      "area_heuristic": "nearest src/modules/<area>/"
+    },
+    {
+      "kind": "ui-flow",
+      "source": "React pages linked from routes.tsx",
+      "area_heuristic": "src/pages/<area>/<PageName>"
+    },
+    {
+      "kind": "entity",
+      "source": "Prisma `model` blocks",
+      "area_heuristic": "model-name dictionary (User→users, Session→auth, …)"
+    },
+    {
+      "kind": "test",
+      "source": "Jest describe / it / test in *.spec.ts",
+      "area_heuristic": "src/modules/<area>/ or filename stem"
+    },
+    {
+      "kind": "doc-context",
+      "source": "README.md / CLAUDE.md / docs/**/*.md",
+      "area_heuristic": "folder name (docs, modules, …)"
+    }
+  ],
+  "reading_findings": [
+    "Every shape has `kind` + `title` — use them for first-pass clustering.",
+    "`area` is the glue: findings that share an `area` usually belong to the same Epic / FR cluster.",
+    "`file` is the authoritative path — quote it back to the user when proposing a cluster.",
+    "`endpoint.hasTests` flags `true` when the same `area` has at least one test finding — use it to prime the TC section.",
+    "`ui-flow.linkedEndpointGuess` is a soft hint (filename / route substring match) — verify before trusting.",
+    "`doc-context.excerpt` is capped at 280 chars — treat it as a summary seed, not the full text."
+  ],
+  "epic_fr_clustering": {
+    "order": "Epic-by-Epic, then FR-by-FR",
+    "steps": [
+      {
+        "id": 1,
+        "name": "Group by area",
+        "action": "Collect every finding whose `area` matches. Add `doc-context` findings that share the area name or a parent folder."
+      },
+      {
+        "id": 2,
+        "name": "Pick the Epic level",
+        "action": "One Epic per coherent area (e.g. `auth`, `storage`, `accounts`). Title + narrative come from the richest `doc-context` in the group, or from the user's wording."
+      },
+      {
+        "id": 3,
+        "name": "Propose the FRs",
+        "rules": [
+          "One FR per `endpoint` (or per tight endpoint cluster — CRUD on the same resource collapses into one FR).",
+          "Reuse `ui-flow` routes as acceptance criteria on the user-facing FR.",
+          "Populate `dsRefs` / `tcRefs` from the items seeded in step 4 so the FR surfaces traceability links."
+        ]
+      },
+      {
+        "id": 4,
+        "name": "Seed the Epic-level DS / TC / NFR sections",
+        "action": "Every Epic carries the SRS five-category shape (UR + FR + DS + TC + NFR). See `templates/examples/example-epic.md` (rendered) and `templates/examples/example-epic.spec.json` (machine-readable) for the exact layout. Apply the `seeding` rules below."
+      },
+      {
+        "id": 5,
+        "name": "Flag gaps",
+        "action": "Any `endpoint` with `hasTests=false` is a test-coverage gap — surface it as a **TODO** TC item (title `\"{METHOD} {PATH} — happy path\"`, `expectedResult: \"to write\"`), not silently."
+      }
+    ]
+  },
+  "seeding": {
+    "philosophy": "Scanners surface raw material, the agent synthesises items. Reuse the L1+L2+L3 pattern from the eval: deterministic findings feed AI prompts, the agent always runs, the user always validates before write.",
+    "ds_items": {
+      "description": "One `DsItem` per material design decision visible in code.",
+      "mappings": [
+        {
+          "finding": "entity (Prisma model)",
+          "title": "Data model — <EntityName>",
+          "description_source": "fields + @unique / @id / @relation + deletedAt flag"
+        },
+        {
+          "finding": "endpoint with non-trivial DTO (POST/PATCH body ≥ 2 fields)",
+          "title": "API contract — <METHOD> <path>",
+          "description_source": "DTO field list + validation rules surfaced by class-validator decorators"
+        },
+        {
+          "finding": "ui-flow with formFields.length ≥ 2",
+          "title": "UI form — <PageName>",
+          "description_source": "form field list + linkedEndpointGuess if present"
+        }
+      ],
+      "grouping_rules": [
+        "Group by the Epic's area.",
+        "Set `frRefs` to every FR in the group whose endpoint/entity/UI flow matches.",
+        "Deduplicate by title prefix — if two entities share the same core name (e.g. `User` + `UserProfile`), collapse into a single DS item with both sub-models listed in the description."
+      ]
+    },
+    "tc_items": {
+      "description": "One `TcItem` per `test.cases[]` entry.",
+      "mappings": [
+        {
+          "source": "test.cases[i].title",
+          "target_field": "title",
+          "rule": "the `it(...)` / `test(...)` string verbatim"
+        },
+        {
+          "source": "test.cases[i] structure",
+          "target_field": "steps",
+          "rule": "parse Given/When/Then from the title if phrased that way, else bullet the `describe` chain"
+        },
+        {
+          "source": "assertion in the test body (if readable)",
+          "target_field": "expectedResult",
+          "rule": "if not parseable, use `\"see <test.file>\"`"
+        },
+        {
+          "source": "test.area or endpoint.area",
+          "target_field": "frRefs",
+          "rule": "every FR whose area matches"
+        }
+      ],
+      "todo_for_untested_endpoints": {
+        "when": "endpoint with hasTests=false",
+        "emit_as": "TODO TC item (the drift is auditable, not invisible)",
+        "shape": {
+          "id": "TC-<area>-<slug>-todo",
+          "title": "<METHOD> <path> — happy path",
+          "expectedResult": "to write",
+          "frRefs": ["<FR-id>"]
+        },
+        "reviewer_options": ["accept the TODO (making the gap part of the public contract)", "reject it and flag upstream"]
+      }
+    },
+    "nfr_items": {
+      "description": "NFRs are **proposed, not derived** — every seeded item must be marked for explicit human validation. Always emit with `priority: 'P3'` and `target: '<proposed — needs human validation>'`. The reviewer lifts priority / refines target before accepting.",
+      "layer1_stack_signals": [
+        {
+          "signal": "auth module present (endpoints under /auth/* or Prisma Session / RefreshToken model)",
+          "seeded_nfrs": ["Security — JWT access token expiry ≤ 15 min", "Security — refresh token rotation on every use", "Security — login rate limit ≤ 5 attempts / minute / IP"]
+        },
+        {
+          "signal": "i18n module (src/locales/ folder or i18next dep)",
+          "seeded_nfrs": ["i18n — all user-facing strings translated in FR + EN", "a11y — locale switchable without page reload"]
+        },
+        {
+          "signal": "Prisma + Postgres detected",
+          "seeded_nfrs": ["Data — soft delete via deletedAt on user-owned entities", "Data — all migrations reversible (up + down)"]
+        },
+        {
+          "signal": "docker-compose*.yml + /health endpoint present",
+          "seeded_nfrs": ["Ops — API health check p95 ≤ 1 s"]
+        },
+        {
+          "signal": "Playwright or e2e spec files present",
+          "seeded_nfrs": ["Quality — e2e coverage on critical user flows (login, signup, checkout when applicable)"]
+        },
+        {
+          "signal": "@nestjs/swagger + docs/openapi.json generated",
+          "seeded_nfrs": ["Docs — OpenAPI spec regenerated on every API change (CI guard)"]
+        }
+      ],
+      "layer2_standard_saas_catalogue": [
+        {
+          "nfr": "Perf — p95 API latency ≤ 500 ms at 100 req/s sustained",
+          "always_propose": true
+        },
+        {
+          "nfr": "Availability — uptime target 99.5% (excluding scheduled maintenance)",
+          "always_propose": true
+        },
+        {
+          "nfr": "Security — all user-uploaded files virus-scanned before persistence",
+          "condition": "only if storage module present"
+        },
+        {
+          "nfr": "Privacy — PII fields encrypted at rest",
+          "condition": "only if schema carries email, phone, address"
+        }
+      ]
+    }
+  },
+  "coverage_table": {
+    "purpose": "Before firing the review prompt on an Epic cluster, emit a one-shot coverage table so the reviewer sees what got seeded per category and where it came from.",
+    "template": [
+      "SRS coverage for Epic: <title>",
+      "┌──────┬───────────────┬──────────────────────────────────────────────┐",
+      "│ Cat  │ Items proposed│ Source                                       │",
+      "├──────┼───────────────┼──────────────────────────────────────────────┤",
+      "│ UR   │ 3             │ doc-context + inferred from FRs              │",
+      "│ FR   │ 5             │ 5 endpoint clusters                          │",
+      "│ DS   │ 4             │ 2 entities + 1 endpoint + 1 UI form          │",
+      "│ TC   │ 8 (+ 2 TODO)  │ test.cases[] across 3 spec files             │",
+      "│ NFR  │ 4 (proposed)  │ auth + i18n + prisma + playwright signals    │",
+      "└──────┴───────────────┴──────────────────────────────────────────────┘"
+    ],
+    "red_flag": "A cluster with **zero DS or zero TC** is a red flag — either the area is genuinely pure UI glue (no data model, no tests yet) or the scanners missed something. Surface the anomaly in the review prompt rather than silently proposing an Epic with empty sections."
+  },
+  "review_loop": {
+    "rule": "Never write to Notion without confirmation. Drive the loop one cluster at a time.",
+    "prompt_template": [
+      "🔍 J'ai trouvé <N> éléments dans le scanner pour le domaine `<area>`. Je te propose de créer :",
+      "",
+      "  📘 Epic : <title>",
+      "     ├─ FR : <title 1>  (based on: <file-1>, <file-2>)",
+      "     ├─ FR : <title 2>  (based on: <file-3>)",
+      "     └─ gaps : <endpoint without tests>, <page without linked endpoint>",
+      "",
+      "Je pars sur cette structure, ou tu veux retailler l'Epic ? [accept / edit / reject / skip-area]"
+    ],
+    "branches": {
+      "accept": "serialise the cluster as DraftCandidate[] and call `srs-cli.sh write --spec <tmp.json>`",
+      "edit": "negotiate the title / narrative / FR split and re-confirm",
+      "reject": "drop the cluster and continue",
+      "skip-area": "park the area and continue with the next"
+    },
+    "throttle": "Never batch-accept more than one Epic per prompt — the reviewer has to be able to course-correct cluster by cluster."
+  }
+}

--- a/scaffolds/skills-templates/sf-srs/scripts/detect-eval-signals.sh
+++ b/scaffolds/skills-templates/sf-srs/scripts/detect-eval-signals.sh
@@ -167,7 +167,7 @@ classify_text() {
     echo '{"signal":"trivial","confidence":"medium","target":"acknowledgement"}'
     return 0
   fi
-  if [[ "$lowered" =~ ^(read |show me |what does |explain |describe ) ]]; then
+  if [[ "$lowered" =~ ^(read |show me |what does |explain |describe |montre-moi |montre moi |explique |peux-tu |peux tu |qu\'est-ce que |qu\ est-ce que ) ]]; then
     echo '{"signal":"trivial","confidence":"low","target":"read-only request"}'
     return 0
   fi

--- a/scaffolds/skills-templates/sf-srs/scripts/detect-eval-signals.sh
+++ b/scaffolds/skills-templates/sf-srs/scripts/detect-eval-signals.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# detect-eval-signals.sh — conversational eval hook helper (SUB-10 companion).
+#
+# The sf-srs skill reads this script (not SKILL.md prose) when it needs to decide
+# whether a conversation turn carries a new SRS signal worth proposing via
+# `srs-cli.sh apply-update`. The script ships two modes:
+#
+#   --rules         Emit the detection rules + patch shape as JSON on stdout.
+#                   The agent loads this once per session and reasons against it.
+#                   This is the deterministic source of truth — SKILL.md only
+#                   points here.
+#
+#   --classify      Apply crude regex heuristics to a turn (text on stdin or as
+#                   a single argument) and emit {signal, confidence, target}.
+#                   Intended as a prefilter — the agent still has the final say,
+#                   but a low-confidence classification saves a round of thought
+#                   on trivial turns.
+#
+# Exit codes: 0 = clean output on stdout. 2 = bad input / unknown mode.
+#
+# The regex layer is intentionally conservative: false negatives (skip a real
+# signal) are cheaper than false positives (interrupt the user on a trivial
+# turn). Edit the rules JSON when the taxonomy shifts; edit the classifier
+# regexes only to tighten or widen a single signal row.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<EOF
+Usage: detect-eval-signals.sh [--rules | --classify [<text>]]
+
+Modes:
+  --rules                Emit detection rules + patch shape as JSON.
+  --classify [<text>]    Classify a turn. Reads stdin if <text> omitted.
+
+Output (classify): one JSON object
+  {"signal":"ur|fr|ds|tc|revision|trivial|none","confidence":"low|medium","target":"..."}
+EOF
+}
+
+emit_rules() {
+  cat <<'JSON'
+{
+  "description": "Detection heuristics + patch shape for the sf-srs conversational eval hook. SKILL.md points here; edit JSON, not prose.",
+  "precondition": {
+    "manifest_key": "tools.srs.enabled",
+    "expected_value": true,
+    "behavior_when_disabled": "Do nothing — the hook is dormant until the SRS module is installed."
+  },
+  "throttle": {
+    "max_proposals_per_turn": 1,
+    "dedup_window": "conversation-turn boundary (no persistent cache)"
+  },
+  "trivial_skip": [
+    "pure tool invocations",
+    "'ok' / 'thanks' / acknowledgements",
+    "'read X' / 'show me Y' / 'what does this do'",
+    "formatting nitpicks",
+    "small bug reports already covered by an existing FR",
+    "performance tweaks without observable user impact",
+    "pure refactor requests"
+  ],
+  "signals": [
+    {
+      "id": "ur",
+      "meaning": "Describes a user need / outcome",
+      "target": "new UR on the Epic page",
+      "patch_kind": "add-ur",
+      "example": "users should be able to log in with SSO",
+      "regex_hints": [
+        "(?i)\\busers? (should|need|want|must)\\b",
+        "(?i)\\bas a [a-z ]+,? i (want|need)\\b",
+        "(?i)\\bl'utilisateur (doit|veut|a besoin)\\b"
+      ]
+    },
+    {
+      "id": "fr",
+      "meaning": "Defines a new feature or rule",
+      "target": "new FR page under the Epic",
+      "patch_kind": "add-fr",
+      "example": "we need a feature that lets admins export audit logs as CSV",
+      "regex_hints": [
+        "(?i)\\b(new feature|add a feature|feature that|functionality to)\\b",
+        "(?i)\\b(allow|enable|support) [a-z]+ to\\b",
+        "(?i)\\bon (doit|veut) (pouvoir|permettre)\\b"
+      ]
+    },
+    {
+      "id": "ds",
+      "meaning": "Clarifies an implementation decision",
+      "target": "new DS on the relevant FR page",
+      "patch_kind": "add-ds",
+      "example": "let's use BCrypt with cost factor 12 for password hashing",
+      "regex_hints": [
+        "(?i)\\b(let's use|we('ll| will) use|on va utiliser)\\b",
+        "(?i)\\b(decision|choix technique|on part sur)\\b",
+        "(?i)\\b(implemented? with|via|using) [A-Z][a-z]"
+      ]
+    },
+    {
+      "id": "tc",
+      "meaning": "Adds an acceptance / test condition",
+      "target": "new TC on the relevant FR page",
+      "patch_kind": "add-tc",
+      "example": "and a test that proves unicode passwords are accepted",
+      "regex_hints": [
+        "(?i)\\b(a test that|test case|we should test|assert that|il faut tester)\\b",
+        "(?i)\\b(acceptance criteri(on|a)|given .* when .* then)\\b"
+      ]
+    },
+    {
+      "id": "revision",
+      "meaning": "Reopens a previously closed decision",
+      "target": "likely an FR or DS revision",
+      "patch_kind": "add-ds",
+      "note": "v1 is ADD-only — propose an appended item documenting the reversal rather than modifying the existing one in place.",
+      "example": "on reconsidère la règle : finalement on autorise les chiffres",
+      "regex_hints": [
+        "(?i)\\b(reconsider|revisit|on change d'avis|finalement on)\\b",
+        "(?i)\\b(actually|in fact|scratch that)\\b"
+      ]
+    }
+  ],
+  "confirmation_flow": {
+    "before_coding": true,
+    "prompt_template": [
+      "💡 Ce que tu viens de décrire ressemble à <UR / FR / DS / TC>. Proposition :",
+      "  • <target page> — add <item id> : <narrative | title>",
+      "  • (if TC)        steps : ...",
+      "",
+      "J'applique via `srs-cli.sh apply-update` ? [accept / edit / reject]"
+    ],
+    "branches": {
+      "accept": "build patch JSON (see shape below) and run `.claude/skills/sf-srs/scripts/srs-cli.sh apply-update < patch.json` (or pipe via stdin). On exit 0, continue with the coding task.",
+      "edit": "rework the proposed item text with the user, then re-confirm.",
+      "reject": "drop the proposal and continue. Do NOT re-propose the same item in the same conversation."
+    }
+  },
+  "patch_shape": {
+    "kind": "add-ur | add-fr | add-ds | add-tc",
+    "pageId": "<epic page id for add-ur / add-fr, FR page id for add-ds / add-tc>",
+    "item": "UrItem | FrSpec | DsItem | TcItem — same shapes as src/builders/srs/types.ts",
+    "note": "optional free-text annotation appended as a paragraph"
+  },
+  "scope_limits_v1": {
+    "add_only": "Modifying an existing item (e.g. tightening FR-012) is out of scope — SrsAdapter.updatePage is append-only on Notion. A follow-up SUB will extend the adapter with replace/delete semantics.",
+    "append_placement": "add-ur / add-ds / add-tc append new blocks to the END of the target page under an 'Added …' heading2. The canonical section (User Requirements / Design / Test Cases) is NOT updated in-place. Reviewers fold the appended block back during the next human SRS review.",
+    "add_fr": "Creates a brand-new child page under the Epic via adapter.createFrPage. The Epic page's 'Traceability' table is NOT refreshed (same append-only limitation) — the new FR is still discoverable as a child page."
+  },
+  "dogfood_checklist": "After any change to the rules, run a short manual session: drop 5 utterances (one per signal row + one trivial control) and confirm the hook fires exactly on the four signals and skips the trivial one."
+}
+JSON
+}
+
+classify_text() {
+  local text="$1"
+  local lowered
+  lowered=$(echo "$text" | tr '[:upper:]' '[:lower:]')
+
+  # Trivial short-circuit — common acknowledgements and noise.
+  # Fail-closed so an empty / ack turn does not fire a proposal.
+  if [[ -z "${text//[[:space:]]/}" ]]; then
+    echo '{"signal":"none","confidence":"medium","target":"empty turn"}'
+    return 0
+  fi
+  if [[ "$lowered" =~ ^(ok|okay|thanks?|ok[[:space:]]+thanks?|thx|merci|ty|yes|no|yep|nope|got[[:space:]]+it|sounds[[:space:]]+good|lgtm)[[:punct:][:space:]]*$ ]]; then
+    echo '{"signal":"trivial","confidence":"medium","target":"acknowledgement"}'
+    return 0
+  fi
+  if [[ "$lowered" =~ ^(read |show me |what does |explain |describe ) ]]; then
+    echo '{"signal":"trivial","confidence":"low","target":"read-only request"}'
+    return 0
+  fi
+
+  # TC wins over FR when both match — explicit acceptance criteria are rarer
+  # and more specific than a general feature ask.
+  if [[ "$lowered" =~ (a\ test\ that|test\ case|we\ should\ test|assert\ that|il\ faut\ tester|acceptance\ criteri(on|a)|given.*when.*then) ]]; then
+    echo '{"signal":"tc","confidence":"medium","target":"new TC on the relevant FR page"}'
+    return 0
+  fi
+
+  # DS — "let's use X", "we'll use X", technical choice language.
+  if [[ "$lowered" =~ (let\'s\ use|we\'ll\ use|we\ will\ use|on\ va\ utiliser|on\ part\ sur|implemented\ with|implemented\ via|decision:) ]]; then
+    echo '{"signal":"ds","confidence":"medium","target":"new DS on the relevant FR page"}'
+    return 0
+  fi
+
+  # Revision markers — reopening a closed decision.
+  if [[ "$lowered" =~ (reconsider|revisit|on\ change\ d\'avis|finalement\ on|actually|in\ fact|scratch\ that) ]]; then
+    echo '{"signal":"revision","confidence":"low","target":"FR or DS revision (ADD-only in v1)"}'
+    return 0
+  fi
+
+  # FR — feature/rule language.
+  if [[ "$lowered" =~ (new\ feature|add\ a\ feature|feature\ that|functionality\ to|allow\ .*\ to|enable\ .*\ to|support\ .*\ to|on\ doit\ pouvoir|on\ veut\ permettre) ]]; then
+    echo '{"signal":"fr","confidence":"medium","target":"new FR page under the Epic"}'
+    return 0
+  fi
+
+  # UR — user-need language.
+  if [[ "$lowered" =~ (users?\ (should|need|want|must)|as\ a\ [a-z\ ]+\ i\ (want|need)|l\'utilisateur\ (doit|veut|a\ besoin)) ]]; then
+    echo '{"signal":"ur","confidence":"medium","target":"new UR on the Epic page"}'
+    return 0
+  fi
+
+  echo '{"signal":"none","confidence":"low","target":"no matching heuristic — agent may still judge manually"}'
+}
+
+MODE=${1:---rules}
+shift || true
+
+case "$MODE" in
+  --rules)
+    emit_rules
+    ;;
+  --classify)
+    if [[ $# -gt 0 ]]; then
+      classify_text "$*"
+    else
+      TEXT=$(cat)
+      classify_text "$TEXT"
+    fi
+    ;;
+  -h|--help)
+    usage
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/src/__tests__/unit/skill/srs-detect-eval-signals.spec.ts
+++ b/src/__tests__/unit/skill/srs-detect-eval-signals.spec.ts
@@ -1,0 +1,80 @@
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileP = promisify(execFile)
+
+// Regression guard for #280 (PR #284 code-review follow-up): the conversational
+// eval hook relies on this bash classifier as a cheap prefilter. If the signal
+// taxonomy or the heuristics drift, the agent either misses real SRS updates
+// or spams the user on trivial turns. Each row of REQUIRED_CASES pins one
+// (input → signal) expectation from the dogfood checklist declared in the
+// script's `--rules` output.
+const CLI = path.resolve(__dirname, '../../../../.claude/skills/sf-srs/scripts/detect-eval-signals.sh')
+const BASH = '/bin/bash'
+
+type Signal = 'ur' | 'fr' | 'ds' | 'tc' | 'revision' | 'trivial' | 'none'
+
+async function classify(text: string): Promise<{ signal: Signal; confidence: string; target: string }> {
+  const { stdout } = await execFileP(BASH, [CLI, '--classify', text])
+  return JSON.parse(stdout)
+}
+
+const CASES: { name: string; input: string; expected: Signal }[] = [
+  // trivial shortcircuit — acknowledgements
+  { name: 'ack-en', input: 'ok thanks', expected: 'trivial' },
+  { name: 'ack-fr', input: 'merci', expected: 'trivial' },
+
+  // trivial shortcircuit — read-only requests (EN + FR coverage from B.3)
+  { name: 'read-en', input: 'show me the config', expected: 'trivial' },
+  { name: 'read-fr-montre', input: 'montre-moi le code', expected: 'trivial' },
+  { name: 'read-fr-explique', input: "peux-tu m'expliquer ce module", expected: 'trivial' },
+
+  // TC — acceptance criteria / test language (wins over FR)
+  { name: 'tc-en', input: 'we should test that login rejects empty passwords', expected: 'tc' },
+  { name: 'tc-fr', input: 'il faut tester le flow de reset password', expected: 'tc' },
+
+  // DS — technical decision markers
+  { name: 'ds-en', input: "let's use bcrypt for password hashing", expected: 'ds' },
+  { name: 'ds-fr', input: 'on va utiliser argon2 pour les mots de passe', expected: 'ds' },
+
+  // Revision markers
+  { name: 'revision-en', input: 'reconsider the session TTL decision', expected: 'revision' },
+  { name: 'revision-fr', input: "on change d'avis sur la stack email", expected: 'revision' },
+
+  // FR — feature/rule language
+  { name: 'fr-en', input: 'add a feature that allows users to export their data', expected: 'fr' },
+  { name: 'fr-fr', input: 'on doit pouvoir exporter les données utilisateur', expected: 'fr' },
+
+  // UR — user-need language
+  { name: 'ur-en', input: 'users should be able to reset their password', expected: 'ur' },
+  { name: 'ur-fr', input: "l'utilisateur doit pouvoir supprimer son compte", expected: 'ur' },
+
+  // None — empty and unrelated turns
+  { name: 'empty', input: '   ', expected: 'none' },
+  { name: 'none-generic', input: 'deployed to staging', expected: 'none' }
+]
+
+describe('sf-srs detect-eval-signals --classify contract (#280)', () => {
+  it.each(CASES)('$name → $expected', async ({ input, expected }) => {
+    const result = await classify(input)
+    expect(result.signal).toBe(expected)
+  })
+
+  it('emits valid JSON on every path (never plain text)', async () => {
+    for (const c of CASES) {
+      const { stdout } = await execFileP(BASH, [CLI, '--classify', c.input])
+      expect(() => JSON.parse(stdout)).not.toThrow()
+    }
+  })
+
+  it('--rules mode exposes the stable taxonomy', async () => {
+    const { stdout } = await execFileP(BASH, [CLI, '--rules'])
+    const rules = JSON.parse(stdout)
+    expect(rules).toHaveProperty('precondition')
+    expect(rules).toHaveProperty('trivial_skip')
+    expect(rules).toHaveProperty('signals')
+    const signalIds = (rules.signals as { id: string }[]).map((s) => s.id).sort()
+    expect(signalIds).toEqual(['ds', 'fr', 'revision', 'tc', 'ur'])
+  })
+})

--- a/src/__tests__/unit/skill/srs-five-category-seeding.spec.ts
+++ b/src/__tests__/unit/skill/srs-five-category-seeding.spec.ts
@@ -1,55 +1,89 @@
 import { readFileSync } from 'fs'
 import path from 'path'
 
-// Regression guard for #247: the sf-srs SKILL.md must teach the AI agent how to
+// Regression guard for #247: the sf-srs skill must teach the AI agent how to
 // seed DS / TC / NFR items from scanner findings (five-category completeness:
 // UR + FR + DS + TC + NFR). Without this guidance the drafter silently produces
 // UR+FR only and the generated SRS can't pass a real audit. The byte-equality
 // drift guard (tool-skill-drift.spec.ts) ensures the scaffolded copy stays in
 // sync — this spec pins the *content* so a refactor can't accidentally strip
 // the sections.
-const SKILL_PATHS = [path.resolve(__dirname, '../../../../.claude/skills/sf-srs/SKILL.md'), path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/SKILL.md')]
-
-const REQUIRED_HEADINGS = [
-  /### Seeding DS \/ TC \/ NFR \(five-category completeness\)/,
-  /#### DS items \(Design Specifications\)/,
-  /#### TC items \(Test Cases\)/,
-  /#### NFR items \(Non-Functional Requirements\)/,
-  /#### Coverage table \(pre-accept\)/
+//
+// #280 moved the rules from SKILL.md prose to `data/clustering-rules.json`, so
+// the content assertions now run against the JSON artefact. The schema below
+// mirrors what the agent reads at drafting time.
+const RULES_PATHS = [
+  path.resolve(__dirname, '../../../../.claude/skills/sf-srs/data/clustering-rules.json'),
+  path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/data/clustering-rules.json')
 ]
 
-const REQUIRED_MAPPINGS = [
-  /entity.*Data model/,
-  /API contract.*METHOD/,
-  /UI form/,
-  /test\.cases\[i\]\.title/,
-  /hasTests=false/,
-  /TODO.*TC/,
-  /JWT access token expiry/,
-  /refresh token rotation/,
-  /i18n.*translated/,
-  /deletedAt/,
-  /proposed — needs human validation/
-]
+const REQUIRED_SEEDING_SECTIONS = ['ds_items', 'tc_items', 'nfr_items']
 
-describe('sf-srs five-category seeding guidance (#247)', () => {
-  it.each(SKILL_PATHS)('%s declares all DS/TC/NFR seeding headings', (file) => {
-    const content = readFileSync(file, 'utf8')
-    for (const pattern of REQUIRED_HEADINGS) {
-      expect(content).toMatch(pattern)
+const REQUIRED_DS_TITLE_PATTERNS = [/Data model — <EntityName>/, /API contract — <METHOD> <path>/, /UI form — <PageName>/]
+
+const REQUIRED_TC_SIGNALS = [/test\.cases\[i\]\.title/, /hasTests=false/, /TODO TC item/]
+
+const REQUIRED_NFR_LAYER1 = [/JWT access token expiry/, /refresh token rotation/, /i18n — all user-facing strings translated/, /deletedAt/]
+
+const REQUIRED_NFR_DISCLAIMER = /proposed — needs human validation/
+
+type ClusteringRules = {
+  seeding: {
+    ds_items: { mappings: { title: string }[] }
+    tc_items: {
+      mappings: { source: string }[]
+      todo_for_untested_endpoints: { when: string; emit_as: string }
+    }
+    nfr_items: {
+      description: string
+      layer1_stack_signals: { seeded_nfrs: string[] }[]
+    }
+  }
+  coverage_table: { template: string[] }
+}
+
+describe('sf-srs five-category seeding rules (#247 / #280)', () => {
+  it.each(RULES_PATHS)('%s declares DS/TC/NFR seeding sections', (file) => {
+    const rules = JSON.parse(readFileSync(file, 'utf8')) as ClusteringRules
+    for (const section of REQUIRED_SEEDING_SECTIONS) {
+      expect(rules.seeding).toHaveProperty(section)
     }
   })
 
-  it.each(SKILL_PATHS)('%s carries the scanner-finding → section mapping signals', (file) => {
-    const content = readFileSync(file, 'utf8')
-    for (const pattern of REQUIRED_MAPPINGS) {
-      expect(content).toMatch(pattern)
+  it.each(RULES_PATHS)('%s seeds DS items from every scanner-finding shape', (file) => {
+    const rules = JSON.parse(readFileSync(file, 'utf8')) as ClusteringRules
+    const titles = rules.seeding.ds_items.mappings.map((m) => m.title).join('\n')
+    for (const pattern of REQUIRED_DS_TITLE_PATTERNS) {
+      expect(titles).toMatch(pattern)
     }
   })
 
-  it.each(SKILL_PATHS)('%s tells the agent to emit a five-category coverage table', (file) => {
-    const content = readFileSync(file, 'utf8')
-    expect(content).toMatch(/SRS coverage for Epic/)
-    expect(content).toMatch(/Items proposed/)
+  it.each(RULES_PATHS)('%s carries the test-coverage gap signals', (file) => {
+    const rules = JSON.parse(readFileSync(file, 'utf8')) as ClusteringRules
+    const tcMappings = rules.seeding.tc_items.mappings.map((m) => m.source).join('\n')
+    const todo = JSON.stringify(rules.seeding.tc_items.todo_for_untested_endpoints)
+    const joined = `${tcMappings}\n${todo}`
+    for (const pattern of REQUIRED_TC_SIGNALS) {
+      expect(joined).toMatch(pattern)
+    }
+  })
+
+  it.each(RULES_PATHS)('%s proposes the standard SaaS NFR catalogue', (file) => {
+    const rules = JSON.parse(readFileSync(file, 'utf8')) as ClusteringRules
+    const nfrs = rules.seeding.nfr_items.layer1_stack_signals.flatMap((s) => s.seeded_nfrs).join('\n')
+    for (const pattern of REQUIRED_NFR_LAYER1) {
+      expect(nfrs).toMatch(pattern)
+    }
+    expect(rules.seeding.nfr_items.description).toMatch(REQUIRED_NFR_DISCLAIMER)
+  })
+
+  it.each(RULES_PATHS)('%s defines the five-category coverage table template', (file) => {
+    const rules = JSON.parse(readFileSync(file, 'utf8')) as ClusteringRules
+    const joined = rules.coverage_table.template.join('\n')
+    expect(joined).toMatch(/SRS coverage for Epic/)
+    expect(joined).toMatch(/Items proposed/)
+    for (const cat of ['UR', 'FR', 'DS', 'TC', 'NFR']) {
+      expect(joined).toContain(cat)
+    }
   })
 })

--- a/src/__tests__/unit/skill/tool-skill-drift.spec.ts
+++ b/src/__tests__/unit/skill/tool-skill-drift.spec.ts
@@ -88,6 +88,16 @@ const PAIRS = [
     scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/scripts/srs-cli.sh')
   },
   {
+    name: 'sf-srs detect-eval-signals.sh',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/scripts/detect-eval-signals.sh'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/scripts/detect-eval-signals.sh')
+  },
+  {
+    name: 'sf-srs data/clustering-rules.json',
+    inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/data/clustering-rules.json'),
+    scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/data/clustering-rules.json')
+  },
+  {
     name: 'sf-srs templates/pages/README.md',
     inRepo: path.resolve(__dirname, '../../../../.claude/skills/sf-srs/templates/pages/README.md'),
     scaffolded: path.resolve(__dirname, '../../../../scaffolds/skills-templates/sf-srs/templates/pages/README.md')


### PR DESCRIPTION
## Summary

- Move clustering rules (finding kinds, Epic/FR clustering steps, DS/TC/NFR seeding mappings, coverage-table template, review-loop shape) from `sf-srs/SKILL.md` prose into `sf-srs/data/clustering-rules.json`. The agent reads JSON once per drafting session — no more paragraph-level interpretation every call.
- Move eval-hook detection heuristics (5 signal rows + trivial-skip + patch shape + v1 scope limits) from `sf-srs/SKILL.md` to `sf-srs/scripts/detect-eval-signals.sh`, which exposes two modes: `--rules` (JSON source of truth) and `--classify` (regex prefilter for trivial-turn short-circuit).
- `sf-srs/SKILL.md` drops from 607 → 435 lines (~1200 tokens saved on auto-load).
- Drift spec grows by two PAIRS so the new files stay byte-identical between `.claude/skills/` and `scaffolds/skills-templates/`.
- `#247` regression guard retargeted: it now asserts against the JSON structure instead of prose, preserving the invariant while following the content to its new home.

## Test plan

- [x] `npx jest --selectProjects unit -t "tool-skill drift guard"` — 25/25 PAIRS pass (23 previous + 2 new).
- [x] `npx jest --selectProjects unit -t "five-category seeding"` — 10/10 pass against the new JSON artefact.
- [x] Full test suite (pre-commit): 1158 passed, 2 skipped.
- [x] `detect-eval-signals.sh --classify` smoke-tested on the five canonical utterances (UR / FR / DS / TC / trivial) — all classify correctly.
- [x] Docker build tests (pre-push): `multirepo-minimal` + `monorepo-minimal` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)