### PR TITLE
feat(#337): rename ticket types to sf-* prefix

### DIFF
--- a/.claude/docs/manifest-schema.md
+++ b/.claude/docs/manifest-schema.md
@@ -24,22 +24,22 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
 
 ## Fields read by each skill
 
-| Skill                     | Field                           | Purpose                                                                                                                                          |
-| ------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sf-workflow`             | `workflow.tool`                 | Routes CLI calls to the right tool adapter                                                                                                       |
-| `sf-workflow`             | `workflow.workingBranch`        | Default branch for `git checkout -b feature/...`                                                                                                 |
-| `sf-workflow`             | `workflow.prTargetBranch`       | Default PR target                                                                                                                                |
-| `sf-workflow`             | `workflow.branchNaming.feature` | Pattern for feature branches                                                                                                                     |
-| `sf-workflow`             | `workflow.commitFormat.pattern` | Enforced by commitlint hook                                                                                                                      |
-| `sf-tool-github-projects` | `workflow.projectUrl`           | GitHub Projects V2 URL (org or user)                                                                                                             |
-| `sf-tool-github-projects` | `workflow.workingBranch`        | Used by `create-pr` to target the right base                                                                                                     |
-| `sf-tool-github-projects` | `workflow.statuses`             | Status options declared on the board                                                                                                             |
-| `sf-tool-github-projects` | `workflow.issueTypes`           | Native GitHub Issue Type chips (Epic/Story/Task/Issues) — org-level. Note: `Issues` is plural because GitHub reserves the singular `Issue` name. |
-| `sf-tool-github-projects` | `tools.srs.backend`             | Enables SRS gating on `create-subtask` (Rule 8)                                                                                                  |
-| `sf-srs`                  | `tools.srs.backend`             | Resolves which `SrsAdapter` to instantiate                                                                                                       |
-| `sf-srs`                  | `tools.srs.rootPage.id`         | Default root container for drafters / eval                                                                                                       |
-| `sf-srs`                  | `tools.srs.enabled`             | Gates the conversational eval hook                                                                                                               |
-| `sf-srs`                  | `tools.srs.scan.exclude`        | Extra exclusion patterns on top of `.gitignore` + `.srsignore`                                                                                   |
+| Skill                     | Field                           | Purpose                                                                                                                                                                                                                                     |
+| ------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sf-workflow`             | `workflow.tool`                 | Routes CLI calls to the right tool adapter                                                                                                                                                                                                  |
+| `sf-workflow`             | `workflow.workingBranch`        | Default branch for `git checkout -b feature/...`                                                                                                                                                                                            |
+| `sf-workflow`             | `workflow.prTargetBranch`       | Default PR target                                                                                                                                                                                                                           |
+| `sf-workflow`             | `workflow.branchNaming.feature` | Pattern for feature branches                                                                                                                                                                                                                |
+| `sf-workflow`             | `workflow.commitFormat.pattern` | Enforced by commitlint hook                                                                                                                                                                                                                 |
+| `sf-tool-github-projects` | `workflow.projectUrl`           | GitHub Projects V2 URL (org or user)                                                                                                                                                                                                        |
+| `sf-tool-github-projects` | `workflow.workingBranch`        | Used by `create-pr` to target the right base                                                                                                                                                                                                |
+| `sf-tool-github-projects` | `workflow.statuses`             | Status options declared on the board                                                                                                                                                                                                        |
+| `sf-tool-github-projects` | `workflow.issueTypes`           | Native GitHub Issue Type chips (sf-epic/sf-story/sf-task/sf-issue) — org-level. The `sf-` prefix avoids collisions with vanilla Epic/Story/Task types defined elsewhere in the org and sidesteps the GitHub-reserved singular `Issue` name. |
+| `sf-tool-github-projects` | `tools.srs.backend`             | Enables SRS gating on `create-subtask` (Rule 8)                                                                                                                                                                                             |
+| `sf-srs`                  | `tools.srs.backend`             | Resolves which `SrsAdapter` to instantiate                                                                                                                                                                                                  |
+| `sf-srs`                  | `tools.srs.rootPage.id`         | Default root container for drafters / eval                                                                                                                                                                                                  |
+| `sf-srs`                  | `tools.srs.enabled`             | Gates the conversational eval hook                                                                                                                                                                                                          |
+| `sf-srs`                  | `tools.srs.scan.exclude`        | Extra exclusion patterns on top of `.gitignore` + `.srsignore`                                                                                                                                                                              |
 
 ## Canonical shape
 
@@ -75,10 +75,10 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
       { "name": "Done", "color": "GREEN" }
     ],
     "issueTypes": [
-      { "name": "Epic", "description": "Grouper for related Stories/Tasks (no PR, no branch)", "color": "PURPLE" },
-      { "name": "Story", "description": "Delivers user-observable value", "color": "BLUE" },
-      { "name": "Task", "description": "Delivers a technical action", "color": "GRAY" },
-      { "name": "Issues", "description": "Defect or unexpected behavior (plural — GitHub reserves the singular 'Issue' name)", "color": "RED" }
+      { "name": "sf-epic", "description": "Grouper for related sf-stories/sf-tasks (no PR, no branch)", "color": "PURPLE" },
+      { "name": "sf-story", "description": "Delivers user-observable value", "color": "BLUE" },
+      { "name": "sf-task", "description": "Delivers a technical action", "color": "GRAY" },
+      { "name": "sf-issue", "description": "Defect or unexpected behavior to investigate and fix", "color": "RED" }
     ]
   },
   "tools": {

--- a/.claude/skills/sf-tool-github-projects/SKILL.md
+++ b/.claude/skills/sf-tool-github-projects/SKILL.md
@@ -10,11 +10,11 @@ github project, create subtask, update ticket status, github issue, project boar
 
 Three orthogonal axes on every ticket:
 
-| Axis           | Where it lives                                              | What it controls                                                                                                                            |
-| -------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Status**     | Projects V2 board (Single select field "Status")            | Workflow phase (Backlog → … → Done)                                                                                                         |
-| **Complexity** | GitHub label (`complexity: bug\|low\|medium\|complex`)      | Rigor level applied in each phase (agents, tests, reviews)                                                                                  |
-| **Type**       | GitHub Issue Type (org-level chip — Epic/Story/Task/Issues) | Ticket nature in the hierarchy (replaces `[EPIC]`/`[STORY]` title markers). `Issues` is plural — GitHub reserves the singular `Issue` name. |
+| Axis           | Where it lives                                                         | What it controls                                                                                                                                                                                                                        |
+| -------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**     | Projects V2 board (Single select field "Status")                       | Workflow phase (Backlog → … → Done)                                                                                                                                                                                                     |
+| **Complexity** | GitHub label (`complexity: bug\|low\|medium\|complex`)                 | Rigor level applied in each phase (agents, tests, reviews)                                                                                                                                                                              |
+| **Type**       | GitHub Issue Type (org-level chip — sf-epic/sf-story/sf-task/sf-issue) | Ticket nature in the hierarchy (replaces `[EPIC]`/`[STORY]` title markers). The `sf-` prefix avoids collisions with vanilla Epic/Story/Task types defined elsewhere in the org and sidesteps the GitHub-reserved singular `Issue` name. |
 
 Never encode status in a label. Never encode complexity on the board. Type is org-scoped — a single set of types serves every repo in the org.
 
@@ -40,7 +40,7 @@ All via `.claude/skills/sf-tool-github-projects/github-projects-cli.sh <cmd> [ar
 | `create-pr <ticket>`                     | Push branch + open PR against `workingBranch`                                                     |
 | `list [status]`                          | List project items, optionally filtered by status                                                 |
 | `ensure-issue-types [--dry-run]`         | Idempotently create org-level issue types from `workflow.issueTypes` in `.saasfoundry.json`       |
-| `assign-type <issue> <type>`             | Attach a native GitHub Issue Type chip (Epic/Story/Task/Issues) to the issue                      |
+| `assign-type <issue> <type>`             | Attach a native GitHub Issue Type chip (sf-epic/sf-story/sf-task/sf-issue) to the issue           |
 | `delete-issue-type <type>`               | Remove an issue type from the org (cleanup of legacy types like Bug/Feature)                      |
 
 Status names are case-insensitive — the CLI matches against the options defined on the board.

--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -456,8 +456,11 @@ cmd_create_subtask() {
   BODY="${POSITIONAL[2]:-}"
   # Native sub-issue linking (addSubIssue mutation below) makes the parent
   # relationship visible in the GitHub UI on its own — no need for a textual
-  # `[Parent #N]` title prefix anymore. Native Issue Type chips (Epic/Story/
-  # Task/Issues) replace the old `[EPIC]`/`[STORY]` markers via assign-type.
+  # `[Parent #N]` title prefix anymore. Native Issue Type chips
+  # (sf-epic/sf-story/sf-task/sf-issue) replace the old `[EPIC]`/`[STORY]`
+  # markers via assign-type. The `sf-` prefix avoids collisions with vanilla
+  # Epic/Story/Task types defined elsewhere in the org and sidesteps the
+  # "Issue" reserved-name constraint.
   FULL_TITLE="${TITLE}"
 
   # If no body was supplied, render a type-specific skeleton so the created
@@ -537,10 +540,10 @@ cmd_create_subtask() {
   if [ "${declared_types:-0}" != "0" ]; then
     local target_type
     case "$TICKET_TYPE" in
-      epic)   target_type="Epic" ;;
-      story)  target_type="Story" ;;
-      task)   target_type="Task" ;;
-      issue)  target_type="Issues" ;;  # GitHub reserves "Issue" singular — must be plural
+      epic)   target_type="sf-epic" ;;
+      story)  target_type="sf-story" ;;
+      task)   target_type="sf-task" ;;
+      issue)  target_type="sf-issue" ;;  # `sf-` prefix avoids the GitHub-reserved "Issue" name
     esac
     if [ -n "$target_type" ]; then
       "$0" assign-type "$CHILD_NUMBER" "$target_type" 2>/dev/null || \
