### PR TITLE
[#287] [Parent #277] [Parent #277] JSON Schema + CI validation for sf-srs data files

### DIFF
--- a/.claude/skills/sf-srs/data/clustering-rules.json
+++ b/.claude/skills/sf-srs/data/clustering-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/clustering-rules.schema.json",
   "version": 1,
   "description": "Structured clustering & seeding rules consumed by the sf-srs drafting flow (`srs-cli.sh draft --from codebase`). SKILL.md points to this file; edit here, not in prose.",
   "finding_kinds": [

--- a/.claude/skills/sf-srs/scripts/detect-eval-signals.sh
+++ b/.claude/skills/sf-srs/scripts/detect-eval-signals.sh
@@ -41,6 +41,7 @@ EOF
 emit_rules() {
   cat <<'JSON'
 {
+  "$schema": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/detect-eval-signals-rules.schema.json",
   "description": "Detection heuristics + patch shape for the sf-srs conversational eval hook. SKILL.md points here; edit JSON, not prose.",
   "precondition": {
     "manifest_key": "tools.srs.enabled",

--- a/scaffolds/skills-templates/sf-srs/data/clustering-rules.json
+++ b/scaffolds/skills-templates/sf-srs/data/clustering-rules.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/clustering-rules.schema.json",
   "version": 1,
   "description": "Structured clustering & seeding rules consumed by the sf-srs drafting flow (`srs-cli.sh draft --from codebase`). SKILL.md points to this file; edit here, not in prose.",
   "finding_kinds": [

--- a/scaffolds/skills-templates/sf-srs/scripts/detect-eval-signals.sh
+++ b/scaffolds/skills-templates/sf-srs/scripts/detect-eval-signals.sh
@@ -41,6 +41,7 @@ EOF
 emit_rules() {
   cat <<'JSON'
 {
+  "$schema": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/detect-eval-signals-rules.schema.json",
   "description": "Detection heuristics + patch shape for the sf-srs conversational eval hook. SKILL.md points here; edit JSON, not prose.",
   "precondition": {
     "manifest_key": "tools.srs.enabled",

--- a/schemas/clustering-rules.schema.json
+++ b/schemas/clustering-rules.schema.json
@@ -1,0 +1,237 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/clustering-rules.schema.json",
+  "title": "sf-srs clustering & seeding rules",
+  "description": "Shape of `.claude/skills/sf-srs/data/clustering-rules.json`. Pinned by #287 so the data contract is verifiable at commit time instead of implied by the prose that reads it.",
+  "type": "object",
+  "required": ["version", "finding_kinds", "epic_fr_clustering", "seeding", "coverage_table", "review_loop"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional pointer to this schema for IDE live validation."
+    },
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Bump when the shape changes in a non-additive way."
+    },
+    "description": { "type": "string" },
+    "finding_kinds": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["kind", "source", "area_heuristic"],
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["endpoint", "ui-flow", "entity", "test", "doc-context"]
+          },
+          "source": { "type": "string", "minLength": 1 },
+          "area_heuristic": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "reading_findings": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "epic_fr_clustering": {
+      "type": "object",
+      "required": ["order", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "order": { "type": "string", "minLength": 1 },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["id", "name"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "integer", "minimum": 1 },
+              "name": { "type": "string", "minLength": 1 },
+              "action": { "type": "string" },
+              "rules": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 }
+              }
+            },
+            "anyOf": [{ "required": ["action"] }, { "required": ["rules"] }]
+          }
+        }
+      }
+    },
+    "seeding": {
+      "type": "object",
+      "required": ["philosophy", "ds_items", "tc_items", "nfr_items"],
+      "additionalProperties": false,
+      "properties": {
+        "philosophy": { "type": "string", "minLength": 1 },
+        "ds_items": { "$ref": "#/definitions/dsItems" },
+        "tc_items": { "$ref": "#/definitions/tcItems" },
+        "nfr_items": { "$ref": "#/definitions/nfrItems" }
+      }
+    },
+    "coverage_table": {
+      "type": "object",
+      "required": ["purpose", "template", "red_flag"],
+      "additionalProperties": false,
+      "properties": {
+        "purpose": { "type": "string", "minLength": 1 },
+        "template": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "red_flag": { "type": "string", "minLength": 1 }
+      }
+    },
+    "review_loop": {
+      "type": "object",
+      "required": ["rule", "prompt_template", "branches", "throttle"],
+      "additionalProperties": false,
+      "properties": {
+        "rule": { "type": "string", "minLength": 1 },
+        "prompt_template": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "branches": {
+          "type": "object",
+          "required": ["accept", "edit", "reject", "skip-area"],
+          "additionalProperties": false,
+          "properties": {
+            "accept": { "type": "string", "minLength": 1 },
+            "edit": { "type": "string", "minLength": 1 },
+            "reject": { "type": "string", "minLength": 1 },
+            "skip-area": { "type": "string", "minLength": 1 }
+          }
+        },
+        "throttle": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "definitions": {
+    "dsItems": {
+      "type": "object",
+      "required": ["description", "mappings", "grouping_rules"],
+      "additionalProperties": false,
+      "properties": {
+        "description": { "type": "string", "minLength": 1 },
+        "mappings": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["finding", "title", "description_source"],
+            "additionalProperties": false,
+            "properties": {
+              "finding": { "type": "string", "minLength": 1 },
+              "title": { "type": "string", "minLength": 1 },
+              "description_source": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "grouping_rules": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "tcItems": {
+      "type": "object",
+      "required": ["description", "mappings", "todo_for_untested_endpoints"],
+      "additionalProperties": false,
+      "properties": {
+        "description": { "type": "string", "minLength": 1 },
+        "mappings": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["source", "target_field", "rule"],
+            "additionalProperties": false,
+            "properties": {
+              "source": { "type": "string", "minLength": 1 },
+              "target_field": { "type": "string", "minLength": 1 },
+              "rule": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "todo_for_untested_endpoints": {
+          "type": "object",
+          "required": ["when", "emit_as", "shape", "reviewer_options"],
+          "additionalProperties": false,
+          "properties": {
+            "when": { "type": "string", "minLength": 1 },
+            "emit_as": { "type": "string", "minLength": 1 },
+            "shape": {
+              "type": "object",
+              "required": ["id", "title", "expectedResult", "frRefs"],
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "title": { "type": "string", "minLength": 1 },
+                "expectedResult": { "type": "string", "minLength": 1 },
+                "frRefs": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "type": "string", "minLength": 1 }
+                }
+              }
+            },
+            "reviewer_options": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "nfrItems": {
+      "type": "object",
+      "required": ["description", "layer1_stack_signals", "layer2_standard_saas_catalogue"],
+      "additionalProperties": false,
+      "properties": {
+        "description": { "type": "string", "minLength": 1 },
+        "layer1_stack_signals": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["signal", "seeded_nfrs"],
+            "additionalProperties": false,
+            "properties": {
+              "signal": { "type": "string", "minLength": 1 },
+              "seeded_nfrs": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        },
+        "layer2_standard_saas_catalogue": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["nfr"],
+            "additionalProperties": false,
+            "properties": {
+              "nfr": { "type": "string", "minLength": 1 },
+              "always_propose": { "type": "boolean" },
+              "condition": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/detect-eval-signals-rules.schema.json
+++ b/schemas/detect-eval-signals-rules.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/detect-eval-signals-rules.schema.json",
+  "title": "sf-srs detect-eval-signals --rules output",
+  "description": "Shape of the JSON emitted by `.claude/skills/sf-srs/scripts/detect-eval-signals.sh --rules`. Pinned by #287 so the conversational eval hook contract is verifiable at commit time.",
+  "type": "object",
+  "required": ["description", "precondition", "throttle", "trivial_skip", "signals", "confirmation_flow", "patch_shape", "scope_limits_v1", "dogfood_checklist"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional pointer to this schema for IDE live validation."
+    },
+    "description": { "type": "string", "minLength": 1 },
+    "precondition": {
+      "type": "object",
+      "required": ["manifest_key", "expected_value", "behavior_when_disabled"],
+      "additionalProperties": false,
+      "properties": {
+        "manifest_key": { "type": "string", "minLength": 1 },
+        "expected_value": {},
+        "behavior_when_disabled": { "type": "string", "minLength": 1 }
+      }
+    },
+    "throttle": {
+      "type": "object",
+      "required": ["max_proposals_per_turn", "dedup_window"],
+      "additionalProperties": false,
+      "properties": {
+        "max_proposals_per_turn": { "type": "integer", "minimum": 1 },
+        "dedup_window": { "type": "string", "minLength": 1 }
+      }
+    },
+    "trivial_skip": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "signals": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/signal" }
+    },
+    "confirmation_flow": {
+      "type": "object",
+      "required": ["before_coding", "prompt_template", "branches"],
+      "additionalProperties": false,
+      "properties": {
+        "before_coding": { "type": "boolean" },
+        "prompt_template": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "branches": {
+          "type": "object",
+          "required": ["accept", "edit", "reject"],
+          "additionalProperties": false,
+          "properties": {
+            "accept": { "type": "string", "minLength": 1 },
+            "edit": { "type": "string", "minLength": 1 },
+            "reject": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "patch_shape": {
+      "type": "object",
+      "required": ["kind", "pageId", "item", "note"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "pageId": { "type": "string", "minLength": 1 },
+        "item": { "type": "string", "minLength": 1 },
+        "note": { "type": "string", "minLength": 1 }
+      }
+    },
+    "scope_limits_v1": {
+      "type": "object",
+      "required": ["add_only", "append_placement", "add_fr"],
+      "additionalProperties": false,
+      "properties": {
+        "add_only": { "type": "string", "minLength": 1 },
+        "append_placement": { "type": "string", "minLength": 1 },
+        "add_fr": { "type": "string", "minLength": 1 }
+      }
+    },
+    "dogfood_checklist": { "type": "string", "minLength": 1 }
+  },
+  "definitions": {
+    "signal": {
+      "type": "object",
+      "required": ["id", "meaning", "target", "patch_kind", "example", "regex_hints"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": ["ur", "fr", "ds", "tc", "revision"]
+        },
+        "meaning": { "type": "string", "minLength": 1 },
+        "target": { "type": "string", "minLength": 1 },
+        "patch_kind": {
+          "type": "string",
+          "enum": ["add-ur", "add-fr", "add-ds", "add-tc"]
+        },
+        "example": { "type": "string", "minLength": 1 },
+        "regex_hints": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "note": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/src/__tests__/unit/skill/srs-data-schemas.spec.ts
+++ b/src/__tests__/unit/skill/srs-data-schemas.spec.ts
@@ -1,0 +1,126 @@
+import { execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import path from 'path'
+import Ajv from 'ajv'
+
+// Regression guard for #287: pin the data contracts of the two sf-srs JSON
+// artefacts to a published JSON Schema so the agent that reads them can trust
+// the shape instead of re-parsing prose. The schemas live under /schemas/ and
+// are referenced via `$schema` URLs (same pattern as the manifest schema
+// shipped in #286). Drift either way (schema vs data) breaks the eval hook and
+// the drafting flow — both are critical surfaces for the SRS module.
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+
+const CLUSTERING_SCHEMA_PATH = path.join(REPO_ROOT, 'schemas/clustering-rules.schema.json')
+const EVAL_SIGNALS_SCHEMA_PATH = path.join(REPO_ROOT, 'schemas/detect-eval-signals-rules.schema.json')
+
+const CLUSTERING_DATA_PATHS = [path.join(REPO_ROOT, '.claude/skills/sf-srs/data/clustering-rules.json'), path.join(REPO_ROOT, 'scaffolds/skills-templates/sf-srs/data/clustering-rules.json')]
+
+const EVAL_SIGNALS_SCRIPT_PATHS = [
+  path.join(REPO_ROOT, '.claude/skills/sf-srs/scripts/detect-eval-signals.sh'),
+  path.join(REPO_ROOT, 'scaffolds/skills-templates/sf-srs/scripts/detect-eval-signals.sh')
+]
+
+const newAjv = () => new Ajv({ allErrors: true, strict: false })
+
+describe('clustering-rules.schema.json — canonical shape', () => {
+  const schema = JSON.parse(readFileSync(CLUSTERING_SCHEMA_PATH, 'utf8'))
+  const validate = newAjv().compile(schema)
+
+  it.each(CLUSTERING_DATA_PATHS)('%s validates against the schema', (file) => {
+    const data = JSON.parse(readFileSync(file, 'utf8'))
+    const ok = validate(data)
+    if (!ok) throw new Error(JSON.stringify(validate.errors, null, 2))
+    expect(ok).toBe(true)
+  })
+
+  it('the data file declares the canonical $schema URL', () => {
+    for (const file of CLUSTERING_DATA_PATHS) {
+      const data = JSON.parse(readFileSync(file, 'utf8'))
+      expect(data.$schema).toBe('https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/clustering-rules.schema.json')
+    }
+  })
+})
+
+describe('clustering-rules.schema.json — rejection cases', () => {
+  const schema = JSON.parse(readFileSync(CLUSTERING_SCHEMA_PATH, 'utf8'))
+  const validate = newAjv().compile(schema)
+  const minimal = JSON.parse(readFileSync(CLUSTERING_DATA_PATHS[0], 'utf8'))
+
+  it('rejects an unknown finding_kinds.kind enum', () => {
+    const broken = structuredClone(minimal)
+    broken.finding_kinds[0].kind = 'snowflake'
+    expect(validate(broken)).toBe(false)
+  })
+
+  it('rejects a typo in a top-level field (additionalProperties: false)', () => {
+    const broken = structuredClone(minimal)
+    broken.seedingg = broken.seeding
+    delete broken.seeding
+    expect(validate(broken)).toBe(false)
+  })
+
+  it('rejects a non-integer version', () => {
+    const broken = structuredClone(minimal)
+    broken.version = '1'
+    expect(validate(broken)).toBe(false)
+  })
+
+  it('rejects a missing required seeding section', () => {
+    const broken = structuredClone(minimal)
+    delete broken.seeding.nfr_items
+    expect(validate(broken)).toBe(false)
+  })
+})
+
+describe('detect-eval-signals-rules.schema.json — canonical shape', () => {
+  const schema = JSON.parse(readFileSync(EVAL_SIGNALS_SCHEMA_PATH, 'utf8'))
+  const validate = newAjv().compile(schema)
+
+  it.each(EVAL_SIGNALS_SCRIPT_PATHS)('%s --rules output validates against the schema', (script) => {
+    const stdout = execFileSync('bash', [script, '--rules'], { encoding: 'utf8' })
+    const data = JSON.parse(stdout)
+    const ok = validate(data)
+    if (!ok) throw new Error(JSON.stringify(validate.errors, null, 2))
+    expect(ok).toBe(true)
+  })
+
+  it('the --rules output declares the canonical $schema URL', () => {
+    for (const script of EVAL_SIGNALS_SCRIPT_PATHS) {
+      const stdout = execFileSync('bash', [script, '--rules'], { encoding: 'utf8' })
+      const data = JSON.parse(stdout)
+      expect(data.$schema).toBe('https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/detect-eval-signals-rules.schema.json')
+    }
+  })
+})
+
+describe('detect-eval-signals-rules.schema.json — rejection cases', () => {
+  const schema = JSON.parse(readFileSync(EVAL_SIGNALS_SCHEMA_PATH, 'utf8'))
+  const validate = newAjv().compile(schema)
+  const minimal = JSON.parse(execFileSync('bash', [EVAL_SIGNALS_SCRIPT_PATHS[0], '--rules'], { encoding: 'utf8' }))
+
+  it('rejects an unknown signal.id enum', () => {
+    const broken = structuredClone(minimal)
+    broken.signals[0].id = 'urgent'
+    expect(validate(broken)).toBe(false)
+  })
+
+  it('rejects an unknown signal.patch_kind enum', () => {
+    const broken = structuredClone(minimal)
+    broken.signals[0].patch_kind = 'replace-fr'
+    expect(validate(broken)).toBe(false)
+  })
+
+  it('rejects a missing throttle.max_proposals_per_turn', () => {
+    const broken = structuredClone(minimal)
+    delete broken.throttle.max_proposals_per_turn
+    expect(validate(broken)).toBe(false)
+  })
+
+  it('rejects a non-integer throttle.max_proposals_per_turn', () => {
+    const broken = structuredClone(minimal)
+    broken.throttle.max_proposals_per_turn = 'one'
+    expect(validate(broken)).toBe(false)
+  })
+})


### PR DESCRIPTION
Resolves #287

## Summary

Pin two new JSON Schema (draft-07) contracts so the sf-srs data layer is verifiable at commit time instead of implied by the prose that reads it. Same publishing pattern as the manifest schema shipped in [PR #293](https://github.com/DiamondForgeFr/SaaSFoundry/pull/293) (#286).

- `schemas/clustering-rules.schema.json` — covers `data/clustering-rules.json` (version, finding_kinds, epic_fr_clustering, seeding {ds/tc/nfr}, coverage_table, review_loop)
- `schemas/detect-eval-signals-rules.schema.json` — covers `scripts/detect-eval-signals.sh --rules` output (precondition, throttle, trivial_skip, signals[], confirmation_flow, patch_shape, scope_limits_v1)

Both data sources gain a `$schema` field pointing at the published schema URL. A Jest spec wraps ajv validation so drift between schema and data fails the CI gate.

## Acceptance criteria — status

| AC item | Status |
|---|---|
| Both schemas validate the canonical shapes without modification | ✅ |
| `$schema` references resolve to the shipped schema files | ✅ |
| Jest spec runs ajv against both files and fails on drift (`src/__tests__/unit/skill/srs-data-schemas.spec.ts`) | ✅ 14/14 |
| Drift guard stays green for mirrored files; existing tests stay green | ✅ 1214/1216 (2 skipped baseline) |
| Drop ≥1 defensive `jq // empty` / regex-with-fallback branch from sf-srs skill code | ⚠️ N/A — see below |

### AC item « drop defensive fallback » — N/A justification

The sf-srs skill code (bash scripts in `.claude/skills/sf-srs/scripts/` and the SKILL.md prose) doesn't currently use `jq // empty` patterns or regex-with-fallback branches tied to `clustering-rules.json` / `detect-eval-signals --rules`. The agent reads these JSON artefacts directly via the SKILL.md reference; no runtime guards exist to remove. The schema lift still delivers its primary value (IDE live validation, CI gate, agent-provable contract) — this AC item assumed defensive code that doesn't actually live in this skill.

## Out-of-scope follow-ups (deferred)

- `sf check-srs-rules` CLI wrapper (only if real demand appears)
- Schema coverage for `templates/examples/example-epic.spec.json` (separate ticket)

## Test plan

- [x] `npm run test:pre-commit` — 102 suites / 1214 tests passed
- [x] New spec `srs-data-schemas.spec.ts` — 14/14 (4 canonical + 2 `$schema` URL + 8 rejection cases)
- [x] Drift guard `tool-skill-drift.spec.ts` green (data files pair-mirrored)
- [x] Pre-push docker scenarios `multirepo-minimal` + `monorepo-minimal` passed
- [x] No public CLI surface change

🤖 Generated with [Claude Code](https://claude.com/claude-code)