### PR TITLE
refactor(#281): github-projects-cli — consolidate URL parser

### DIFF
--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -32,15 +32,20 @@ load_config() {
   PROJECT_URL=$(jq -r '.workflow.projectUrl // empty' .saasfoundry.json)
   WORKING_BRANCH=$(jq -r '.workflow.workingBranch // "develop"' .saasfoundry.json)
 
-  # Parse owner and project number from URL
-  # Formats supported:
+  # Parse owner + project number from PROJECT_URL in one pass. Supported shapes:
   #   https://github.com/orgs/{owner}/projects/{number}
   #   https://github.com/users/{owner}/projects/{number}
+  # On a non-matching / empty URL both fields stay empty — callers (notably
+  # load_project_schema) already guard on that and surface a clear error.
   PROJECT_OWNER=""
   PROJECT_NUMBER=""
   if [ -n "$PROJECT_URL" ]; then
-    PROJECT_OWNER=$(echo "$PROJECT_URL" | sed -nE 's#https?://github.com/(orgs|users)/([^/]+)/projects/[0-9]+.*#\2#p')
-    PROJECT_NUMBER=$(echo "$PROJECT_URL" | sed -nE 's#.*/projects/([0-9]+).*#\1#p')
+    local parsed
+    parsed=$(echo "$PROJECT_URL" | sed -nE 's#^https?://github\.com/(orgs|users)/([^/]+)/projects/([0-9]+).*$#\2/\3#p')
+    if [ -n "$parsed" ]; then
+      PROJECT_OWNER=${parsed%/*}
+      PROJECT_NUMBER=${parsed##*/}
+    fi
   fi
 }
 

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -32,15 +32,20 @@ load_config() {
   PROJECT_URL=$(jq -r '.workflow.projectUrl // empty' .saasfoundry.json)
   WORKING_BRANCH=$(jq -r '.workflow.workingBranch // "develop"' .saasfoundry.json)
 
-  # Parse owner and project number from URL
-  # Formats supported:
+  # Parse owner + project number from PROJECT_URL in one pass. Supported shapes:
   #   https://github.com/orgs/{owner}/projects/{number}
   #   https://github.com/users/{owner}/projects/{number}
+  # On a non-matching / empty URL both fields stay empty — callers (notably
+  # load_project_schema) already guard on that and surface a clear error.
   PROJECT_OWNER=""
   PROJECT_NUMBER=""
   if [ -n "$PROJECT_URL" ]; then
-    PROJECT_OWNER=$(echo "$PROJECT_URL" | sed -nE 's#https?://github.com/(orgs|users)/([^/]+)/projects/[0-9]+.*#\2#p')
-    PROJECT_NUMBER=$(echo "$PROJECT_URL" | sed -nE 's#.*/projects/([0-9]+).*#\1#p')
+    local parsed
+    parsed=$(echo "$PROJECT_URL" | sed -nE 's#^https?://github\.com/(orgs|users)/([^/]+)/projects/([0-9]+).*$#\2/\3#p')
+    if [ -n "$parsed" ]; then
+      PROJECT_OWNER=${parsed%/*}
+      PROJECT_NUMBER=${parsed##*/}
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

- Replace the two separate `sed` calls that extracted `PROJECT_OWNER` and `PROJECT_NUMBER` from `.saasfoundry.json → workflow.projectUrl` with a single anchored regex that captures both, then splits with bash parameter expansion.
- Regex supports both `orgs/<slug>/projects/<N>` and `users/<slug>/projects/<N>` URLs, tolerates query strings, and leaves both fields empty on non-match (same fail-open contract — `load_project_schema` already surfaces a clear error).
- The other AC in #281 ("dedupe `load_config`") was already satisfied by #137 / #135's schema-cache refactor — only one definition exists today. Noted in the commit body to close the loop.

## Test plan

- [x] `bash -n github-projects-cli.sh` — syntax check clean.
- [x] URL parser smoke-tested against three shapes: `orgs/X/projects/N`, `users/X/projects/N`, URL with `?fullscreen=true` query — all three parse correctly.
- [x] Live: `status 281`, `get-labels 281` — identical output to pre-refactor.
- [x] `npx jest --selectProjects unit -t "tool-skill drift guard"` — 23/23 PAIRS pass (byte-identical to scaffold).
- [x] Full suite (pre-commit): build + lint + jest all green.
- [x] Docker build tests (pre-push): `multirepo-minimal` + `monorepo-minimal` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)