### PR TITLE
feat(#328): native GitHub Issue Types — ensure/assign/delete CLI + create-subtask integration

### DIFF
--- a/.claude/docs/manifest-schema.md
+++ b/.claude/docs/manifest-schema.md
@@ -24,21 +24,22 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
 
 ## Fields read by each skill
 
-| Skill                     | Field                           | Purpose                                                        |
-| ------------------------- | ------------------------------- | -------------------------------------------------------------- |
-| `sf-workflow`             | `workflow.tool`                 | Routes CLI calls to the right tool adapter                     |
-| `sf-workflow`             | `workflow.workingBranch`        | Default branch for `git checkout -b feature/...`               |
-| `sf-workflow`             | `workflow.prTargetBranch`       | Default PR target                                              |
-| `sf-workflow`             | `workflow.branchNaming.feature` | Pattern for feature branches                                   |
-| `sf-workflow`             | `workflow.commitFormat.pattern` | Enforced by commitlint hook                                    |
-| `sf-tool-github-projects` | `workflow.projectUrl`           | GitHub Projects V2 URL (org or user)                           |
-| `sf-tool-github-projects` | `workflow.workingBranch`        | Used by `create-pr` to target the right base                   |
-| `sf-tool-github-projects` | `workflow.statuses`             | Status options declared on the board                           |
-| `sf-tool-github-projects` | `tools.srs.backend`             | Enables SRS gating on `create-subtask` (Rule 8)                |
-| `sf-srs`                  | `tools.srs.backend`             | Resolves which `SrsAdapter` to instantiate                     |
-| `sf-srs`                  | `tools.srs.rootPage.id`         | Default root container for drafters / eval                     |
-| `sf-srs`                  | `tools.srs.enabled`             | Gates the conversational eval hook                             |
-| `sf-srs`                  | `tools.srs.scan.exclude`        | Extra exclusion patterns on top of `.gitignore` + `.srsignore` |
+| Skill                     | Field                           | Purpose                                                            |
+| ------------------------- | ------------------------------- | ------------------------------------------------------------------ |
+| `sf-workflow`             | `workflow.tool`                 | Routes CLI calls to the right tool adapter                         |
+| `sf-workflow`             | `workflow.workingBranch`        | Default branch for `git checkout -b feature/...`                   |
+| `sf-workflow`             | `workflow.prTargetBranch`       | Default PR target                                                  |
+| `sf-workflow`             | `workflow.branchNaming.feature` | Pattern for feature branches                                       |
+| `sf-workflow`             | `workflow.commitFormat.pattern` | Enforced by commitlint hook                                        |
+| `sf-tool-github-projects` | `workflow.projectUrl`           | GitHub Projects V2 URL (org or user)                               |
+| `sf-tool-github-projects` | `workflow.workingBranch`        | Used by `create-pr` to target the right base                       |
+| `sf-tool-github-projects` | `workflow.statuses`             | Status options declared on the board                               |
+| `sf-tool-github-projects` | `workflow.issueTypes`           | Native GitHub Issue Type chips (Epic/Story/Task/Issue) — org-level |
+| `sf-tool-github-projects` | `tools.srs.backend`             | Enables SRS gating on `create-subtask` (Rule 8)                    |
+| `sf-srs`                  | `tools.srs.backend`             | Resolves which `SrsAdapter` to instantiate                         |
+| `sf-srs`                  | `tools.srs.rootPage.id`         | Default root container for drafters / eval                         |
+| `sf-srs`                  | `tools.srs.enabled`             | Gates the conversational eval hook                                 |
+| `sf-srs`                  | `tools.srs.scan.exclude`        | Extra exclusion patterns on top of `.gitignore` + `.srsignore`     |
 
 ## Canonical shape
 
@@ -72,6 +73,12 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
       { "name": "Human testing", "color": "ORANGE" },
       { "name": "In review", "color": "PINK" },
       { "name": "Done", "color": "GREEN" }
+    ],
+    "issueTypes": [
+      { "name": "Epic", "description": "Grouper for related Stories/Tasks (no PR, no branch)", "color": "PURPLE" },
+      { "name": "Story", "description": "Delivers user-observable value", "color": "BLUE" },
+      { "name": "Task", "description": "Delivers a technical action", "color": "GRAY" },
+      { "name": "Issue", "description": "Defect or unexpected behavior", "color": "RED" }
     ]
   },
   "tools": {

--- a/.claude/skills/sf-tool-github-projects/SKILL.md
+++ b/.claude/skills/sf-tool-github-projects/SKILL.md
@@ -8,14 +8,15 @@ github project, create subtask, update ticket status, github issue, project boar
 
 ## Data model
 
-Two orthogonal axes on every ticket:
+Three orthogonal axes on every ticket:
 
-| Axis           | Where it lives                                         | What it controls                                           |
-| -------------- | ------------------------------------------------------ | ---------------------------------------------------------- |
-| **Status**     | Projects V2 board (Single select field "Status")       | Workflow phase (Backlog → … → Done)                        |
-| **Complexity** | GitHub label (`complexity: bug\|low\|medium\|complex`) | Rigor level applied in each phase (agents, tests, reviews) |
+| Axis           | Where it lives                                             | What it controls                                                           |
+| -------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Status**     | Projects V2 board (Single select field "Status")           | Workflow phase (Backlog → … → Done)                                        |
+| **Complexity** | GitHub label (`complexity: bug\|low\|medium\|complex`)     | Rigor level applied in each phase (agents, tests, reviews)                 |
+| **Type**       | GitHub Issue Type (org-level chip — Epic/Story/Task/Issue) | Ticket nature in the hierarchy (replaces `[EPIC]`/`[STORY]` title markers) |
 
-Never encode status in a label. Never encode complexity on the board. Keep them independent.
+Never encode status in a label. Never encode complexity on the board. Type is org-scoped — a single set of types serves every repo in the org.
 
 ## Configuration
 
@@ -38,6 +39,9 @@ All via `.claude/skills/sf-tool-github-projects/github-projects-cli.sh <cmd> [ar
 | `get-ticket <ticket>`                    | Print title + body (used by `detect-complexity.sh`)                                               |
 | `create-pr <ticket>`                     | Push branch + open PR against `workingBranch`                                                     |
 | `list [status]`                          | List project items, optionally filtered by status                                                 |
+| `ensure-issue-types [--dry-run]`         | Idempotently create org-level issue types from `workflow.issueTypes` in `.saasfoundry.json`       |
+| `assign-type <issue> <type>`             | Attach a native GitHub Issue Type chip (Epic/Story/Task/Issue) to the issue                       |
+| `delete-issue-type <type>`               | Remove an issue type from the org (cleanup of legacy types like Bug/Feature)                      |
 
 Status names are case-insensitive — the CLI matches against the options defined on the board.
 
@@ -118,9 +122,36 @@ $CLI update-status 42 "In review"
 $CLI update-status 42 "Done"
 ```
 
+## Issue Types (org-level chips)
+
+Native GitHub Issue Types replace the legacy textual title markers (`[EPIC]`, `[STORY]`, `[Parent #N]`). Types live at the **organisation** level — one canonical set is shared across every repo in the
+org. The CLI keeps the org in sync with `.saasfoundry.json` → `workflow.issueTypes[]`:
+
+```bash
+# 1. One-time setup — create missing types declared in the manifest (idempotent)
+$CLI ensure-issue-types
+
+# 2. Assign a type to an existing issue
+$CLI assign-type 42 Story
+
+# 3. Cleanup — remove a legacy type after reassigning its issues
+$CLI delete-issue-type Bug
+```
+
+`create-subtask` automatically calls `assign-type` for the matching native type after creation (best-effort — subtask creation never fails because of a type-assignment hiccup).
+
+**Permissions** — `ensure-issue-types`, `assign-type`, and `delete-issue-type` write to org-level config and require the `admin:org` scope on the `gh` token. Refresh once with:
+
+```bash
+gh auth refresh --hostname github.com --scopes admin:org
+```
+
+Without that scope the CLI still works for read paths and prints an actionable message before exiting (no silent failure).
+
 ## Requirements
 
 - `gh` CLI authenticated (`gh auth status` must show `project` + `repo` scopes)
+- `gh` token has `admin:org` scope **only** if you'll run the Issue Types commands (otherwise read paths are enough)
 - `jq` for JSON parsing
 - Project exists with a single-select "Status" field whose options match `.saasfoundry.json` → `workflow.statuses`
 

--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -932,6 +932,9 @@ cmd_ensure_issue_types() {
 
   local owner
   owner=$(_get_issue_types_owner)
+  # `exit 1` inside _get_issue_types_owner only kills the $() subshell — the
+  # parent script keeps running with $owner empty unless we re-check here.
+  [ -z "$owner" ] && exit 1
 
   local desired_json
   desired_json=$(jq -c '.workflow.issueTypes // []' .saasfoundry.json 2>/dev/null)
@@ -989,7 +992,10 @@ cmd_ensure_issue_types() {
       }' \
       -F oid="$owner_id" -F n="$name" -F d="$desc" -F c="$color" 2>&1) || true
 
-    if echo "$resp" | jq -e '.data.createIssueType.issueType.id' > /dev/null 2>&1; then
+    # Treat "data + errors" partial responses as failures — GraphQL allows
+    # both to coexist, and we don't want a half-broken type silently logged
+    # as ✓ created.
+    if echo "$resp" | jq -e '.data.createIssueType.issueType.id and (.errors | not)' > /dev/null 2>&1; then
       echo -e "    ${GREEN}✓ created${NC} ${name} (${color})"
     else
       _handle_issue_type_error "Create issue type '${name}'" "$resp"
@@ -1011,6 +1017,7 @@ cmd_assign_type() {
 
   local owner
   owner=$(_get_issue_types_owner)
+  [ -z "$owner" ] && exit 1
 
   local type_id
   type_id=$(_find_type_id "$owner" "$type_name")
@@ -1036,7 +1043,7 @@ cmd_assign_type() {
     }' \
     -F iid="$issue_id" -F tid="$type_id" 2>&1) || true
 
-  if echo "$resp" | jq -e '.data.updateIssueIssueType.issue.number' > /dev/null 2>&1; then
+  if echo "$resp" | jq -e '.data.updateIssueIssueType.issue.number and (.errors | not)' > /dev/null 2>&1; then
     local applied
     applied=$(echo "$resp" | jq -r '.data.updateIssueIssueType.issue.issueType.name // "?"')
     echo -e "${GREEN}✓ Issue #${issue} → type '${applied}'${NC}"
@@ -1056,6 +1063,7 @@ cmd_delete_issue_type() {
 
   local owner
   owner=$(_get_issue_types_owner)
+  [ -z "$owner" ] && exit 1
 
   local type_id
   type_id=$(_find_type_id "$owner" "$type_name")
@@ -1069,7 +1077,7 @@ cmd_delete_issue_type() {
     -f query='mutation($tid:ID!){deleteIssueType(input:{issueTypeId:$tid}){clientMutationId}}' \
     -F tid="$type_id" 2>&1) || true
 
-  if echo "$resp" | jq -e '.data.deleteIssueType' > /dev/null 2>&1; then
+  if echo "$resp" | jq -e '.data.deleteIssueType and (.errors | not)' > /dev/null 2>&1; then
     _invalidate_types_cache
     echo -e "${GREEN}✓ Deleted issue type '${type_name}' from '${owner}'${NC}"
   else

--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -454,7 +454,11 @@ cmd_create_subtask() {
   PARENT_NUMBER="${POSITIONAL[0]}"
   TITLE="${POSITIONAL[1]}"
   BODY="${POSITIONAL[2]:-}"
-  FULL_TITLE="[Parent #${PARENT_NUMBER}] ${TITLE}"
+  # Native sub-issue linking (addSubIssue mutation below) makes the parent
+  # relationship visible in the GitHub UI on its own — no need for a textual
+  # `[Parent #N]` title prefix anymore. Native Issue Type chips (Epic/Story/
+  # Task/Issue) replace the old `[EPIC]`/`[STORY]` markers via assign-type.
+  FULL_TITLE="${TITLE}"
 
   # If no body was supplied, render a type-specific skeleton so the created
   # issue lands with the right section shape instead of an empty body.
@@ -522,6 +526,26 @@ cmd_create_subtask() {
     echo -e "${RED}Error: Failed to link subtask${NC}"
     echo "$RESULT"
     exit 1
+  fi
+
+  # Auto-assign the native GitHub Issue Type matching --type. Best-effort: a
+  # missing type (org doesn't have it yet) or a missing org-admin scope must
+  # not break subtask creation — the chip is cosmetic, the parent link is
+  # already in place. Skip silently when workflow.issueTypes isn't declared.
+  local declared_types
+  declared_types=$(jq -r '(.workflow.issueTypes // []) | length' .saasfoundry.json 2>/dev/null)
+  if [ "${declared_types:-0}" != "0" ]; then
+    local target_type
+    case "$TICKET_TYPE" in
+      epic)   target_type="Epic" ;;
+      story)  target_type="Story" ;;
+      task)   target_type="Task" ;;
+      issue)  target_type="Issue" ;;
+    esac
+    if [ -n "$target_type" ]; then
+      "$0" assign-type "$CHILD_NUMBER" "$target_type" 2>/dev/null || \
+        echo -e "${YELLOW}  (issue type '${target_type}' not assigned — run 'ensure-issue-types' or assign manually)${NC}"
+    fi
   fi
 }
 
@@ -799,20 +823,279 @@ cmd_cache_clear() {
 }
 
 # ───────────────────────────────────────────────────────────────────────────
+# Issue Types — native GitHub typing (replaces textual [EPIC]/[STORY] markers)
+#
+# GitHub Issue Types (GA 2024) live at the **org level** — types are created
+# once on the organisation and then assigned to issues across any of its repos.
+# Three commands cover the full lifecycle:
+#
+#   ensure-issue-types     idempotent: creates each name in workflow.issueTypes
+#                          missing from the org (reads .saasfoundry.json)
+#   assign-type            attach a type to a single issue
+#   delete-issue-type      remove a type from the org (cleanup of legacy types)
+#
+# All operate via raw GraphQL (`gh api graphql`) — `gh` has no first-class
+# Issue Types subcommand yet. Mutations: createIssueType / deleteIssueType /
+# updateIssueIssueType. The `_TYPES_CACHE` map is per-process to keep the
+# bootstrap script (which assigns hundreds of issues) reasonably snappy.
+# ───────────────────────────────────────────────────────────────────────────
+
+# Resolve the org login from .saasfoundry.json's projectUrl. Issue Types are
+# always org-scoped — user-projects are unsupported (GitHub limitation).
+_get_issue_types_owner() {
+  load_config
+  if [ -z "$PROJECT_OWNER" ]; then
+    echo -e "${RED}Error: workflow.projectUrl is missing or malformed in .saasfoundry.json${NC}" >&2
+    exit 1
+  fi
+  if ! echo "$PROJECT_URL" | grep -q '/orgs/'; then
+    echo -e "${RED}Error: Issue Types require an organisation project (URL must contain /orgs/<owner>/projects/<n>)${NC}" >&2
+    echo "  Current projectUrl: ${PROJECT_URL}" >&2
+    exit 1
+  fi
+  echo "$PROJECT_OWNER"
+}
+
+# Fetch the org node ID — needed as ownerId for createIssueType.
+_get_org_node_id() {
+  local owner=$1
+  gh api graphql -f query='query($o:String!){organization(login:$o){id}}' -F o="$owner" 2>/dev/null \
+    | jq -r '.data.organization.id // empty'
+}
+
+# Fetch the org's existing issue types as JSON array of {id,name,color,description}.
+# Cached per-process — bootstrap workflows can call this dozens of times.
+_TYPES_CACHE_OWNER=""
+_TYPES_CACHE_JSON=""
+_get_org_issue_types() {
+  local owner=$1
+  if [ "$_TYPES_CACHE_OWNER" = "$owner" ] && [ -n "$_TYPES_CACHE_JSON" ]; then
+    echo "$_TYPES_CACHE_JSON"
+    return 0
+  fi
+  local resp
+  resp=$(gh api graphql \
+    -f query='query($o:String!){organization(login:$o){issueTypes(first:50){nodes{id name description color isEnabled}}}}' \
+    -F o="$owner" 2>/dev/null)
+  local types
+  types=$(echo "$resp" | jq -c '.data.organization.issueTypes.nodes // []')
+  _TYPES_CACHE_OWNER="$owner"
+  _TYPES_CACHE_JSON="$types"
+  echo "$types"
+}
+
+# Reset the per-process cache (called after create/delete mutations).
+_invalidate_types_cache() {
+  _TYPES_CACHE_OWNER=""
+  _TYPES_CACHE_JSON=""
+}
+
+# Look up a type id by case-insensitive name. Echoes empty if not found.
+_find_type_id() {
+  local owner=$1 name=$2
+  _get_org_issue_types "$owner" | jq -r --arg s "$name" '
+    .[] | select((.name | ascii_downcase) == ($s | ascii_downcase)) | .id
+  ' | head -n1
+}
+
+# Translate "permission denied" GraphQL responses into a single, actionable line.
+# Issue Type mutations require org-admin scope — users without that role need
+# to ask their org owner (or fall back to manual creation in the org settings UI).
+_handle_issue_type_error() {
+  local action=$1 detail=$2
+  if echo "$detail" | grep -qiE 'INSUFFICIENT_SCOPES|admin:org'; then
+    echo -e "${RED}✗ ${action}: gh token is missing the 'admin:org' scope.${NC}" >&2
+    echo "  Issue Type mutations are org-admin operations and need this scope." >&2
+    echo "  Fix once with:" >&2
+    echo "    gh auth refresh --hostname github.com --scopes admin:org" >&2
+    echo "  …then re-run this command. Alternative: ask an org owner to run it." >&2
+  elif echo "$detail" | grep -qiE 'permission|forbidden|not authorized'; then
+    echo -e "${RED}✗ Permission denied: ${action} requires org-admin on this organisation.${NC}" >&2
+    echo "  Manual fallback — ask an org owner to:" >&2
+    echo "    1. Visit https://github.com/organizations/<org>/settings/issue-types" >&2
+    echo "    2. ${action}" >&2
+    echo "    3. Re-run this command (the create step will become a no-op)." >&2
+  else
+    echo -e "${RED}✗ ${action} failed:${NC}" >&2
+    echo "  $detail" >&2
+  fi
+}
+
+cmd_ensure_issue_types() {
+  local DRY_RUN=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run) DRY_RUN=1; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  local owner
+  owner=$(_get_issue_types_owner)
+
+  local desired_json
+  desired_json=$(jq -c '.workflow.issueTypes // []' .saasfoundry.json 2>/dev/null)
+  if [ "$desired_json" = "[]" ] || [ -z "$desired_json" ]; then
+    echo -e "${YELLOW}No workflow.issueTypes declared in .saasfoundry.json — nothing to ensure.${NC}"
+    return 0
+  fi
+
+  local existing_json
+  existing_json=$(_get_org_issue_types "$owner")
+
+  echo -e "${BLUE}Ensuring issue types on org '${owner}'...${NC}"
+
+  local owner_id=""
+  local missing
+  missing=$(jq -c --argjson existing "$existing_json" '
+    [.[] | . as $d
+      | select(($existing | map(.name | ascii_downcase) | index(($d.name | ascii_downcase))) | not)]
+  ' <<<"$desired_json")
+
+  local count
+  count=$(echo "$missing" | jq 'length')
+  if [ "$count" = "0" ]; then
+    echo -e "${GREEN}✓ All declared issue types already exist on '${owner}'.${NC}"
+    return 0
+  fi
+
+  echo "  → ${count} missing type(s) to create"
+
+  local i name desc color
+  for ((i=0; i<count; i++)); do
+    name=$(echo "$missing" | jq -r ".[$i].name")
+    desc=$(echo "$missing" | jq -r ".[$i].description // \"\"")
+    color=$(echo "$missing" | jq -r ".[$i].color // \"GRAY\"")
+
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "    [dry-run] would create: ${name} (${color})"
+      continue
+    fi
+
+    if [ -z "$owner_id" ]; then
+      owner_id=$(_get_org_node_id "$owner")
+      if [ -z "$owner_id" ]; then
+        echo -e "${RED}Error: Could not resolve org node id for '${owner}'${NC}" >&2
+        exit 1
+      fi
+    fi
+
+    local resp
+    resp=$(gh api graphql \
+      -f query='mutation($oid:ID!,$n:String!,$d:String,$c:IssueTypeColor){
+        createIssueType(input:{ownerId:$oid,isEnabled:true,name:$n,description:$d,color:$c}){
+          issueType{id name color}
+        }
+      }' \
+      -F oid="$owner_id" -F n="$name" -F d="$desc" -F c="$color" 2>&1) || true
+
+    if echo "$resp" | jq -e '.data.createIssueType.issueType.id' > /dev/null 2>&1; then
+      echo -e "    ${GREEN}✓ created${NC} ${name} (${color})"
+    else
+      _handle_issue_type_error "Create issue type '${name}'" "$resp"
+      exit 1
+    fi
+  done
+
+  _invalidate_types_cache
+  echo -e "${GREEN}✓ ensure-issue-types complete${NC}"
+}
+
+cmd_assign_type() {
+  if [ "$#" -lt 2 ]; then
+    echo -e "${RED}Error: Missing arguments${NC}" >&2
+    echo "Usage: $0 assign-type <issue-number> <type-name>" >&2
+    exit 1
+  fi
+  local issue=$1 type_name=$2
+
+  local owner
+  owner=$(_get_issue_types_owner)
+
+  local type_id
+  type_id=$(_find_type_id "$owner" "$type_name")
+  if [ -z "$type_id" ]; then
+    echo -e "${RED}Error: Issue type '${type_name}' not found on org '${owner}'${NC}" >&2
+    echo "  Run: $0 ensure-issue-types  (or create it manually in the org settings)" >&2
+    exit 1
+  fi
+
+  local issue_id
+  issue_id=$(gh issue view "$issue" --json id --jq '.id' 2>/dev/null)
+  if [ -z "$issue_id" ]; then
+    echo -e "${RED}Error: Could not find issue #${issue}${NC}" >&2
+    exit 1
+  fi
+
+  local resp
+  resp=$(gh api graphql \
+    -f query='mutation($iid:ID!,$tid:ID!){
+      updateIssueIssueType(input:{issueId:$iid,issueTypeId:$tid}){
+        issue{number issueType{name}}
+      }
+    }' \
+    -F iid="$issue_id" -F tid="$type_id" 2>&1) || true
+
+  if echo "$resp" | jq -e '.data.updateIssueIssueType.issue.number' > /dev/null 2>&1; then
+    local applied
+    applied=$(echo "$resp" | jq -r '.data.updateIssueIssueType.issue.issueType.name // "?"')
+    echo -e "${GREEN}✓ Issue #${issue} → type '${applied}'${NC}"
+  else
+    _handle_issue_type_error "Assign type '${type_name}' to #${issue}" "$resp"
+    exit 1
+  fi
+}
+
+cmd_delete_issue_type() {
+  if [ "$#" -lt 1 ]; then
+    echo -e "${RED}Error: Missing arguments${NC}" >&2
+    echo "Usage: $0 delete-issue-type <type-name>" >&2
+    exit 1
+  fi
+  local type_name=$1
+
+  local owner
+  owner=$(_get_issue_types_owner)
+
+  local type_id
+  type_id=$(_find_type_id "$owner" "$type_name")
+  if [ -z "$type_id" ]; then
+    echo -e "${YELLOW}Type '${type_name}' not present on org '${owner}' — nothing to delete.${NC}"
+    return 0
+  fi
+
+  local resp
+  resp=$(gh api graphql \
+    -f query='mutation($tid:ID!){deleteIssueType(input:{issueTypeId:$tid}){clientMutationId}}' \
+    -F tid="$type_id" 2>&1) || true
+
+  if echo "$resp" | jq -e '.data.deleteIssueType' > /dev/null 2>&1; then
+    _invalidate_types_cache
+    echo -e "${GREEN}✓ Deleted issue type '${type_name}' from '${owner}'${NC}"
+  else
+    _handle_issue_type_error "Delete issue type '${type_name}'" "$resp"
+    exit 1
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
 # Router
 # ───────────────────────────────────────────────────────────────────────────
 
 case "$COMMAND" in
-  create-subtask)  cmd_create_subtask "$@" ;;
-  update-status)   cmd_update_status "$@" ;;
-  status)          cmd_status "$@" ;;
-  set-complexity)  cmd_set_complexity "$@" ;;
-  get-complexity)  cmd_get_complexity "$@" ;;
-  get-labels)      cmd_get_labels "$@" ;;
-  get-ticket)      cmd_get_ticket "$@" ;;
-  create-pr)       cmd_create_pr "$@" ;;
-  list)            cmd_list "$@" ;;
-  cache-clear)     cmd_cache_clear "$@" ;;
+  create-subtask)     cmd_create_subtask "$@" ;;
+  update-status)      cmd_update_status "$@" ;;
+  status)             cmd_status "$@" ;;
+  set-complexity)     cmd_set_complexity "$@" ;;
+  get-complexity)     cmd_get_complexity "$@" ;;
+  get-labels)         cmd_get_labels "$@" ;;
+  get-ticket)         cmd_get_ticket "$@" ;;
+  create-pr)          cmd_create_pr "$@" ;;
+  list)               cmd_list "$@" ;;
+  cache-clear)        cmd_cache_clear "$@" ;;
+  ensure-issue-types) cmd_ensure_issue_types "$@" ;;
+  assign-type)        cmd_assign_type "$@" ;;
+  delete-issue-type)  cmd_delete_issue_type "$@" ;;
   "")
     echo -e "${RED}Error: No command specified${NC}"
     echo ""