@@ -1122,7 +1125,7 @@ case "$COMMAND" in
     echo "  list [status]                            List project items (optionally filtered)"
     echo "  cache-clear                              Drop the on-disk schema cache"
     echo "  ensure-issue-types [--dry-run]           Idempotently create missing issue types from .saasfoundry.json"
-    echo "  assign-type <issue> <type>               Assign a native GitHub Issue Type (Epic|Story|Task|Issue)"
+    echo "  assign-type <issue> <type>               Assign a native GitHub Issue Type (sf-epic|sf-story|sf-task|sf-issue)"
     echo "  delete-issue-type <type>                 Remove an issue type from the org (cleanup)"
     exit 1
     ;;

--- a/.saasfoundry.json
+++ b/.saasfoundry.json
@@ -51,23 +51,23 @@
     ],
     "issueTypes": [
       {
-        "name": "Epic",
-        "description": "Grouper for related Stories/Tasks (no PR, no branch)",
+        "name": "sf-epic",
+        "description": "Grouper for related sf-stories/sf-tasks (no PR, no branch)",
         "color": "PURPLE"
       },
       {
-        "name": "Story",
+        "name": "sf-story",
         "description": "Delivers user-observable value",
         "color": "BLUE"
       },
       {
-        "name": "Task",
+        "name": "sf-task",
         "description": "Delivers a technical action (refactor, infra, tooling)",
         "color": "GRAY"
       },
       {
-        "name": "Issues",
-        "description": "Defect or unexpected behavior to investigate and fix (plural form — 'Issue' singular is a GitHub-reserved name)",
+        "name": "sf-issue",
+        "description": "Defect or unexpected behavior to investigate and fix",
         "color": "RED"
       }
     ]

