### PR TITLE
feat(#286): JSON Schema for .saasfoundry.json + idempotent migration

### DIFF
--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -470,7 +470,7 @@ cmd_create_subtask() {
   # success line so the intent is visible in shell history / PR review.
   if [ -f ".saasfoundry.json" ]; then
     local srs_backend
-    srs_backend=$(jq -r 'if (.tools.srs.backend | type) == "string" then .tools.srs.backend else empty end' .saasfoundry.json 2>/dev/null)
+    srs_backend=$(jq -r '.tools.srs.backend // empty' .saasfoundry.json)
     if [ -n "$srs_backend" ] && [ -z "$BYPASS_SRS_REASON" ]; then
       echo -e "${RED}✗ Rule 8: this project has SRS enabled (tools.srs.backend=${srs_backend}).${NC}" >&2
       echo "  Feature subtasks must be spawned from a drafted SRS page via:" >&2

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
         "@types/module-alias": "2.0.4",
         "@types/node": "22.14.0",
         "@types/shelljs": "0.8.12",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "eslint": "9.19.0",
         "eslint-config-prettier": "10.0.1",
         "eslint-plugin-prettier": "5.2.3",
@@ -3800,10 +3802,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3813,6 +3816,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/algoliasearch": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "@types/module-alias": "2.0.4",
     "@types/node": "22.14.0",
     "@types/shelljs": "0.8.12",
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1",
     "eslint": "9.19.0",
     "eslint-config-prettier": "10.0.1",
     "eslint-plugin-prettier": "5.2.3",

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -470,7 +470,7 @@ cmd_create_subtask() {
   # success line so the intent is visible in shell history / PR review.
   if [ -f ".saasfoundry.json" ]; then
     local srs_backend
-    srs_backend=$(jq -r 'if (.tools.srs.backend | type) == "string" then .tools.srs.backend else empty end' .saasfoundry.json 2>/dev/null)
+    srs_backend=$(jq -r '.tools.srs.backend // empty' .saasfoundry.json)
     if [ -n "$srs_backend" ] && [ -z "$BYPASS_SRS_REASON" ]; then
       echo -e "${RED}✗ Rule 8: this project has SRS enabled (tools.srs.backend=${srs_backend}).${NC}" >&2
       echo "  Feature subtasks must be spawned from a drafted SRS page via:" >&2

--- a/schemas/saasfoundry-manifest.schema.json
+++ b/schemas/saasfoundry-manifest.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json",
+  "title": "SaaSFoundry project manifest",
+  "description": "Shape of .saasfoundry.json at the root of every SaaSFoundry-managed project. Mirrors the SaaSFoundryManifest TypeScript type in src/types.ts and the canonical example in .claude/docs/manifest-schema.md.",
+  "type": "object",
+  "required": ["version", "structure", "projectName"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional pointer to this schema for IDE live validation."
+    },
+    "version": {
+      "type": "string",
+      "description": "CLI version that generated the manifest (semver, e.g. 1.0.0-beta)."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of manifest generation."
+    },
+    "structure": {
+      "type": "string",
+      "enum": ["monorepo", "multirepo", "cli"],
+      "description": "Repo layout emitted by sf new."
+    },
+    "projectName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "modules": {
+      "type": "object",
+      "required": ["emailService", "s3Setup", "dbSetup", "includeAnalytics", "advancedSkills"],
+      "additionalProperties": false,
+      "properties": {
+        "emailService": { "type": "string", "enum": ["none", "mailersend"] },
+        "s3Setup": { "type": "string", "enum": ["docker", "credentials", "manual"] },
+        "dbSetup": { "type": "string", "enum": ["docker", "credentials", "manual"] },
+        "includeAnalytics": { "type": "boolean" },
+        "advancedSkills": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "skillsAccounts": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "fileHashes": {
+      "type": "object",
+      "description": "Map of relative path → SHA hash used by sf update to detect user edits.",
+      "additionalProperties": { "type": "string" }
+    },
+    "workflow": { "$ref": "#/definitions/workflowConfig" },
+    "aiRules": { "$ref": "#/definitions/aiRules" },
+    "tools": { "$ref": "#/definitions/toolsConfig" }
+  },
+  "definitions": {
+    "workflowConfig": {
+      "type": "object",
+      "required": ["tool"],
+      "additionalProperties": false,
+      "properties": {
+        "tool": {
+          "type": "string",
+          "enum": ["github-projects", "jira", "notion", "linear", "none"]
+        },
+        "template": { "type": "string" },
+        "projectUrl": { "type": "string", "format": "uri" },
+        "workingBranch": { "type": "string" },
+        "prTargetBranch": { "type": "string" },
+        "releaseBranch": { "type": "string" },
+        "requireCodeReview": { "type": "boolean" },
+        "branchNaming": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "feature": { "type": "string" },
+            "fix": { "type": "string" },
+            "release": { "type": "string" }
+          }
+        },
+        "commitFormat": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "pattern": { "type": "string" },
+            "requireTicket": { "type": "boolean" },
+            "types": {
+              "type": "array",
+              "items": { "type": "string" },
+              "uniqueItems": true
+            }
+          }
+        },
+        "statuses": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/workflowStatus" }
+        },
+        "validated": { "type": "boolean" },
+        "lastValidated": { "type": "string", "format": "date-time" }
+      }
+    },
+    "workflowStatus": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "color": {
+          "type": "string",
+          "enum": ["GRAY", "YELLOW", "BLUE", "PURPLE", "ORANGE", "PINK", "GREEN", "RED"]
+        }
+      }
+    },
+    "aiRules": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "alwaysCreateBranchFromWorking": { "type": "boolean" },
+        "alwaysCreateTicketBeforeCode": { "type": "boolean" },
+        "autoUpdateTicketStatus": { "type": "boolean" },
+        "requireHumanCheckOnPushedBranch": { "type": "boolean" }
+      }
+    },
+    "toolsConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "srs": { "$ref": "#/definitions/srsToolConfig" }
+      }
+    },
+    "srsToolConfig": {
+      "type": "object",
+      "required": ["enabled", "backend"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "backend": { "type": "string", "const": "notion" },
+        "rootPage": { "$ref": "#/definitions/srsPageRef" },
+        "pendingIngestion": { "$ref": "#/definitions/pendingIngestion" },
+        "scan": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "exclude": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "srsPageRef": {
+      "type": "object",
+      "required": ["id", "url", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "url": { "type": "string" },
+        "name": { "type": "string" }
+      }
+    },
+    "pendingIngestion": {
+      "type": "object",
+      "required": ["sourceBackend", "sourceParent", "createdAt"],
+      "additionalProperties": false,
+      "properties": {
+        "sourceBackend": { "type": "string", "const": "notion" },
+        "sourceParent": { "$ref": "#/definitions/srsPageRef" },
+        "createdAt": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/src/__tests__/integration/commands/update.spec.ts
+++ b/src/__tests__/integration/commands/update.spec.ts
@@ -122,6 +122,63 @@ describe('updateCommand (integration)', () => {
     })
   })
 
+  // Regression guard for #290 — `sf update` is the migration vector that
+  // back-fills the JSON Schema URL into manifests scaffolded before #286
+  // shipped. The migration must persist on the early-return paths (most users
+  // run `sf update` to see "up to date" and bail) and never clobber a
+  // user-customized $schema (e.g. someone forking the schema for a private
+  // CLI build).
+  describe('$schema migration (#290)', () => {
+    const SCHEMA_URL = 'https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json'
+
+    it('stamps $schema on a legacy manifest even when the run hits the early-return', async () => {
+      mockedGetModuleSelections.mockResolvedValue([])
+      const manifest = buildBaseManifest()
+      delete (manifest as Partial<SaaSFoundryManifest>).$schema
+      await writeFile('.saasfoundry.json', JSON.stringify(manifest))
+
+      await updateCommand()
+
+      const written = JSON.parse(await readFile('.saasfoundry.json', 'utf8')) as SaaSFoundryManifest
+      expect(written.$schema).toBe(SCHEMA_URL)
+    })
+
+    it('writes $schema as the first field for shape parity with sf new', async () => {
+      mockedGetModuleSelections.mockResolvedValue([])
+      const manifest = buildBaseManifest()
+      delete (manifest as Partial<SaaSFoundryManifest>).$schema
+      await writeFile('.saasfoundry.json', JSON.stringify(manifest))
+
+      await updateCommand()
+
+      const written = JSON.parse(await readFile('.saasfoundry.json', 'utf8'))
+      expect(Object.keys(written)[0]).toBe('$schema')
+    })
+
+    it('preserves a user-customized $schema (idempotent)', async () => {
+      mockedGetModuleSelections.mockResolvedValue([])
+      const customUrl = 'https://internal.example.com/schemas/saasfoundry-manifest.schema.json'
+      const manifest = buildBaseManifest({ $schema: customUrl })
+      await writeFile('.saasfoundry.json', JSON.stringify(manifest))
+
+      await updateCommand()
+
+      const written = JSON.parse(await readFile('.saasfoundry.json', 'utf8')) as SaaSFoundryManifest
+      expect(written.$schema).toBe(customUrl)
+    })
+
+    it('does not mutate disk in --dry-run mode', async () => {
+      const manifest = buildBaseManifest()
+      delete (manifest as Partial<SaaSFoundryManifest>).$schema
+      const original = JSON.stringify(manifest)
+      await writeFile('.saasfoundry.json', original)
+
+      await updateCommand({ dryRun: true, nonInteractive: true })
+
+      expect(await readFile('.saasfoundry.json', 'utf8')).toBe(original)
+    })
+  })
+
   describe('no modules available', () => {
     it('returns early when everything is already installed', async () => {
       const manifest = buildBaseManifest({

--- a/src/__tests__/unit/skill/github-projects-cli.bypass-srs.spec.ts
+++ b/src/__tests__/unit/skill/github-projects-cli.bypass-srs.spec.ts
@@ -195,30 +195,10 @@ describe('sf-tool-github-projects — create-subtask Rule 8 guard', () => {
       }
     })
 
-    it('treats a non-string tools.srs.backend (e.g. number) as "not set" (Rule 8 dormant)', async () => {
-      const sandbox = await buildSandbox({
-        workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' },
-        tools: { srs: { backend: 42 } }
-      })
-      try {
-        const res = await runCli(['create-subtask', '42', 'Thing'], sandbox)
-        expect(res.code).toBe(0)
-      } finally {
-        await sandbox.cleanup()
-      }
-    })
-
-    it('treats a boolean tools.srs.backend as "not set" (Rule 8 dormant)', async () => {
-      const sandbox = await buildSandbox({
-        workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' },
-        tools: { srs: { backend: true } }
-      })
-      try {
-        const res = await runCli(['create-subtask', '42', 'Thing'], sandbox)
-        expect(res.code).toBe(0)
-      } finally {
-        await sandbox.cleanup()
-      }
-    })
+    // Non-string backend values (number, boolean) used to be tested here as
+    // "treats X as not set". The manifest JSON Schema now pins
+    // tools.srs.backend to const "notion" — so a malformed value is caught at
+    // the schema layer (ajv / IDE), not by the bash script's runtime guard.
+    // The script side simplified accordingly (#291).
   })
 })

--- a/src/__tests__/unit/skill/manifest-schema.spec.ts
+++ b/src/__tests__/unit/skill/manifest-schema.spec.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import Ajv from 'ajv'
+import addFormats from 'ajv-formats'
+
+// Regression guard for #286: the JSON Schema is the single source of truth
+// for `.saasfoundry.json`. If a canonical shape from manifest-schema.md stops
+// validating, scaffolded projects break — IDEs surface red squiggles where
+// none should appear, and downstream skill scripts that trusted schema-pinned
+// fields face values they don't expect.
+
+const SCHEMA_PATH = join(__dirname, '../../../../schemas/saasfoundry-manifest.schema.json')
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8'))
+
+const ajv = new Ajv({ allErrors: true, strict: false })
+addFormats(ajv)
+const validate = ajv.compile(schema)
+
+const baseManifest = {
+  $schema: 'https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json',
+  version: '1.0.0-beta',
+  generatedAt: '2026-04-25T00:00:00.000Z',
+  structure: 'multirepo',
+  projectName: 'demo'
+}
+
+describe('saasfoundry-manifest.schema.json — canonical shapes', () => {
+  it('accepts a minimal manifest (only required fields)', () => {
+    expect(validate({ version: '1.0.0', structure: 'cli', projectName: 'demo' })).toBe(true)
+  })
+
+  it('accepts the full canonical shape from manifest-schema.md', () => {
+    const full = {
+      ...baseManifest,
+      modules: {
+        emailService: 'mailersend',
+        s3Setup: 'docker',
+        dbSetup: 'credentials',
+        includeAnalytics: true,
+        advancedSkills: ['context7', 'notion']
+      },
+      skillsAccounts: { context7: 'demo-account' },
+      fileHashes: { 'src/main.ts': 'abc123' },
+      workflow: {
+        tool: 'github-projects',
+        template: 'SaaSFoundry AI',
+        projectUrl: 'https://github.com/orgs/demo/projects/1',
+        workingBranch: 'develop',
+        prTargetBranch: 'develop',
+        releaseBranch: 'master',
+        requireCodeReview: true,
+        branchNaming: { feature: 'feature/{N}-{description}', fix: 'fix/{N}-{description}', release: 'rc-{version}' },
+        commitFormat: { pattern: '<type>(#<ticket>): <description>', requireTicket: true, types: ['feat', 'fix'] },
+        statuses: [
+          { name: 'Backlog', color: 'GRAY' },
+          { name: 'In progress', color: 'BLUE' }
+        ],
+        validated: true,
+        lastValidated: '2026-04-25T00:00:00.000Z'
+      },
+      aiRules: {
+        alwaysCreateBranchFromWorking: true,
+        alwaysCreateTicketBeforeCode: true,
+        autoUpdateTicketStatus: false,
+        requireHumanCheckOnPushedBranch: true
+      },
+      tools: {
+        srs: {
+          enabled: true,
+          backend: 'notion',
+          rootPage: { id: 'page-uuid', url: 'https://notion.so/x', name: 'My Epic' },
+          scan: { exclude: ['scaffolds/', 'docs/'] }
+        }
+      }
+    }
+    expect(validate(full)).toBe(true)
+  })
+
+  it('accepts every structure enum value', () => {
+    for (const structure of ['monorepo', 'multirepo', 'cli']) {
+      expect(validate({ version: '1.0.0', structure, projectName: 'demo' })).toBe(true)
+    }
+  })
+
+  it('accepts every workflow.tool enum value', () => {
+    for (const tool of ['github-projects', 'jira', 'notion', 'linear', 'none']) {
+      expect(validate({ ...baseManifest, workflow: { tool } })).toBe(true)
+    }
+  })
+})
+
+describe('saasfoundry-manifest.schema.json — rejection cases', () => {
+  it('rejects a manifest missing a required root field', () => {
+    expect(validate({ version: '1.0.0', structure: 'cli' })).toBe(false)
+  })
+
+  it('rejects an unknown structure value', () => {
+    expect(validate({ version: '1.0.0', structure: 'desktop', projectName: 'demo' })).toBe(false)
+  })
+
+  it('rejects an unknown workflow.tool value', () => {
+    expect(validate({ ...baseManifest, workflow: { tool: 'azure-devops' } })).toBe(false)
+  })
+
+  it('rejects an unknown workflow.statuses[].color value', () => {
+    expect(
+      validate({ ...baseManifest, workflow: { tool: 'github-projects', statuses: [{ name: 'Done', color: 'NEON' }] } })
+    ).toBe(false)
+  })
+
+  it('rejects a non-string tools.srs.backend (schema pins const "notion")', () => {
+    // Guards the rationale for #291 — the bash script no longer needs a runtime
+    // type check because non-string backend values are rejected at this layer.
+    expect(validate({ ...baseManifest, tools: { srs: { enabled: true, backend: 42 } } })).toBe(false)
+    expect(validate({ ...baseManifest, tools: { srs: { enabled: true, backend: 'jira' } } })).toBe(false)
+  })
+
+  it('rejects a typo in a top-level field (additionalProperties: false)', () => {
+    expect(validate({ ...baseManifest, structuer: 'cli' })).toBe(false)
+  })
+})

--- a/src/__tests__/unit/skill/manifest-schema.spec.ts
+++ b/src/__tests__/unit/skill/manifest-schema.spec.ts
@@ -103,9 +103,7 @@ describe('saasfoundry-manifest.schema.json — rejection cases', () => {
   })
 
   it('rejects an unknown workflow.statuses[].color value', () => {
-    expect(
-      validate({ ...baseManifest, workflow: { tool: 'github-projects', statuses: [{ name: 'Done', color: 'NEON' }] } })
-    ).toBe(false)
+    expect(validate({ ...baseManifest, workflow: { tool: 'github-projects', statuses: [{ name: 'Done', color: 'NEON' }] } })).toBe(false)
   })
 
   it('rejects a non-string tools.srs.backend (schema pins const "notion")', () => {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -18,7 +18,7 @@ import { startBackend, startFrontend, startMonorepoApps, waitForServer } from '.
 import { bootstrapSrs } from '../runners/srs.runner'
 import { getHuskySetupCommand, openTerminal } from '../runners/terminal.runner'
 import { NotionSrsAdapter } from '../tools/notion/srs.adapter'
-import { SaaSFoundryManifest, SrsToolConfig } from '../types'
+import { manifestSchemaUrl, SaaSFoundryManifest, SrsToolConfig } from '../types'
 import { upsertEnvKey } from '../utils/env-file'
 import { ensureGitignorePatterns } from '../utils/gitignore'
 import { checkNodeVersion, computeFileHashes, setDefaultDbCredentials } from '../utils'
@@ -244,6 +244,7 @@ export async function newCommand(opts: NewCommandOptions = {}) {
     spinner.text = 'Computing file hashes for update tracking...'
     const fileHashes = await computeFileHashes('.')
     const manifest: SaaSFoundryManifest = {
+      $schema: manifestSchemaUrl,
       version: cliVersion,
       generatedAt: new Date().toISOString(),
       structure: startProjectAnswers.isMonorepo ? 'monorepo' : 'multirepo',

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -22,7 +22,7 @@ import { AdvancedSkillCredentials } from '../prompts/skills.prompts'
 import { promptSrsConfiguration } from '../prompts/srs.prompts'
 import { bootstrapSrs } from '../runners/srs.runner'
 import { NotionSrsAdapter } from '../tools/notion/srs.adapter'
-import { SaaSFoundryManifest, SrsToolConfig } from '../types'
+import { manifestSchemaUrl, SaaSFoundryManifest, SrsToolConfig } from '../types'
 import { upsertEnvKey } from '../utils/env-file'
 import { ensureGitignorePatterns } from '../utils/gitignore'
 import { checkNodeVersion, computeFileHashes, fileExists, getNvmPrefix } from '../utils'
@@ -282,7 +282,18 @@ export async function updateCommand(opts: UpdateCommandOptions = {}) {
     process.exit(1)
   }
 
-  const manifest: SaaSFoundryManifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+  let manifest: SaaSFoundryManifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+
+  // Idempotent $schema migration: stamp the canonical URL on legacy manifests
+  // and persist immediately so the field survives early-return paths (dry-run
+  // aside — we never mutate the disk in dry-run mode). Preserves user-customized
+  // values. Rebuilt with $schema first to match the sf new output shape.
+  if (!manifest.$schema) {
+    manifest = { $schema: manifestSchemaUrl, ...manifest }
+    if (!dryRun) {
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2))
+    }
+  }
 
   // Initialise the dry-run report. We populate it as we walk the two flows and
   // emit it on stdout at the end of the command when `--dry-run` is set.

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,6 +205,7 @@ export interface ToolsConfig {
 }
 
 export interface SaaSFoundryManifest {
+  $schema?: string
   version: string
   generatedAt: string
   structure: 'monorepo' | 'multirepo' | 'cli'
@@ -222,6 +223,12 @@ export interface SaaSFoundryManifest {
   aiRules?: AIRules
   tools?: ToolsConfig
 }
+
+// JSON Schema URL stamped into .saasfoundry.json so IDEs pick up live validation.
+// Points at master on the canonical repo — scaffolded projects don't ship a local
+// copy of the schema; drift is prevented by a Jest guard on the source of truth.
+export const manifestSchemaUrl =
+  'https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json'
 
 // Paths
 export const blueprintsPath = resolve(__dirname, '../scaffolds/blueprints')

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,8 +227,7 @@ export interface SaaSFoundryManifest {
 // JSON Schema URL stamped into .saasfoundry.json so IDEs pick up live validation.
 // Points at master on the canonical repo — scaffolded projects don't ship a local
 // copy of the schema; drift is prevented by a Jest guard on the source of truth.
-export const manifestSchemaUrl =
-  'https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json'
+export const manifestSchemaUrl = 'https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json'
 
 // Paths
 export const blueprintsPath = resolve(__dirname, '../scaffolds/blueprints')


### PR DESCRIPTION
Closes #286
Closes #288
Closes #289
Closes #290
Closes #291
Closes #292

## Summary

- Ship `schemas/saasfoundry-manifest.schema.json` (draft-07) as the single source of truth for the manifest shape — `$id` points at master so IDEs pick up live validation without scaffolds shipping a local copy.
- Stamp `$schema` automatically: `sf new` writes it on every fresh manifest; `sf update` back-fills it on legacy projects (idempotent, preserves user-customized values, persists on the early-return path, no-op on `--dry-run`).
- Drop one defensive `jq` runtime guard now redundant: `tools.srs.backend` is pinned to const `"notion"` by the schema, so the bash script can use a plain `// empty` fallback. ~600 chars / ~150 tokens removed across the active skill + scaffold mirror.
- Lock the contract with two new specs: ajv-driven schema validation (canonical shapes pass, malformed shapes / typos / unknown enum values reject) + integration coverage for the `sf update` migration (back-fill, idempotency, `$schema`-first ordering, dry-run no-op).

1200 tests passing (was 1186 → +14 new, −2 obsoleted).

## Subtasks

| # | Title |
|---|---|
| #288 | Ship `saasfoundry-manifest.schema.json` |
| #289 | Wire `$schema` into `sf new` manifest generation |
| #290 | `sf update` — idempotent `$schema` migration |
| #291 | Drop one defensive `jq` fallback now schema-pinned |
| #292 | Tests — ajv schema validation + migration coverage |

## Test plan

- [x] `npx jest` — full suite green (1200 passing, 2 skipped)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hook on every sub commit (prettier + eslint + tsc + jest)
- [x] Pre-push hook (Docker scaffold tests) — passed on `git push`
- [ ] Manual smoke: open a scaffolded `.saasfoundry.json` in VS Code and confirm `$schema` triggers IDE autocomplete + flags an unknown field
- [ ] Manual smoke: run `sf update --dry-run` on a manifest without `$schema` → disk unchanged
- [ ] Manual smoke: run `sf update` on a manifest without `$schema` (no modules to add, version up-to-date) → field stamped first, file otherwise byte-equivalent