@@ -830,11 +1113,14 @@ case "$COMMAND" in
     echo "  create-pr <ticket>                       Open PR for current branch"
     echo "  list [status]                            List project items (optionally filtered)"
     echo "  cache-clear                              Drop the on-disk schema cache"
+    echo "  ensure-issue-types [--dry-run]           Idempotently create missing issue types from .saasfoundry.json"
+    echo "  assign-type <issue> <type>               Assign a native GitHub Issue Type (Epic|Story|Task|Issue)"
+    echo "  delete-issue-type <type>                 Remove an issue type from the org (cleanup)"
     exit 1
     ;;
   *)
     echo -e "${RED}Error: Unknown command '${COMMAND}'${NC}"
-    echo "Available: create-subtask, status, update-status, set-complexity, get-complexity, get-labels, get-ticket, create-pr, list, cache-clear"
+    echo "Available: create-subtask, status, update-status, set-complexity, get-complexity, get-labels, get-ticket, create-pr, list, cache-clear, ensure-issue-types, assign-type, delete-issue-type"
     exit 1
     ;;
 esac

--- a/.saasfoundry.json
+++ b/.saasfoundry.json
@@ -48,6 +48,28 @@
         "name": "Done",
         "color": "GREEN"
       }
+    ],
+    "issueTypes": [
+      {
+        "name": "Epic",
+        "description": "Grouper for related Stories/Tasks (no PR, no branch)",
+        "color": "PURPLE"
+      },
+      {
+        "name": "Story",
+        "description": "Delivers user-observable value",
+        "color": "BLUE"
+      },
+      {
+        "name": "Task",
+        "description": "Delivers a technical action (refactor, infra, tooling)",
+        "color": "GRAY"
+      },
+      {
+        "name": "Issue",
+        "description": "Defect or unexpected behavior to investigate and fix",
+        "color": "RED"
+      }
     ]
   },
   "tools": {

--- a/scaffolds/docs/manifest-schema.md
+++ b/scaffolds/docs/manifest-schema.md
@@ -24,21 +24,22 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
 
 ## Fields read by each skill
 
-| Skill                     | Field                           | Purpose                                                        |
-| ------------------------- | ------------------------------- | -------------------------------------------------------------- |
-| `sf-workflow`             | `workflow.tool`                 | Routes CLI calls to the right tool adapter                     |
-| `sf-workflow`             | `workflow.workingBranch`        | Default branch for `git checkout -b feature/...`               |
-| `sf-workflow`             | `workflow.prTargetBranch`       | Default PR target                                              |
-| `sf-workflow`             | `workflow.branchNaming.feature` | Pattern for feature branches                                   |
-| `sf-workflow`             | `workflow.commitFormat.pattern` | Enforced by commitlint hook                                    |
-| `sf-tool-github-projects` | `workflow.projectUrl`           | GitHub Projects V2 URL (org or user)                           |
-| `sf-tool-github-projects` | `workflow.workingBranch`        | Used by `create-pr` to target the right base                   |
-| `sf-tool-github-projects` | `workflow.statuses`             | Status options declared on the board                           |
-| `sf-tool-github-projects` | `tools.srs.backend`             | Enables SRS gating on `create-subtask` (Rule 8)                |
-| `sf-srs`                  | `tools.srs.backend`             | Resolves which `SrsAdapter` to instantiate                     |
-| `sf-srs`                  | `tools.srs.rootPage.id`         | Default root container for drafters / eval                     |
-| `sf-srs`                  | `tools.srs.enabled`             | Gates the conversational eval hook                             |
-| `sf-srs`                  | `tools.srs.scan.exclude`        | Extra exclusion patterns on top of `.gitignore` + `.srsignore` |
+| Skill                     | Field                           | Purpose                                                            |
+| ------------------------- | ------------------------------- | ------------------------------------------------------------------ |
+| `sf-workflow`             | `workflow.tool`                 | Routes CLI calls to the right tool adapter                         |
+| `sf-workflow`             | `workflow.workingBranch`        | Default branch for `git checkout -b feature/...`                   |
+| `sf-workflow`             | `workflow.prTargetBranch`       | Default PR target                                                  |
+| `sf-workflow`             | `workflow.branchNaming.feature` | Pattern for feature branches                                       |
+| `sf-workflow`             | `workflow.commitFormat.pattern` | Enforced by commitlint hook                                        |
+| `sf-tool-github-projects` | `workflow.projectUrl`           | GitHub Projects V2 URL (org or user)                               |
+| `sf-tool-github-projects` | `workflow.workingBranch`        | Used by `create-pr` to target the right base                       |
+| `sf-tool-github-projects` | `workflow.statuses`             | Status options declared on the board                               |
+| `sf-tool-github-projects` | `workflow.issueTypes`           | Native GitHub Issue Type chips (Epic/Story/Task/Issue) — org-level |
+| `sf-tool-github-projects` | `tools.srs.backend`             | Enables SRS gating on `create-subtask` (Rule 8)                    |
+| `sf-srs`                  | `tools.srs.backend`             | Resolves which `SrsAdapter` to instantiate                         |
+| `sf-srs`                  | `tools.srs.rootPage.id`         | Default root container for drafters / eval                         |
+| `sf-srs`                  | `tools.srs.enabled`             | Gates the conversational eval hook                                 |
+| `sf-srs`                  | `tools.srs.scan.exclude`        | Extra exclusion patterns on top of `.gitignore` + `.srsignore`     |
 
 ## Canonical shape
 
@@ -72,6 +73,12 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
       { "name": "Human testing", "color": "ORANGE" },
       { "name": "In review", "color": "PINK" },
       { "name": "Done", "color": "GREEN" }
+    ],
+    "issueTypes": [
+      { "name": "Epic", "description": "Grouper for related Stories/Tasks (no PR, no branch)", "color": "PURPLE" },
+      { "name": "Story", "description": "Delivers user-observable value", "color": "BLUE" },
+      { "name": "Task", "description": "Delivers a technical action", "color": "GRAY" },
+      { "name": "Issue", "description": "Defect or unexpected behavior", "color": "RED" }
     ]
   },
   "tools": {

--- a/scaffolds/skills-templates/tools/github-projects/SKILL.md
+++ b/scaffolds/skills-templates/tools/github-projects/SKILL.md
@@ -8,14 +8,15 @@ github project, create subtask, update ticket status, github issue, project boar
 
 ## Data model
 
-Two orthogonal axes on every ticket:
+Three orthogonal axes on every ticket:
 
-| Axis           | Where it lives                                         | What it controls                                           |
-| -------------- | ------------------------------------------------------ | ---------------------------------------------------------- |
-| **Status**     | Projects V2 board (Single select field "Status")       | Workflow phase (Backlog → … → Done)                        |
-| **Complexity** | GitHub label (`complexity: bug\|low\|medium\|complex`) | Rigor level applied in each phase (agents, tests, reviews) |
+| Axis           | Where it lives                                             | What it controls                                                           |
+| -------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Status**     | Projects V2 board (Single select field "Status")           | Workflow phase (Backlog → … → Done)                                        |
+| **Complexity** | GitHub label (`complexity: bug\|low\|medium\|complex`)     | Rigor level applied in each phase (agents, tests, reviews)                 |
+| **Type**       | GitHub Issue Type (org-level chip — Epic/Story/Task/Issue) | Ticket nature in the hierarchy (replaces `[EPIC]`/`[STORY]` title markers) |
 
-Never encode status in a label. Never encode complexity on the board. Keep them independent.
+Never encode status in a label. Never encode complexity on the board. Type is org-scoped — a single set of types serves every repo in the org.
 
 ## Configuration
 
@@ -38,6 +39,9 @@ All via `.claude/skills/sf-tool-github-projects/github-projects-cli.sh <cmd> [ar
 | `get-ticket <ticket>`                    | Print title + body (used by `detect-complexity.sh`)                                               |
 | `create-pr <ticket>`                     | Push branch + open PR against `workingBranch`                                                     |
 | `list [status]`                          | List project items, optionally filtered by status                                                 |
+| `ensure-issue-types [--dry-run]`         | Idempotently create org-level issue types from `workflow.issueTypes` in `.saasfoundry.json`       |
+| `assign-type <issue> <type>`             | Attach a native GitHub Issue Type chip (Epic/Story/Task/Issue) to the issue                       |
+| `delete-issue-type <type>`               | Remove an issue type from the org (cleanup of legacy types like Bug/Feature)                      |
 
 Status names are case-insensitive — the CLI matches against the options defined on the board.
 
@@ -118,9 +122,36 @@ $CLI update-status 42 "In review"
 $CLI update-status 42 "Done"
 ```
 
+## Issue Types (org-level chips)
+
+Native GitHub Issue Types replace the legacy textual title markers (`[EPIC]`, `[STORY]`, `[Parent #N]`). Types live at the **organisation** level — one canonical set is shared across every repo in the
+org. The CLI keeps the org in sync with `.saasfoundry.json` → `workflow.issueTypes[]`:
+
+```bash
+# 1. One-time setup — create missing types declared in the manifest (idempotent)
+$CLI ensure-issue-types
+
+# 2. Assign a type to an existing issue
+$CLI assign-type 42 Story
+
+# 3. Cleanup — remove a legacy type after reassigning its issues
+$CLI delete-issue-type Bug
+```
+
+`create-subtask` automatically calls `assign-type` for the matching native type after creation (best-effort — subtask creation never fails because of a type-assignment hiccup).
+
+**Permissions** — `ensure-issue-types`, `assign-type`, and `delete-issue-type` write to org-level config and require the `admin:org` scope on the `gh` token. Refresh once with:
+
+```bash
+gh auth refresh --hostname github.com --scopes admin:org
+```
+
+Without that scope the CLI still works for read paths and prints an actionable message before exiting (no silent failure).
+
 ## Requirements
 
 - `gh` CLI authenticated (`gh auth status` must show `project` + `repo` scopes)
+- `gh` token has `admin:org` scope **only** if you'll run the Issue Types commands (otherwise read paths are enough)
 - `jq` for JSON parsing
 - Project exists with a single-select "Status" field whose options match `.saasfoundry.json` → `workflow.statuses`
 

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -932,6 +932,9 @@ cmd_ensure_issue_types() {
 
   local owner
   owner=$(_get_issue_types_owner)
+  # `exit 1` inside _get_issue_types_owner only kills the $() subshell — the
+  # parent script keeps running with $owner empty unless we re-check here.
+  [ -z "$owner" ] && exit 1
 
   local desired_json
   desired_json=$(jq -c '.workflow.issueTypes // []' .saasfoundry.json 2>/dev/null)
@@ -989,7 +992,10 @@ cmd_ensure_issue_types() {
       }' \
       -F oid="$owner_id" -F n="$name" -F d="$desc" -F c="$color" 2>&1) || true
 
-    if echo "$resp" | jq -e '.data.createIssueType.issueType.id' > /dev/null 2>&1; then
+    # Treat "data + errors" partial responses as failures — GraphQL allows
+    # both to coexist, and we don't want a half-broken type silently logged
+    # as ✓ created.
+    if echo "$resp" | jq -e '.data.createIssueType.issueType.id and (.errors | not)' > /dev/null 2>&1; then
       echo -e "    ${GREEN}✓ created${NC} ${name} (${color})"
     else
       _handle_issue_type_error "Create issue type '${name}'" "$resp"
@@ -1011,6 +1017,7 @@ cmd_assign_type() {
 
   local owner
   owner=$(_get_issue_types_owner)
+  [ -z "$owner" ] && exit 1
 
   local type_id
   type_id=$(_find_type_id "$owner" "$type_name")
@@ -1036,7 +1043,7 @@ cmd_assign_type() {
     }' \
     -F iid="$issue_id" -F tid="$type_id" 2>&1) || true
 
-  if echo "$resp" | jq -e '.data.updateIssueIssueType.issue.number' > /dev/null 2>&1; then
+  if echo "$resp" | jq -e '.data.updateIssueIssueType.issue.number and (.errors | not)' > /dev/null 2>&1; then
     local applied
     applied=$(echo "$resp" | jq -r '.data.updateIssueIssueType.issue.issueType.name // "?"')
     echo -e "${GREEN}✓ Issue #${issue} → type '${applied}'${NC}"
@@ -1056,6 +1063,7 @@ cmd_delete_issue_type() {
 
   local owner
   owner=$(_get_issue_types_owner)
+  [ -z "$owner" ] && exit 1
 
   local type_id
   type_id=$(_find_type_id "$owner" "$type_name")
@@ -1069,7 +1077,7 @@ cmd_delete_issue_type() {
     -f query='mutation($tid:ID!){deleteIssueType(input:{issueTypeId:$tid}){clientMutationId}}' \
     -F tid="$type_id" 2>&1) || true
 
-  if echo "$resp" | jq -e '.data.deleteIssueType' > /dev/null 2>&1; then
+  if echo "$resp" | jq -e '.data.deleteIssueType and (.errors | not)' > /dev/null 2>&1; then
     _invalidate_types_cache
     echo -e "${GREEN}✓ Deleted issue type '${type_name}' from '${owner}'${NC}"
   else

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -454,7 +454,11 @@ cmd_create_subtask() {
   PARENT_NUMBER="${POSITIONAL[0]}"
   TITLE="${POSITIONAL[1]}"
   BODY="${POSITIONAL[2]:-}"
-  FULL_TITLE="[Parent #${PARENT_NUMBER}] ${TITLE}"
+  # Native sub-issue linking (addSubIssue mutation below) makes the parent
+  # relationship visible in the GitHub UI on its own — no need for a textual
+  # `[Parent #N]` title prefix anymore. Native Issue Type chips (Epic/Story/
+  # Task/Issue) replace the old `[EPIC]`/`[STORY]` markers via assign-type.
+  FULL_TITLE="${TITLE}"
 
   # If no body was supplied, render a type-specific skeleton so the created
   # issue lands with the right section shape instead of an empty body.
@@ -522,6 +526,26 @@ cmd_create_subtask() {
     echo -e "${RED}Error: Failed to link subtask${NC}"
     echo "$RESULT"
     exit 1
+  fi
+
+  # Auto-assign the native GitHub Issue Type matching --type. Best-effort: a
+  # missing type (org doesn't have it yet) or a missing org-admin scope must
+  # not break subtask creation — the chip is cosmetic, the parent link is
+  # already in place. Skip silently when workflow.issueTypes isn't declared.
+  local declared_types
+  declared_types=$(jq -r '(.workflow.issueTypes // []) | length' .saasfoundry.json 2>/dev/null)
+  if [ "${declared_types:-0}" != "0" ]; then
+    local target_type
+    case "$TICKET_TYPE" in
+      epic)   target_type="Epic" ;;
+      story)  target_type="Story" ;;
+      task)   target_type="Task" ;;
+      issue)  target_type="Issue" ;;
+    esac
+    if [ -n "$target_type" ]; then
+      "$0" assign-type "$CHILD_NUMBER" "$target_type" 2>/dev/null || \
+        echo -e "${YELLOW}  (issue type '${target_type}' not assigned — run 'ensure-issue-types' or assign manually)${NC}"
+    fi
   fi
 }
 
@@ -799,20 +823,279 @@ cmd_cache_clear() {
 }
 
 # ───────────────────────────────────────────────────────────────────────────
+# Issue Types — native GitHub typing (replaces textual [EPIC]/[STORY] markers)
+#
+# GitHub Issue Types (GA 2024) live at the **org level** — types are created
+# once on the organisation and then assigned to issues across any of its repos.
+# Three commands cover the full lifecycle:
+#
+#   ensure-issue-types     idempotent: creates each name in workflow.issueTypes
+#                          missing from the org (reads .saasfoundry.json)
+#   assign-type            attach a type to a single issue
+#   delete-issue-type      remove a type from the org (cleanup of legacy types)
+#
+# All operate via raw GraphQL (`gh api graphql`) — `gh` has no first-class
+# Issue Types subcommand yet. Mutations: createIssueType / deleteIssueType /
+# updateIssueIssueType. The `_TYPES_CACHE` map is per-process to keep the
+# bootstrap script (which assigns hundreds of issues) reasonably snappy.
+# ───────────────────────────────────────────────────────────────────────────
+
+# Resolve the org login from .saasfoundry.json's projectUrl. Issue Types are
+# always org-scoped — user-projects are unsupported (GitHub limitation).
+_get_issue_types_owner() {
+  load_config
+  if [ -z "$PROJECT_OWNER" ]; then
+    echo -e "${RED}Error: workflow.projectUrl is missing or malformed in .saasfoundry.json${NC}" >&2
+    exit 1
+  fi
+  if ! echo "$PROJECT_URL" | grep -q '/orgs/'; then
+    echo -e "${RED}Error: Issue Types require an organisation project (URL must contain /orgs/<owner>/projects/<n>)${NC}" >&2
+    echo "  Current projectUrl: ${PROJECT_URL}" >&2
+    exit 1
+  fi
+  echo "$PROJECT_OWNER"
+}
+
+# Fetch the org node ID — needed as ownerId for createIssueType.
+_get_org_node_id() {
+  local owner=$1
+  gh api graphql -f query='query($o:String!){organization(login:$o){id}}' -F o="$owner" 2>/dev/null \
+    | jq -r '.data.organization.id // empty'
+}
+
+# Fetch the org's existing issue types as JSON array of {id,name,color,description}.
+# Cached per-process — bootstrap workflows can call this dozens of times.
+_TYPES_CACHE_OWNER=""
+_TYPES_CACHE_JSON=""
+_get_org_issue_types() {
+  local owner=$1
+  if [ "$_TYPES_CACHE_OWNER" = "$owner" ] && [ -n "$_TYPES_CACHE_JSON" ]; then
+    echo "$_TYPES_CACHE_JSON"
+    return 0
+  fi
+  local resp
+  resp=$(gh api graphql \
+    -f query='query($o:String!){organization(login:$o){issueTypes(first:50){nodes{id name description color isEnabled}}}}' \
+    -F o="$owner" 2>/dev/null)
+  local types
+  types=$(echo "$resp" | jq -c '.data.organization.issueTypes.nodes // []')
+  _TYPES_CACHE_OWNER="$owner"
+  _TYPES_CACHE_JSON="$types"
+  echo "$types"
+}
+
+# Reset the per-process cache (called after create/delete mutations).
+_invalidate_types_cache() {
+  _TYPES_CACHE_OWNER=""
+  _TYPES_CACHE_JSON=""
+}
+
+# Look up a type id by case-insensitive name. Echoes empty if not found.
+_find_type_id() {
+  local owner=$1 name=$2
+  _get_org_issue_types "$owner" | jq -r --arg s "$name" '
+    .[] | select((.name | ascii_downcase) == ($s | ascii_downcase)) | .id
+  ' | head -n1
+}
+
+# Translate "permission denied" GraphQL responses into a single, actionable line.
+# Issue Type mutations require org-admin scope — users without that role need
+# to ask their org owner (or fall back to manual creation in the org settings UI).
+_handle_issue_type_error() {
+  local action=$1 detail=$2
+  if echo "$detail" | grep -qiE 'INSUFFICIENT_SCOPES|admin:org'; then
+    echo -e "${RED}✗ ${action}: gh token is missing the 'admin:org' scope.${NC}" >&2
+    echo "  Issue Type mutations are org-admin operations and need this scope." >&2
+    echo "  Fix once with:" >&2
+    echo "    gh auth refresh --hostname github.com --scopes admin:org" >&2
+    echo "  …then re-run this command. Alternative: ask an org owner to run it." >&2
+  elif echo "$detail" | grep -qiE 'permission|forbidden|not authorized'; then
+    echo -e "${RED}✗ Permission denied: ${action} requires org-admin on this organisation.${NC}" >&2
+    echo "  Manual fallback — ask an org owner to:" >&2
+    echo "    1. Visit https://github.com/organizations/<org>/settings/issue-types" >&2
+    echo "    2. ${action}" >&2
+    echo "    3. Re-run this command (the create step will become a no-op)." >&2
+  else
+    echo -e "${RED}✗ ${action} failed:${NC}" >&2
+    echo "  $detail" >&2
+  fi
+}
+
+cmd_ensure_issue_types() {
+  local DRY_RUN=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run) DRY_RUN=1; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  local owner
+  owner=$(_get_issue_types_owner)
+
+  local desired_json
+  desired_json=$(jq -c '.workflow.issueTypes // []' .saasfoundry.json 2>/dev/null)
+  if [ "$desired_json" = "[]" ] || [ -z "$desired_json" ]; then
+    echo -e "${YELLOW}No workflow.issueTypes declared in .saasfoundry.json — nothing to ensure.${NC}"
+    return 0
+  fi
+
+  local existing_json
+  existing_json=$(_get_org_issue_types "$owner")
+
+  echo -e "${BLUE}Ensuring issue types on org '${owner}'...${NC}"
+
+  local owner_id=""
+  local missing
+  missing=$(jq -c --argjson existing "$existing_json" '
+    [.[] | . as $d
+      | select(($existing | map(.name | ascii_downcase) | index(($d.name | ascii_downcase))) | not)]
+  ' <<<"$desired_json")
+
+  local count
+  count=$(echo "$missing" | jq 'length')
+  if [ "$count" = "0" ]; then
+    echo -e "${GREEN}✓ All declared issue types already exist on '${owner}'.${NC}"
+    return 0
+  fi
+
+  echo "  → ${count} missing type(s) to create"
+
+  local i name desc color
+  for ((i=0; i<count; i++)); do
+    name=$(echo "$missing" | jq -r ".[$i].name")
+    desc=$(echo "$missing" | jq -r ".[$i].description // \"\"")
+    color=$(echo "$missing" | jq -r ".[$i].color // \"GRAY\"")
+
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "    [dry-run] would create: ${name} (${color})"
+      continue
+    fi
+
+    if [ -z "$owner_id" ]; then
+      owner_id=$(_get_org_node_id "$owner")
+      if [ -z "$owner_id" ]; then
+        echo -e "${RED}Error: Could not resolve org node id for '${owner}'${NC}" >&2
+        exit 1
+      fi
+    fi
+
+    local resp
+    resp=$(gh api graphql \
+      -f query='mutation($oid:ID!,$n:String!,$d:String,$c:IssueTypeColor){
+        createIssueType(input:{ownerId:$oid,isEnabled:true,name:$n,description:$d,color:$c}){
+          issueType{id name color}
+        }
+      }' \
+      -F oid="$owner_id" -F n="$name" -F d="$desc" -F c="$color" 2>&1) || true
+
+    if echo "$resp" | jq -e '.data.createIssueType.issueType.id' > /dev/null 2>&1; then
+      echo -e "    ${GREEN}✓ created${NC} ${name} (${color})"
+    else
+      _handle_issue_type_error "Create issue type '${name}'" "$resp"
+      exit 1
+    fi
+  done
+
+  _invalidate_types_cache
+  echo -e "${GREEN}✓ ensure-issue-types complete${NC}"
+}
+
+cmd_assign_type() {
+  if [ "$#" -lt 2 ]; then
+    echo -e "${RED}Error: Missing arguments${NC}" >&2
+    echo "Usage: $0 assign-type <issue-number> <type-name>" >&2
+    exit 1
+  fi
+  local issue=$1 type_name=$2
+
+  local owner
+  owner=$(_get_issue_types_owner)
+
+  local type_id
+  type_id=$(_find_type_id "$owner" "$type_name")
+  if [ -z "$type_id" ]; then
+    echo -e "${RED}Error: Issue type '${type_name}' not found on org '${owner}'${NC}" >&2
+    echo "  Run: $0 ensure-issue-types  (or create it manually in the org settings)" >&2
+    exit 1
+  fi
+
+  local issue_id
+  issue_id=$(gh issue view "$issue" --json id --jq '.id' 2>/dev/null)
+  if [ -z "$issue_id" ]; then
+    echo -e "${RED}Error: Could not find issue #${issue}${NC}" >&2
+    exit 1
+  fi
+
+  local resp
+  resp=$(gh api graphql \
+    -f query='mutation($iid:ID!,$tid:ID!){
+      updateIssueIssueType(input:{issueId:$iid,issueTypeId:$tid}){
+        issue{number issueType{name}}
+      }
+    }' \
+    -F iid="$issue_id" -F tid="$type_id" 2>&1) || true
+
+  if echo "$resp" | jq -e '.data.updateIssueIssueType.issue.number' > /dev/null 2>&1; then
+    local applied
+    applied=$(echo "$resp" | jq -r '.data.updateIssueIssueType.issue.issueType.name // "?"')
+    echo -e "${GREEN}✓ Issue #${issue} → type '${applied}'${NC}"
+  else
+    _handle_issue_type_error "Assign type '${type_name}' to #${issue}" "$resp"
+    exit 1
+  fi
+}
+
+cmd_delete_issue_type() {
+  if [ "$#" -lt 1 ]; then
+    echo -e "${RED}Error: Missing arguments${NC}" >&2
+    echo "Usage: $0 delete-issue-type <type-name>" >&2
+    exit 1
+  fi
+  local type_name=$1
+
+  local owner
+  owner=$(_get_issue_types_owner)
+
+  local type_id
+  type_id=$(_find_type_id "$owner" "$type_name")
+  if [ -z "$type_id" ]; then
+    echo -e "${YELLOW}Type '${type_name}' not present on org '${owner}' — nothing to delete.${NC}"
+    return 0
+  fi
+
+  local resp
+  resp=$(gh api graphql \
+    -f query='mutation($tid:ID!){deleteIssueType(input:{issueTypeId:$tid}){clientMutationId}}' \
+    -F tid="$type_id" 2>&1) || true
+
+  if echo "$resp" | jq -e '.data.deleteIssueType' > /dev/null 2>&1; then
+    _invalidate_types_cache
+    echo -e "${GREEN}✓ Deleted issue type '${type_name}' from '${owner}'${NC}"
+  else
+    _handle_issue_type_error "Delete issue type '${type_name}'" "$resp"
+    exit 1
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
 # Router
 # ───────────────────────────────────────────────────────────────────────────
 
 case "$COMMAND" in
-  create-subtask)  cmd_create_subtask "$@" ;;
-  update-status)   cmd_update_status "$@" ;;
-  status)          cmd_status "$@" ;;
-  set-complexity)  cmd_set_complexity "$@" ;;
-  get-complexity)  cmd_get_complexity "$@" ;;
-  get-labels)      cmd_get_labels "$@" ;;
-  get-ticket)      cmd_get_ticket "$@" ;;
-  create-pr)       cmd_create_pr "$@" ;;
-  list)            cmd_list "$@" ;;
-  cache-clear)     cmd_cache_clear "$@" ;;
+  create-subtask)     cmd_create_subtask "$@" ;;
+  update-status)      cmd_update_status "$@" ;;
+  status)             cmd_status "$@" ;;
+  set-complexity)     cmd_set_complexity "$@" ;;
+  get-complexity)     cmd_get_complexity "$@" ;;
+  get-labels)         cmd_get_labels "$@" ;;
+  get-ticket)         cmd_get_ticket "$@" ;;
+  create-pr)          cmd_create_pr "$@" ;;
+  list)               cmd_list "$@" ;;
+  cache-clear)        cmd_cache_clear "$@" ;;
+  ensure-issue-types) cmd_ensure_issue_types "$@" ;;
+  assign-type)        cmd_assign_type "$@" ;;
+  delete-issue-type)  cmd_delete_issue_type "$@" ;;
   "")
     echo -e "${RED}Error: No command specified${NC}"
     echo ""