--- a/scaffolds/docs/manifest-schema.md
+++ b/scaffolds/docs/manifest-schema.md
@@ -24,22 +24,22 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
 
 ## Fields read by each skill
 
-| Skill                     | Field                           | Purpose                                                                                                                                          |
-| ------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sf-workflow`             | `workflow.tool`                 | Routes CLI calls to the right tool adapter                                                                                                       |
-| `sf-workflow`             | `workflow.workingBranch`        | Default branch for `git checkout -b feature/...`                                                                                                 |
-| `sf-workflow`             | `workflow.prTargetBranch`       | Default PR target                                                                                                                                |
-| `sf-workflow`             | `workflow.branchNaming.feature` | Pattern for feature branches                                                                                                                     |
-| `sf-workflow`             | `workflow.commitFormat.pattern` | Enforced by commitlint hook                                                                                                                      |
-| `sf-tool-github-projects` | `workflow.projectUrl`           | GitHub Projects V2 URL (org or user)                                                                                                             |
-| `sf-tool-github-projects` | `workflow.workingBranch`        | Used by `create-pr` to target the right base                                                                                                     |
-| `sf-tool-github-projects` | `workflow.statuses`             | Status options declared on the board                                                                                                             |
-| `sf-tool-github-projects` | `workflow.issueTypes`           | Native GitHub Issue Type chips (Epic/Story/Task/Issues) — org-level. Note: `Issues` is plural because GitHub reserves the singular `Issue` name. |
-| `sf-tool-github-projects` | `tools.srs.backend`             | Enables SRS gating on `create-subtask` (Rule 8)                                                                                                  |
-| `sf-srs`                  | `tools.srs.backend`             | Resolves which `SrsAdapter` to instantiate                                                                                                       |
-| `sf-srs`                  | `tools.srs.rootPage.id`         | Default root container for drafters / eval                                                                                                       |
-| `sf-srs`                  | `tools.srs.enabled`             | Gates the conversational eval hook                                                                                                               |
-| `sf-srs`                  | `tools.srs.scan.exclude`        | Extra exclusion patterns on top of `.gitignore` + `.srsignore`                                                                                   |
+| Skill                     | Field                           | Purpose                                                                                                                                                                                                                                     |
+| ------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sf-workflow`             | `workflow.tool`                 | Routes CLI calls to the right tool adapter                                                                                                                                                                                                  |
+| `sf-workflow`             | `workflow.workingBranch`        | Default branch for `git checkout -b feature/...`                                                                                                                                                                                            |
+| `sf-workflow`             | `workflow.prTargetBranch`       | Default PR target                                                                                                                                                                                                                           |
+| `sf-workflow`             | `workflow.branchNaming.feature` | Pattern for feature branches                                                                                                                                                                                                                |
+| `sf-workflow`             | `workflow.commitFormat.pattern` | Enforced by commitlint hook                                                                                                                                                                                                                 |
+| `sf-tool-github-projects` | `workflow.projectUrl`           | GitHub Projects V2 URL (org or user)                                                                                                                                                                                                        |
+| `sf-tool-github-projects` | `workflow.workingBranch`        | Used by `create-pr` to target the right base                                                                                                                                                                                                |
+| `sf-tool-github-projects` | `workflow.statuses`             | Status options declared on the board                                                                                                                                                                                                        |
+| `sf-tool-github-projects` | `workflow.issueTypes`           | Native GitHub Issue Type chips (sf-epic/sf-story/sf-task/sf-issue) — org-level. The `sf-` prefix avoids collisions with vanilla Epic/Story/Task types defined elsewhere in the org and sidesteps the GitHub-reserved singular `Issue` name. |
+| `sf-tool-github-projects` | `tools.srs.backend`             | Enables SRS gating on `create-subtask` (Rule 8)                                                                                                                                                                                             |
+| `sf-srs`                  | `tools.srs.backend`             | Resolves which `SrsAdapter` to instantiate                                                                                                                                                                                                  |
+| `sf-srs`                  | `tools.srs.rootPage.id`         | Default root container for drafters / eval                                                                                                                                                                                                  |
+| `sf-srs`                  | `tools.srs.enabled`             | Gates the conversational eval hook                                                                                                                                                                                                          |
+| `sf-srs`                  | `tools.srs.scan.exclude`        | Extra exclusion patterns on top of `.gitignore` + `.srsignore`                                                                                                                                                                              |
 
 ## Canonical shape
 
@@ -75,10 +75,10 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
       { "name": "Done", "color": "GREEN" }
     ],
     "issueTypes": [
-      { "name": "Epic", "description": "Grouper for related Stories/Tasks (no PR, no branch)", "color": "PURPLE" },
-      { "name": "Story", "description": "Delivers user-observable value", "color": "BLUE" },
-      { "name": "Task", "description": "Delivers a technical action", "color": "GRAY" },
-      { "name": "Issues", "description": "Defect or unexpected behavior (plural — GitHub reserves the singular 'Issue' name)", "color": "RED" }
+      { "name": "sf-epic", "description": "Grouper for related sf-stories/sf-tasks (no PR, no branch)", "color": "PURPLE" },
+      { "name": "sf-story", "description": "Delivers user-observable value", "color": "BLUE" },
+      { "name": "sf-task", "description": "Delivers a technical action", "color": "GRAY" },
+      { "name": "sf-issue", "description": "Defect or unexpected behavior to investigate and fix", "color": "RED" }
     ]
   },
   "tools": {

--- a/scaffolds/skills-templates/tools/github-projects/SKILL.md
+++ b/scaffolds/skills-templates/tools/github-projects/SKILL.md
@@ -10,11 +10,11 @@ github project, create subtask, update ticket status, github issue, project boar
 
 Three orthogonal axes on every ticket:
 
-| Axis           | Where it lives                                              | What it controls                                                                                                                            |
-| -------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Status**     | Projects V2 board (Single select field "Status")            | Workflow phase (Backlog → … → Done)                                                                                                         |
-| **Complexity** | GitHub label (`complexity: bug\|low\|medium\|complex`)      | Rigor level applied in each phase (agents, tests, reviews)                                                                                  |
-| **Type**       | GitHub Issue Type (org-level chip — Epic/Story/Task/Issues) | Ticket nature in the hierarchy (replaces `[EPIC]`/`[STORY]` title markers). `Issues` is plural — GitHub reserves the singular `Issue` name. |
+| Axis           | Where it lives                                                         | What it controls                                                                                                                                                                                                                        |
+| -------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**     | Projects V2 board (Single select field "Status")                       | Workflow phase (Backlog → … → Done)                                                                                                                                                                                                     |
+| **Complexity** | GitHub label (`complexity: bug\|low\|medium\|complex`)                 | Rigor level applied in each phase (agents, tests, reviews)                                                                                                                                                                              |
+| **Type**       | GitHub Issue Type (org-level chip — sf-epic/sf-story/sf-task/sf-issue) | Ticket nature in the hierarchy (replaces `[EPIC]`/`[STORY]` title markers). The `sf-` prefix avoids collisions with vanilla Epic/Story/Task types defined elsewhere in the org and sidesteps the GitHub-reserved singular `Issue` name. |
 
 Never encode status in a label. Never encode complexity on the board. Type is org-scoped — a single set of types serves every repo in the org.
 
@@ -40,7 +40,7 @@ All via `.claude/skills/sf-tool-github-projects/github-projects-cli.sh <cmd> [ar
 | `create-pr <ticket>`                     | Push branch + open PR against `workingBranch`                                                     |
 | `list [status]`                          | List project items, optionally filtered by status                                                 |
 | `ensure-issue-types [--dry-run]`         | Idempotently create org-level issue types from `workflow.issueTypes` in `.saasfoundry.json`       |
-| `assign-type <issue> <type>`             | Attach a native GitHub Issue Type chip (Epic/Story/Task/Issues) to the issue                      |
+| `assign-type <issue> <type>`             | Attach a native GitHub Issue Type chip (sf-epic/sf-story/sf-task/sf-issue) to the issue           |
 | `delete-issue-type <type>`               | Remove an issue type from the org (cleanup of legacy types like Bug/Feature)                      |
 
 Status names are case-insensitive — the CLI matches against the options defined on the board.

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -456,8 +456,11 @@ cmd_create_subtask() {
   BODY="${POSITIONAL[2]:-}"
   # Native sub-issue linking (addSubIssue mutation below) makes the parent
   # relationship visible in the GitHub UI on its own — no need for a textual
-  # `[Parent #N]` title prefix anymore. Native Issue Type chips (Epic/Story/
-  # Task/Issues) replace the old `[EPIC]`/`[STORY]` markers via assign-type.
+  # `[Parent #N]` title prefix anymore. Native Issue Type chips
+  # (sf-epic/sf-story/sf-task/sf-issue) replace the old `[EPIC]`/`[STORY]`
+  # markers via assign-type. The `sf-` prefix avoids collisions with vanilla
+  # Epic/Story/Task types defined elsewhere in the org and sidesteps the
+  # "Issue" reserved-name constraint.
   FULL_TITLE="${TITLE}"
 
   # If no body was supplied, render a type-specific skeleton so the created
@@ -537,10 +540,10 @@ cmd_create_subtask() {
   if [ "${declared_types:-0}" != "0" ]; then
     local target_type
     case "$TICKET_TYPE" in
-      epic)   target_type="Epic" ;;
-      story)  target_type="Story" ;;
-      task)   target_type="Task" ;;
-      issue)  target_type="Issues" ;;  # GitHub reserves "Issue" singular — must be plural
+      epic)   target_type="sf-epic" ;;
+      story)  target_type="sf-story" ;;
+      task)   target_type="sf-task" ;;
+      issue)  target_type="sf-issue" ;;  # `sf-` prefix avoids the GitHub-reserved "Issue" name
     esac
     if [ -n "$target_type" ]; then
       "$0" assign-type "$CHILD_NUMBER" "$target_type" 2>/dev/null || \