@@ -830,11 +1113,14 @@ case "$COMMAND" in
     echo "  create-pr <ticket>                       Open PR for current branch"
     echo "  list [status]                            List project items (optionally filtered)"
     echo "  cache-clear                              Drop the on-disk schema cache"
+    echo "  ensure-issue-types [--dry-run]           Idempotently create missing issue types from .saasfoundry.json"
+    echo "  assign-type <issue> <type>               Assign a native GitHub Issue Type (Epic|Story|Task|Issue)"
+    echo "  delete-issue-type <type>                 Remove an issue type from the org (cleanup)"
     exit 1
     ;;
   *)
     echo -e "${RED}Error: Unknown command '${COMMAND}'${NC}"
-    echo "Available: create-subtask, status, update-status, set-complexity, get-complexity, get-labels, get-ticket, create-pr, list, cache-clear"
+    echo "Available: create-subtask, status, update-status, set-complexity, get-complexity, get-labels, get-ticket, create-pr, list, cache-clear, ensure-issue-types, assign-type, delete-issue-type"
     exit 1
     ;;
 esac

--- a/schemas/saasfoundry-manifest.schema.json
+++ b/schemas/saasfoundry-manifest.schema.json
@@ -99,11 +99,28 @@
           "type": "array",
           "items": { "$ref": "#/definitions/workflowStatus" }
         },