@@ -1122,7 +1125,7 @@ case "$COMMAND" in
     echo "  list [status]                            List project items (optionally filtered)"
     echo "  cache-clear                              Drop the on-disk schema cache"
     echo "  ensure-issue-types [--dry-run]           Idempotently create missing issue types from .saasfoundry.json"
-    echo "  assign-type <issue> <type>               Assign a native GitHub Issue Type (Epic|Story|Task|Issue)"
+    echo "  assign-type <issue> <type>               Assign a native GitHub Issue Type (sf-epic|sf-story|sf-task|sf-issue)"
     echo "  delete-issue-type <type>                 Remove an issue type from the org (cleanup)"
     exit 1
     ;;

--- a/src/__tests__/unit/skill/github-projects-cli.issue-types.spec.ts
+++ b/src/__tests__/unit/skill/github-projects-cli.issue-types.spec.ts
@@ -32,10 +32,10 @@ interface Sandbox {
 }
 
 const DEFAULT_MANIFEST_TYPES = [
-  { name: 'Epic', color: 'PURPLE', description: 'Grouper' },
-  { name: 'Story', color: 'BLUE', description: 'User value' },
-  { name: 'Task', color: 'GRAY' },
-  { name: 'Issues', color: 'RED' }
+  { name: 'sf-epic', color: 'PURPLE', description: 'Grouper' },
+  { name: 'sf-story', color: 'BLUE', description: 'User value' },
+  { name: 'sf-task', color: 'GRAY' },
+  { name: 'sf-issue', color: 'RED' }
 ]
 
 async function buildSandbox(opts: SandboxOpts = {}): Promise<Sandbox> {
@@ -76,7 +76,7 @@ async function buildSandbox(opts: SandboxOpts = {}): Promise<Sandbox> {
           : opts.failMode === 'partial-create'
             ? '{"data":{"createIssueType":{"issueType":{"id":"IT_X","name":"X","color":"GRAY"}}},"errors":[{"message":"degraded"}]}'
             : opts.failMode === 'partial-assign'
-              ? '{"data":{"updateIssueIssueType":{"issue":{"number":42,"issueType":{"name":"Story"}}}},"errors":[{"message":"degraded"}]}'
+              ? '{"data":{"updateIssueIssueType":{"issue":{"number":42,"issueType":{"name":"sf-story"}}}},"errors":[{"message":"degraded"}]}'
               : '{"errors":[{"message":"Schema is wonky"}]}'
     await writeFile(failMarker, payload)
   }
@@ -127,7 +127,7 @@ if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
       cat "$FAIL_MARKER"
       exit 1
     fi
-    echo '{"data":{"updateIssueIssueType":{"issue":{"number":42,"issueType":{"name":"Story"}}}}}'
+    echo '{"data":{"updateIssueIssueType":{"issue":{"number":42,"issueType":{"name":"sf-story"}}}}}'
     exit 0
   fi
   if echo "$query" | grep -q 'deleteIssueType'; then
@@ -188,10 +188,10 @@ describe('sf-tool-github-projects — ensure-issue-types', () => {
   it('reports "all already exist" when the org has every declared type', async () => {
     sandbox = await buildSandbox({
       existingTypes: [
-        { id: 'IT_E', name: 'Epic' },
-        { id: 'IT_S', name: 'Story' },
-        { id: 'IT_T', name: 'Task' },
-        { id: 'IT_I', name: 'Issues' }
+        { id: 'IT_E', name: 'sf-epic' },
+        { id: 'IT_S', name: 'sf-story' },
+        { id: 'IT_T', name: 'sf-task' },
+        { id: 'IT_I', name: 'sf-issue' }
       ]
     })
     const res = await runCli(['ensure-issue-types'], sandbox)
@@ -203,14 +203,14 @@ describe('sf-tool-github-projects — ensure-issue-types', () => {
   it('creates only the missing types, leaving existing ones untouched', async () => {
     sandbox = await buildSandbox({
       existingTypes: [
-        { id: 'IT_E', name: 'Epic' },
-        { id: 'IT_S', name: 'Story' }
+        { id: 'IT_E', name: 'sf-epic' },
+        { id: 'IT_S', name: 'sf-story' }
       ]
     })
     const res = await runCli(['ensure-issue-types'], sandbox)
     expect(res.code).toBe(0)
     const trace = readTrace(sandbox.tracePath)
-    expect(trace).toEqual(['create:Task:GRAY', 'create:Issues:RED'])
+    expect(trace).toEqual(['create:sf-task:GRAY', 'create:sf-issue:RED'])
     expect(res.stdout).toMatch(/2 missing type\(s\) to create/)
     expect(res.stdout).toMatch(/ensure-issue-types complete/)
   })
@@ -218,10 +218,10 @@ describe('sf-tool-github-projects — ensure-issue-types', () => {
   it('matches existing names case-insensitively (no duplicate creation)', async () => {
     sandbox = await buildSandbox({
       existingTypes: [
-        { id: 'IT_E', name: 'epic' },
-        { id: 'IT_S', name: 'STORY' },
-        { id: 'IT_T', name: 'Task' },
-        { id: 'IT_I', name: 'issues' }
+        { id: 'IT_E', name: 'SF-EPIC' },
+        { id: 'IT_S', name: 'Sf-Story' },
+        { id: 'IT_T', name: 'sf-task' },
+        { id: 'IT_I', name: 'SF-ISSUE' }
       ]
     })
     const res = await runCli(['ensure-issue-types'], sandbox)
@@ -230,12 +230,12 @@ describe('sf-tool-github-projects — ensure-issue-types', () => {
   })
 
   it('--dry-run lists missing types without firing any mutation', async () => {
-    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_E', name: 'Epic' }] })
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_E', name: 'sf-epic' }] })
     const res = await runCli(['ensure-issue-types', '--dry-run'], sandbox)
     expect(res.code).toBe(0)
-    expect(res.stdout).toMatch(/\[dry-run\] would create: Story/)
-    expect(res.stdout).toMatch(/\[dry-run\] would create: Task/)
-    expect(res.stdout).toMatch(/\[dry-run\] would create: Issues/)
+    expect(res.stdout).toMatch(/\[dry-run\] would create: sf-story/)
+    expect(res.stdout).toMatch(/\[dry-run\] would create: sf-task/)
+    expect(res.stdout).toMatch(/\[dry-run\] would create: sf-issue/)
     expect(readTrace(sandbox.tracePath)).toEqual([])
   })
 
@@ -274,35 +274,35 @@ describe('sf-tool-github-projects — assign-type', () => {
   afterEach(async () => sandbox?.cleanup())
 
   it('looks up the type id and calls updateIssueIssueType', async () => {
-    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_STORY', name: 'Story' }] })
-    const res = await runCli(['assign-type', '42', 'Story'], sandbox)
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_STORY', name: 'sf-story' }] })
+    const res = await runCli(['assign-type', '42', 'sf-story'], sandbox)
     expect(res.code).toBe(0)
-    expect(res.stdout).toMatch(/Issue #42 → type 'Story'/)
+    expect(res.stdout).toMatch(/Issue #42 → type 'sf-story'/)
     expect(readTrace(sandbox.tracePath)).toEqual(['assign:I_ISSUE_42:IT_STORY'])
   })
 
   it('matches the type name case-insensitively', async () => {
-    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_STORY', name: 'Story' }] })
-    const res = await runCli(['assign-type', '42', 'story'], sandbox)
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_STORY', name: 'sf-story' }] })
+    const res = await runCli(['assign-type', '42', 'SF-STORY'], sandbox)
     expect(res.code).toBe(0)
     expect(readTrace(sandbox.tracePath)).toEqual(['assign:I_ISSUE_42:IT_STORY'])
   })
 
   it('exits 1 with a remediation hint when the type is unknown to the org', async () => {
-    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_E', name: 'Epic' }] })
-    const res = await runCli(['assign-type', '42', 'Saga'], sandbox)
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_E', name: 'sf-epic' }] })
+    const res = await runCli(['assign-type', '42', 'sf-saga'], sandbox)
     expect(res.code).toBe(1)
-    expect(res.stderr).toMatch(/Issue type 'Saga' not found/)
+    expect(res.stderr).toMatch(/Issue type 'sf-saga' not found/)
     expect(res.stderr).toMatch(/ensure-issue-types/)
     expect(readTrace(sandbox.tracePath)).toEqual([])
   })
 
   it('translates permission errors into a manual-fallback message', async () => {
     sandbox = await buildSandbox({
-      existingTypes: [{ id: 'IT_STORY', name: 'Story' }],
+      existingTypes: [{ id: 'IT_STORY', name: 'sf-story' }],
       failMode: 'permission'
     })
-    const res = await runCli(['assign-type', '42', 'Story'], sandbox)
+    const res = await runCli(['assign-type', '42', 'sf-story'], sandbox)
     expect(res.code).toBe(1)
     expect(res.stderr).toMatch(/Permission denied|admin:org/)
   })
@@ -317,12 +317,12 @@ describe('sf-tool-github-projects — assign-type', () => {
 
   it('rejects "data + errors" partial responses on assign instead of declaring success', async () => {
     sandbox = await buildSandbox({
-      existingTypes: [{ id: 'IT_STORY', name: 'Story' }],
+      existingTypes: [{ id: 'IT_STORY', name: 'sf-story' }],
       failMode: 'partial-assign'
     })
-    const res = await runCli(['assign-type', '42', 'Story'], sandbox)
+    const res = await runCli(['assign-type', '42', 'sf-story'], sandbox)
     expect(res.code).toBe(1)
-    expect(res.stdout).not.toMatch(/Issue #42 → type 'Story'/)
+    expect(res.stdout).not.toMatch(/Issue #42 → type 'sf-story'/)
   })
 })
 
@@ -331,7 +331,7 @@ describe('sf-tool-github-projects — delete-issue-type', () => {
   afterEach(async () => sandbox?.cleanup())
 
   it('is idempotent when the type is already absent (no mutation)', async () => {
-    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_S', name: 'Story' }] })
+    sandbox = await buildSandbox({ existingTypes: [{ id: 'IT_S', name: 'sf-story' }] })
     const res = await runCli(['delete-issue-type', 'Bug'], sandbox)
     expect(res.code).toBe(0)
     expect(res.stdout).toMatch(/Type 'Bug' not present/)

--- a/src/__tests__/unit/skill/manifest-schema.spec.ts
+++ b/src/__tests__/unit/skill/manifest-schema.spec.ts
@@ -55,7 +55,7 @@ describe('saasfoundry-manifest.schema.json — canonical shapes', () => {
           { name: 'Backlog', color: 'GRAY' },
           { name: 'In progress', color: 'BLUE' }
         ],
-        issueTypes: [{ name: 'Epic', description: 'Grouper', color: 'PURPLE' }, { name: 'Story', color: 'BLUE' }, { name: 'Task' }, { name: 'Issues', color: 'RED' }],
+        issueTypes: [{ name: 'sf-epic', description: 'Grouper', color: 'PURPLE' }, { name: 'sf-story', color: 'BLUE' }, { name: 'sf-task' }, { name: 'sf-issue', color: 'RED' }],
         validated: true,
         lastValidated: '2026-04-25T00:00:00.000Z'
       },
@@ -108,7 +108,7 @@ describe('saasfoundry-manifest.schema.json — rejection cases', () => {
   })
 
   it('rejects an unknown workflow.issueTypes[].color value', () => {
-    expect(validate({ ...baseManifest, workflow: { tool: 'github-projects', issueTypes: [{ name: 'Epic', color: 'NEON' }] } })).toBe(false)
+    expect(validate({ ...baseManifest, workflow: { tool: 'github-projects', issueTypes: [{ name: 'sf-epic', color: 'NEON' }] } })).toBe(false)
   })
 
   it('rejects a workflow.issueTypes[] entry missing the required name field', () => {

--- a/src/commands/workflow.ts
+++ b/src/commands/workflow.ts
@@ -184,6 +184,7 @@ async function useTemplate(manifest: SaaSFoundryManifest, templateName?: string)
     prTargetBranch: template.prTargetBranch,
     requireCodeReview: template.requireCodeReview,
     statuses: template.statuses,
+    issueTypes: template.issueTypes,
     branchNaming: template.branchNaming,
     commitFormat: template.commitFormat,
     validated: false
@@ -308,6 +309,7 @@ async function saveAsTemplate(manifest: SaaSFoundryManifest, templateName?: stri
       prTargetBranch: manifest.workflow.prTargetBranch,
       requireCodeReview: manifest.workflow.requireCodeReview,
       statuses: manifest.workflow.statuses,
+      issueTypes: manifest.workflow.issueTypes,
       branchNaming: manifest.workflow.branchNaming,
       commitFormat: manifest.workflow.commitFormat,
       aiRules: manifest.aiRules || {
@@ -327,6 +329,7 @@ async function saveAsTemplate(manifest: SaaSFoundryManifest, templateName?: stri
       prTargetBranch: manifest.workflow.prTargetBranch,
       requireCodeReview: manifest.workflow.requireCodeReview,
       statuses: manifest.workflow.statuses,
+      issueTypes: manifest.workflow.issueTypes,
       branchNaming: manifest.workflow.branchNaming,
       commitFormat: manifest.workflow.commitFormat,
       aiRules: manifest.aiRules || {
@@ -484,6 +487,7 @@ async function createTemplate(templateName?: string) {
     prTargetBranch: workflow.prTargetBranch,
     requireCodeReview: workflow.requireCodeReview,
     statuses: workflow.statuses,
+    issueTypes: workflow.issueTypes,
     branchNaming: workflow.branchNaming,
     commitFormat: workflow.commitFormat,
     aiRules

--- a/src/prompts/workflow.prompts.ts
+++ b/src/prompts/workflow.prompts.ts
@@ -58,6 +58,12 @@ const WORKFLOW_PRESETS = {
           'Feature completed and merged to main branch. Code is deployed or ready for deployment. Close the ticket, archive subtasks, and update any related documentation. Celebrate the win!',
         color: 'GREEN' as GitHubProjectColor
       }
+    ],
+    issueTypes: [
+      { name: 'sf-epic', description: 'Grouper for related sf-stories/sf-tasks (no PR, no branch)', color: 'PURPLE' as GitHubProjectColor },
+      { name: 'sf-story', description: 'Delivers user-observable value', color: 'BLUE' as GitHubProjectColor },
+      { name: 'sf-task', description: 'Delivers a technical action (refactor, infra, tooling)', color: 'GRAY' as GitHubProjectColor },
+      { name: 'sf-issue', description: 'Defect or unexpected behavior to investigate and fix', color: 'RED' as GitHubProjectColor }
     ]
   }
 }
@@ -340,6 +346,8 @@ export const DEFAULT_STATUSES = {
   linear: WORKFLOW_PRESETS.saasfoundry.statuses,
   none: []
 }
+
+export const DEFAULT_ISSUE_TYPES = WORKFLOW_PRESETS.saasfoundry.issueTypes
 
 export const DEFAULT_BRANCH_NAMING = {
   feature: 'feature/{name}',
@@ -974,6 +982,7 @@ export async function promptWorkflowConfiguration(
     prTargetBranch,
     requireCodeReview,
     statuses: workflowStatuses.length > 0 ? workflowStatuses : DEFAULT_STATUSES[tool as keyof typeof DEFAULT_STATUSES],
+    issueTypes: tool === 'github-projects' ? DEFAULT_ISSUE_TYPES : undefined,
     branchNaming: DEFAULT_BRANCH_NAMING,
     commitFormat: DEFAULT_COMMIT_FORMAT
   }
@@ -1019,6 +1028,7 @@ export async function promptWorkflowConfiguration(
         prTargetBranch: workflowConfig.prTargetBranch!,
         requireCodeReview: workflowConfig.requireCodeReview!,
         statuses: workflowConfig.statuses!,
+        issueTypes: workflowConfig.issueTypes,
         branchNaming: workflowConfig.branchNaming!,
         commitFormat: workflowConfig.commitFormat!,
         aiRules: aiRulesConfig


### PR DESCRIPTION
## Summary

Renames the four GitHub Issue Type chips from `Epic`/`Story`/`Task`/`Issues` to `sf-epic`/`sf-story`/`sf-task`/`sf-issue` to:

- Avoid collisions with vanilla `Epic`/`Story`/`Task` types defined elsewhere in orgs that already use them
- Sidestep the GitHub-reserved singular `Issue` name (we previously had to fall back to plural `Issues`)

Wires the `sf-*` defaults into the `saasfoundry` workflow preset and the `apply-template` / `save-as-template` paths so freshly scaffolded projects get the right `issueTypes` in their manifest out of the box.

CLI flags stay short for UX (`--type epic|story|task|issue`); they map internally to the `sf-*` chip names sent to the GraphQL API.

## Changes

- `.saasfoundry.json`: 4 issueTypes renamed to sf-*
- `.claude/skills/sf-tool-github-projects/github-projects-cli.sh`: `target_type` mapping + help text + comment rationale
- `.claude/skills/sf-tool-github-projects/SKILL.md` + `.claude/docs/manifest-schema.md`: Type axis row + canonical shape + assign-type rows updated
- `scaffolds/...`: drift-mirrored
- `src/prompts/workflow.prompts.ts`: `WORKFLOW_PRESETS.saasfoundry.issueTypes` + `DEFAULT_ISSUE_TYPES` + included in `workflowConfig`
- `src/commands/workflow.ts`: `issueTypes` plumbed through `apply` and `save-as-template` flows
- Tests updated (29 across 2 specs); 1242 tests pass

## Post-merge rollout (operational checklist)

After merge, run on the DiamondForgeFr org to migrate the live state:

- [ ] `.claude/skills/sf-tool-github-projects/github-projects-cli.sh ensure-issue-types` (creates sf-epic/sf-story/sf-task/sf-issue chips)
- [ ] Migrate every existing typed ticket from old chip → new chip (one `assign-type <N> <new>` per ticket, or batch via GraphQL)
- [ ] `delete-issue-type Epic` / `Story` / `Task` / `Issues` (cleanup of legacy types)

Requires `gh auth refresh --hostname github.com --scopes admin:org` once before running.

## Test plan

- [x] `npm run test:pre-commit` (1242 pass)
- [x] Pre-push docker tests (multirepo-minimal + monorepo-minimal pass)
- [ ] Post-merge: verify `ensure-issue-types` is idempotent on a fresh run
- [ ] Post-merge: verify a freshly scaffolded project gets sf-* in its `.saasfoundry.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)