+        "issueTypes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/workflowIssueType" }
+        },
         "validated": { "type": "boolean" },
         "lastValidated": { "type": "string", "format": "date-time" }
       }
     },
     "workflowStatus": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "color": {
+          "type": "string",
+          "enum": ["GRAY", "YELLOW", "BLUE", "PURPLE", "ORANGE", "PINK", "GREEN", "RED"]
+        }
+      }
+    },
+    "workflowIssueType": {
       "type": "object",
       "required": ["name"],
       "additionalProperties": false,

--- a/src/__tests__/unit/skill/github-projects-cli.issue-types.spec.ts
+++ b/src/__tests__/unit/skill/github-projects-cli.issue-types.spec.ts
@@ -20,7 +20,7 @@ const BASH = '/bin/bash'
 interface SandboxOpts {
   existingTypes?: Array<{ id: string; name: string; color?: string; description?: string }>
   projectUrl?: string
-  failMode?: 'scopes' | 'permission' | 'unknown'
+  failMode?: 'scopes' | 'permission' | 'unknown' | 'partial-create' | 'partial-assign'
   manifestIssueTypes?: Array<{ name: string; color?: string; description?: string }>
 }
 
@@ -64,12 +64,20 @@ async function buildSandbox(opts: SandboxOpts = {}): Promise<Sandbox> {
   )
 
   if (opts.failMode) {
+    // The "partial-*" payloads pin the regression for the GraphQL "data + errors"
+    // case: a malformed mutation can return BOTH a `data.X.Y` field AND a top-level
+    // `errors[]`. Without a `.errors | not` guard the CLI would print "✓ created"
+    // while the type wasn't actually persisted. See _handle_issue_type_error.
     const payload =
       opts.failMode === 'scopes'
         ? '{"errors":[{"type":"INSUFFICIENT_SCOPES","message":"Resource not accessible by integration; admin:org scope required"}]}'
         : opts.failMode === 'permission'
           ? '{"errors":[{"type":"FORBIDDEN","message":"You are not authorized to perform this action"}]}'
-          : '{"errors":[{"message":"Schema is wonky"}]}'
+          : opts.failMode === 'partial-create'
+            ? '{"data":{"createIssueType":{"issueType":{"id":"IT_X","name":"X","color":"GRAY"}}},"errors":[{"message":"degraded"}]}'
+            : opts.failMode === 'partial-assign'
+              ? '{"data":{"updateIssueIssueType":{"issue":{"number":42,"issueType":{"name":"Story"}}}},"errors":[{"message":"degraded"}]}'
+              : '{"errors":[{"message":"Schema is wonky"}]}'
     await writeFile(failMarker, payload)
   }
 
@@ -252,6 +260,13 @@ describe('sf-tool-github-projects — ensure-issue-types', () => {
     expect(res.stderr).toMatch(/'admin:org' scope/)
     expect(res.stderr).toMatch(/gh auth refresh --hostname github\.com --scopes admin:org/)
   })
+
+  it('rejects "data + errors" partial responses instead of declaring success', async () => {
+    sandbox = await buildSandbox({ existingTypes: [], failMode: 'partial-create' })
+    const res = await runCli(['ensure-issue-types'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stdout).not.toMatch(/✓ created/)
+  })
 })
 
 describe('sf-tool-github-projects — assign-type', () => {
@@ -298,6 +313,16 @@ describe('sf-tool-github-projects — assign-type', () => {
     expect(res.code).toBe(1)
     expect(res.stderr).toMatch(/Missing arguments/)
     expect(res.stderr).toMatch(/Usage:/)
+  })
+
+  it('rejects "data + errors" partial responses on assign instead of declaring success', async () => {
+    sandbox = await buildSandbox({
+      existingTypes: [{ id: 'IT_STORY', name: 'Story' }],
+      failMode: 'partial-assign'
+    })
+    const res = await runCli(['assign-type', '42', 'Story'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stdout).not.toMatch(/Issue #42 → type 'Story'/)
   })
 })
 

--- a/src/__tests__/unit/skill/github-projects-cli.issue-types.spec.ts
+++ b/src/__tests__/unit/skill/github-projects-cli.issue-types.spec.ts
@@ -1,0 +1,333 @@
+import { execFile } from 'node:child_process'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileP = promisify(execFile)
+
+const CLI = path.resolve(__dirname, '../../../../.claude/skills/sf-tool-github-projects/github-projects-cli.sh')
+const BASH = '/bin/bash'
+
+// Regression coverage for #328: native GitHub Issue Types replace the legacy
+// textual `[EPIC]`/`[STORY]` markers. The org-level mutations
+// (createIssueType / updateIssueIssueType / deleteIssueType) are wrapped by
+// three CLI commands; these tests pin the happy paths AND the error handling
+// for the most commonly-hit failure (token missing the `admin:org` scope), so
+// future refactors can't regress the actionable remediation message.
+
+interface SandboxOpts {
+  existingTypes?: Array<{ id: string; name: string; color?: string; description?: string }>
+  projectUrl?: string
+  failMode?: 'scopes' | 'permission' | 'unknown'
+  manifestIssueTypes?: Array<{ name: string; color?: string; description?: string }>
+}
+
+interface Sandbox {
+  dir: string
+  env: NodeJS.ProcessEnv
+  tracePath: string
+  cleanup: () => Promise<void>
+}
+
+const DEFAULT_MANIFEST_TYPES = [
+  { name: 'Epic', color: 'PURPLE', description: 'Grouper' },
+  { name: 'Story', color: 'BLUE', description: 'User value' },
+  { name: 'Task', color: 'GRAY' },
+  { name: 'Issue', color: 'RED' }
+]
+
+async function buildSandbox(opts: SandboxOpts = {}): Promise<Sandbox> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sf-gh-issue-types-'))
+  const binDir = path.join(dir, 'bin')
+  await mkdir(binDir, { recursive: true })
+  const tracePath = path.join(dir, 'gh-trace.txt')
+  const fixtureTypes = path.join(dir, 'existing-types.json')
+  const failMarker = opts.failMode ? path.join(dir, `fail.${opts.failMode}`) : ''
+
+  const projectUrl = opts.projectUrl ?? 'https://github.com/orgs/FakeOrg/projects/42'
+  const issueTypes = opts.manifestIssueTypes ?? DEFAULT_MANIFEST_TYPES
+
+  await writeFile(
+    path.join(dir, '.saasfoundry.json'),
+    JSON.stringify({
+      workflow: { projectUrl, workingBranch: 'develop', issueTypes }
+    })
+  )
+
+  await writeFile(
+    fixtureTypes,
+    JSON.stringify({
+      data: { organization: { issueTypes: { nodes: opts.existingTypes ?? [] } } }
+    })
+  )
+
+  if (opts.failMode) {
+    const payload =
+      opts.failMode === 'scopes'
+        ? '{"errors":[{"type":"INSUFFICIENT_SCOPES","message":"Resource not accessible by integration; admin:org scope required"}]}'
+        : opts.failMode === 'permission'
+          ? '{"errors":[{"type":"FORBIDDEN","message":"You are not authorized to perform this action"}]}'
+          : '{"errors":[{"message":"Schema is wonky"}]}'
+    await writeFile(failMarker, payload)
+  }
+
+  const shim = `#!/bin/bash
+# Test shim — handles gh api graphql + gh issue view for the Issue Types CLI.
+TRACE="${tracePath}"
+TYPES_FIXTURE="${fixtureTypes}"
+FAIL_MARKER="${failMarker}"
+
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+  query=""
+  oid=""; n=""; d=""; c=""; iid=""; tid=""; o=""
+  for arg in "$@"; do
+    case "$arg" in
+      query=*) query=\${arg#query=} ;;
+      oid=*)   oid=\${arg#oid=} ;;
+      n=*)     n=\${arg#n=} ;;
+      d=*)     d=\${arg#d=} ;;
+      c=*)     c=\${arg#c=} ;;
+      iid=*)   iid=\${arg#iid=} ;;
+      tid=*)   tid=\${arg#tid=} ;;
+      o=*)     o=\${arg#o=} ;;
+    esac
+  done
+
+  # Read query for routing.
+  if echo "$query" | grep -q 'issueTypes(first'; then
+    cat "$TYPES_FIXTURE"
+    exit 0
+  fi
+  if echo "$query" | grep -q 'organization(login:'; then
+    echo '{"data":{"organization":{"id":"O_FAKEORG"}}}'
+    exit 0
+  fi
+  if echo "$query" | grep -q 'createIssueType'; then
+    echo "create:$n:$c" >> "$TRACE"
+    if [ -n "$FAIL_MARKER" ] && [ -f "$FAIL_MARKER" ]; then
+      cat "$FAIL_MARKER"
+      exit 1
+    fi
+    printf '{"data":{"createIssueType":{"issueType":{"id":"IT_%s","name":"%s","color":"%s"}}}}\\n' "$n" "$n" "$c"
+    exit 0
+  fi
+  if echo "$query" | grep -q 'updateIssueIssueType'; then
+    echo "assign:$iid:$tid" >> "$TRACE"
+    if [ -n "$FAIL_MARKER" ] && [ -f "$FAIL_MARKER" ]; then
+      cat "$FAIL_MARKER"
+      exit 1
+    fi
+    echo '{"data":{"updateIssueIssueType":{"issue":{"number":42,"issueType":{"name":"Story"}}}}}'
+    exit 0
+  fi
+  if echo "$query" | grep -q 'deleteIssueType'; then
+    echo "delete:$tid" >> "$TRACE"
+    if [ -n "$FAIL_MARKER" ] && [ -f "$FAIL_MARKER" ]; then
+      cat "$FAIL_MARKER"
+      exit 1
+    fi
+    echo '{"data":{"deleteIssueType":{"clientMutationId":null}}}'
+    exit 0
+  fi
+  echo '{}'
+  exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  # Returns bare id because the CLI invokes with --jq '.id'
+  echo "I_ISSUE_42"
+  exit 0
+fi
+
+# Fallback: succeed silently (other commands aren't exercised here).
+echo '{}'
+exit 0
+`
+  const shimPath = path.join(binDir, 'gh')
+  writeFileSync(shimPath, shim)
+  chmodSync(shimPath, 0o755)
+
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    PWD: dir
+  }
+
+  return { dir, env, tracePath, cleanup: () => rm(dir, { recursive: true, force: true }) }
+}
+
+async function runCli(args: string[], sandbox: Sandbox): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await execFileP(BASH, [CLI, ...args], { cwd: sandbox.dir, env: sandbox.env })
+    return { stdout, stderr, code: 0 }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; code?: number }
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: typeof e.code === 'number' ? e.code : 1 }
+  }
+}
+
+function readTrace(p: string): string[] {
+  if (!existsSync(p)) return []
+  return readFileSync(p, 'utf8').split('\n').filter(Boolean)
+}
+
+describe('sf-tool-github-projects — ensure-issue-types', () => {
+  let sandbox: Sandbox
+  afterEach(async () => sandbox?.cleanup())
+
+  it('reports "all already exist" when the org has every declared type', async () => {
+    sandbox = await buildSandbox({
+      existingTypes: [
+        { id: 'IT_E', name: 'Epic' },
+        { id: 'IT_S', name: 'Story' },
+        { id: 'IT_T', name: 'Task' },
+        { id: 'IT_I', name: 'Issue' }
+      ]
+    })
+    const res = await runCli(['ensure-issue-types'], sandbox)
+    expect(res.code).toBe(0)
+    expect(res.stdout).toMatch(/All declared issue types already exist/)
+    expect(readTrace(sandbox.tracePath)).toEqual([])
+  })
+
+  it('creates only the missing types, leaving existing ones untouched', async () => {
+    sandbox = await buildSandbox({
+      existingTypes: [
+        { id: 'IT_E', name: 'Epic' },
+        { id: 'IT_S', name: 'Story' }
+      ]
+    })
+    const res = await runCli(['ensure-issue-types'], sandbox)
+    expect(res.code).toBe(0)
+    const trace = readTrace(sandbox.tracePath)
+    expect(trace).toEqual(['create:Task:GRAY', 'create:Issue:RED'])
+    expect(res.stdout).toMatch(/2 missing type\(s\) to create/)
+    expect(res.stdout).toMatch(/ensure-issue-types complete/)
+  })
+
+  it('matches existing names case-insensitively (no duplicate creation)', async () => {
+    sandbox = await buildSandbox({
+      existingTypes: [
+        { id: 'IT_E', name: 'epic' },
+        { id: 'IT_S', name: 'STORY' },
+        { id: 'IT_T', name: 'Task' },
+        { id: 'IT_I', name: 'issue' }
+      ]
+    })
+    const res = await runCli(['ensure-issue-types'], sandbox)
+    expect(res.code).toBe(0)
+    expect(readTrace(sandbox.tracePath)).toEqual([])
+  })
+
+  it('--dry-run lists missing types without firing any mutation', async () => {
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_E', name: 'Epic' }] })
+    const res = await runCli(['ensure-issue-types', '--dry-run'], sandbox)
+    expect(res.code).toBe(0)
+    expect(res.stdout).toMatch(/\[dry-run\] would create: Story/)
+    expect(res.stdout).toMatch(/\[dry-run\] would create: Task/)
+    expect(res.stdout).toMatch(/\[dry-run\] would create: Issue/)
+    expect(readTrace(sandbox.tracePath)).toEqual([])
+  })
+
+  it('returns success with a clear message when no issueTypes are declared', async () => {
+    sandbox = await buildSandbox({ manifestIssueTypes: [] })
+    const res = await runCli(['ensure-issue-types'], sandbox)
+    expect(res.code).toBe(0)
+    expect(res.stdout).toMatch(/No workflow.issueTypes declared/)
+  })
+
+  it('rejects user-projects URLs (issue types are org-only)', async () => {
+    sandbox = await buildSandbox({ projectUrl: 'https://github.com/users/FakeUser/projects/3' })
+    const res = await runCli(['ensure-issue-types'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stderr).toMatch(/Issue Types require an organisation project/)
+  })
+
+  it('translates INSUFFICIENT_SCOPES errors into actionable admin:org guidance', async () => {
+    sandbox = await buildSandbox({ existingTypes: [], failMode: 'scopes' })
+    const res = await runCli(['ensure-issue-types'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stderr).toMatch(/'admin:org' scope/)
+    expect(res.stderr).toMatch(/gh auth refresh --hostname github\.com --scopes admin:org/)
+  })
+})
+
+describe('sf-tool-github-projects — assign-type', () => {
+  let sandbox: Sandbox
+  afterEach(async () => sandbox?.cleanup())
+
+  it('looks up the type id and calls updateIssueIssueType', async () => {
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_STORY', name: 'Story' }] })
+    const res = await runCli(['assign-type', '42', 'Story'], sandbox)
+    expect(res.code).toBe(0)
+    expect(res.stdout).toMatch(/Issue #42 → type 'Story'/)
+    expect(readTrace(sandbox.tracePath)).toEqual(['assign:I_ISSUE_42:IT_STORY'])
+  })
+
+  it('matches the type name case-insensitively', async () => {
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_STORY', name: 'Story' }] })
+    const res = await runCli(['assign-type', '42', 'story'], sandbox)
+    expect(res.code).toBe(0)
+    expect(readTrace(sandbox.tracePath)).toEqual(['assign:I_ISSUE_42:IT_STORY'])
+  })
+
+  it('exits 1 with a remediation hint when the type is unknown to the org', async () => {
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_E', name: 'Epic' }] })
+    const res = await runCli(['assign-type', '42', 'Saga'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stderr).toMatch(/Issue type 'Saga' not found/)
+    expect(res.stderr).toMatch(/ensure-issue-types/)
+    expect(readTrace(sandbox.tracePath)).toEqual([])
+  })
+
+  it('translates permission errors into a manual-fallback message', async () => {
+    sandbox = await buildSandbox({
+      existingTypes: [{ id: 'IT_STORY', name: 'Story' }],
+      failMode: 'permission'
+    })
+    const res = await runCli(['assign-type', '42', 'Story'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stderr).toMatch(/Permission denied|admin:org/)
+  })
+
+  it('errors on missing arguments', async () => {
+    sandbox = await buildSandbox()
+    const res = await runCli(['assign-type', '42'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stderr).toMatch(/Missing arguments/)
+    expect(res.stderr).toMatch(/Usage:/)
+  })
+})
+
+describe('sf-tool-github-projects — delete-issue-type', () => {
+  let sandbox: Sandbox
+  afterEach(async () => sandbox?.cleanup())
+
+  it('is idempotent when the type is already absent (no mutation)', async () => {
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_S', name: 'Story' }] })
+    const res = await runCli(['delete-issue-type', 'Bug'], sandbox)
+    expect(res.code).toBe(0)
+    expect(res.stdout).toMatch(/Type 'Bug' not present/)
+    expect(readTrace(sandbox.tracePath)).toEqual([])
+  })
+
+  it('calls deleteIssueType with the resolved type id when present', async () => {
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_BUG', name: 'Bug' }] })
+    const res = await runCli(['delete-issue-type', 'Bug'], sandbox)
+    expect(res.code).toBe(0)
+    expect(res.stdout).toMatch(/Deleted issue type 'Bug'/)
+    expect(readTrace(sandbox.tracePath)).toEqual(['delete:IT_BUG'])
+  })
+
+  it('surfaces admin:org guidance when GitHub rejects the mutation', async () => {
+    sandbox = await buildSandbox({
+      existingTypes: [{ id: 'IT_BUG', name: 'Bug' }],
+      failMode: 'scopes'
+    })
+    const res = await runCli(['delete-issue-type', 'Bug'], sandbox)
+    expect(res.code).toBe(1)
+    expect(res.stderr).toMatch(/'admin:org' scope/)
+  })
+})

--- a/src/__tests__/unit/skill/manifest-schema.spec.ts
+++ b/src/__tests__/unit/skill/manifest-schema.spec.ts
@@ -55,6 +55,7 @@ describe('saasfoundry-manifest.schema.json — canonical shapes', () => {
           { name: 'Backlog', color: 'GRAY' },
           { name: 'In progress', color: 'BLUE' }
         ],
+        issueTypes: [{ name: 'Epic', description: 'Grouper', color: 'PURPLE' }, { name: 'Story', color: 'BLUE' }, { name: 'Task' }, { name: 'Issue', color: 'RED' }],
         validated: true,
         lastValidated: '2026-04-25T00:00:00.000Z'
       },
@@ -104,6 +105,14 @@ describe('saasfoundry-manifest.schema.json — rejection cases', () => {
 
   it('rejects an unknown workflow.statuses[].color value', () => {
     expect(validate({ ...baseManifest, workflow: { tool: 'github-projects', statuses: [{ name: 'Done', color: 'NEON' }] } })).toBe(false)
+  })
+
+  it('rejects an unknown workflow.issueTypes[].color value', () => {
+    expect(validate({ ...baseManifest, workflow: { tool: 'github-projects', issueTypes: [{ name: 'Epic', color: 'NEON' }] } })).toBe(false)
+  })
+
+  it('rejects a workflow.issueTypes[] entry missing the required name field', () => {
+    expect(validate({ ...baseManifest, workflow: { tool: 'github-projects', issueTypes: [{ color: 'PURPLE' }] } })).toBe(false)
   })
 
   it('rejects a non-string tools.srs.backend (schema pins const "notion")', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,12 @@ export interface WorkflowStatus {
   color?: GitHubProjectColor
 }
 
+export interface WorkflowIssueType {
+  name: string
+  description?: string
+  color?: GitHubProjectColor
+}
+
 export interface WorkflowConfig {
   tool: 'github-projects' | 'jira' | 'notion' | 'linear' | 'none'
   projectUrl?: string
@@ -148,6 +154,7 @@ export interface WorkflowConfig {
   prTargetBranch?: string
   requireCodeReview?: boolean
   statuses?: WorkflowStatus[]
+  issueTypes?: WorkflowIssueType[]
   branchNaming?: {
     feature?: string
     fix?: string


### PR DESCRIPTION
## Summary

Replaces the legacy textual `[EPIC]`/`[STORY]`/`[Parent #N]` title markers with GitHub's native, org-scoped Issue Types (Epic/Story/Task/Issue):

- 3 new `github-projects-cli.sh` commands: `ensure-issue-types [--dry-run]`, `assign-type <issue> <type>`, `delete-issue-type <type>`
- `create-subtask` drops the `[Parent #N]` prefix (native sub-issue link makes it redundant) and auto-assigns the matching native type after creation (best-effort)
- `workflow.issueTypes[]` plumbed through the JSON schema, `WorkflowConfig` types, manifest doc, and `.saasfoundry.json`
- Adversarial review pass surfaced 2 HIGH findings — both fixed: subshell-exit propagation guard, GraphQL "data + errors" partial-response rejection

Closes #328.

## Test plan

- [x] `npm run test:pre-commit` — **1233 passed**, 2 skipped (added 17 new tests in `github-projects-cli.issue-types.spec.ts` + 2 AJV regression cases for `workflow.issueTypes`)
- [x] `npm run test:pre-push` (Docker top-2 scenarios: multirepo-minimal + monorepo-minimal) — both PASS
- [x] Drift guard (`tool-skill-drift.spec.ts`, 29 cases) — all green; modified shared files re-synced to `scaffolds/`
- [x] Workflow self-test: ticket carries `nature:internal` and successfully transitioned **AI testing → In review** (skipping Human testing) — dogfood validation of #327's nature axis on a real PR
- [ ] Reviewer to confirm CI is green before merge

## Out-of-scope (deferred to post-merge)

- Bootstrap of `DiamondForgeFr` org (create Epic/Story/Issue, reassign existing ~50 issues, delete legacy Bug/Feature) — blocked on `gh auth refresh --hostname github.com --scopes admin:org` (token must carry the `admin:org` scope; mutation requires it)
- Cleanup of `[EPIC]`/`[STORY]`/`[Parent #N]` prefixes from existing issue titles
- Backport to `scaffolds/skills-templates/` for new projects — tracked in #329

## Workflow note

This PR ships from a `nature:internal` ticket — the new dogfood path for refactor / scaffolding work introduced in #327. AI Testing was sufficient; no Human Testing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)