### PR TITLE
feat(#347): PR-existence guard + nature:bundled-pr path for In Review/Done

### DIFF
--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -19,25 +19,33 @@ This workflow adapts its rigor based on ticket complexity:
 
 **Key principle:** Higher complexity = more rigor (analysis depth, planning detail, adversarial review, test coverage)
 
-## 🎚️ Nature axis (user-facing vs internal)
+## 🎚️ Nature axis (user-facing / internal / bundled-pr)
 
-Orthogonal to complexity. Controls whether **Human Testing** is mandatory or optional in the lifecycle.
+Orthogonal to complexity. Controls whether **Human Testing** and **In Review** are mandatory or optional in the lifecycle.
 
-| Label                | Use case                                                                                          | Workflow effect                                        |
-| -------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `nature:user-facing` | Bug fix or feature with visible UX impact — anything a user can click, see, or feel               | Mandatory `AI Testing → Human Testing → In Review`     |
-| `nature:internal`    | Refactor, scaffolding, non-terminal story of a multi-step Epic, internal tooling, doc-only change | Optional `AI Testing → In Review` (skip Human Testing) |
+| Label                | Use case                                                                                                                                        | Workflow effect                                                                       |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `nature:user-facing` | Bug fix or feature with visible UX impact — anything a user can click, see, or feel                                                             | Mandatory `AI Testing → Human Testing → In Review → Done`                             |
+| `nature:internal`    | Refactor, scaffolding, internal tooling, doc-only change — ships its own PR                                                                     | Optional `AI Testing → In Review → Done` (skip Human Testing)                         |
+| `nature:bundled-pr`  | Sub-Story of a multi-step Epic whose merge happens via the **Epic's single bundled PR** — there is no individual PR to open at this Sub's level | `AI Testing → Done` (skip Human Testing **and** In Review — PR is at the parent Epic) |
 
 **Default** — if a ticket has no `nature:*` label, the workflow treats it as `user-facing` (safe default).
 
-**Why this exists** — the Human Testing status is theatrical on tickets that have nothing user-visible to validate (the docker tests + lint + tsc already cover the integration risk). For those, going
-AI Testing → In Review directly removes ceremony without sacrificing safety.
+**Why this exists** — Human Testing is theatrical on tickets with no user-visible surface (the docker tests + lint + tsc already cover the integration risk). And `In Review` on a Sub whose PR is
+bundled at the parent Epic is a board lie: there is no PR to review at this Sub level — the merge happens once at the end of the Epic. For those Subs we go AI Testing → Done directly, and the Epic's
+own ticket carries the In Review / merge ceremony.
 
-**Epic-level Human Testing** — when an Epic is composed entirely of `nature:internal` children, the meaningful manual validation happens at **Epic completion** (e.g. integration test on freshly merged
-`develop`), not on each child. Tag the Epic itself `nature:user-facing` so its own AI Testing → In Review transition still requires that integration check.
+**Epic-level Human Testing** — when an Epic is composed entirely of `nature:internal` (or `nature:bundled-pr`) children, the meaningful manual validation happens at **Epic completion** (e.g.
+integration test on freshly merged `develop`), not on each child. Tag the Epic itself `nature:user-facing` so its own AI Testing → In Review transition still requires that integration check.
 
-**Guard** — `update-status <ticket> "In review"` is rejected when the current status is `AI Testing` and the ticket lacks `nature:internal`. Fix by either tagging the ticket internal or going through
-Human Testing first. Escape hatch: `SF_WORKFLOW_BYPASS_NATURE_GUARD=1` (rare).
+**Guards** (all enforced by `update-status`):
+
+- **Nature guard** on `→ In Review` from `AI Testing` — requires `nature:internal`. `nature:bundled-pr` is rejected here (must go to `Done` instead). Default (no label / `user-facing`) must go through
+  Human Testing first. Escape hatch: `SF_WORKFLOW_BYPASS_NATURE_GUARD=1`.
+- **PR-existence guard** on `→ In Review` — rejected when no open PR is found for the ticket (`In Review` without a PR is meaningless). Escape hatch: `SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD=1`.
+- **Nature guard** on `→ Done` from `AI Testing` — allowed **only** for `nature:bundled-pr` (everyone else must go through `In Review` first). Escape hatch: `SF_WORKFLOW_BYPASS_NATURE_GUARD=1`.
+- **PR-merged guard** on `→ Done` — rejected when an open PR still exists for the ticket (`Done` means merged). Does not fire on `nature:bundled-pr` (no PR is expected). Escape hatch:
+  `SF_WORKFLOW_BYPASS_PR_MERGED_GUARD=1`.
 
 ## 🧩 Ticket Hierarchy (Epic / Story-Task / Subtask)
 

--- a/.claude/skills/sf-workflow/statuses/6-in-review.md
+++ b/.claude/skills/sf-workflow/statuses/6-in-review.md
@@ -5,7 +5,8 @@ entry_conditions:
   - One of:
       - Human Testing validated + non-regression tests created and pushed (`nature:user-facing` path)
       - AI Testing passed + ticket carries `nature:internal` label (skip-Human-Testing path — see SKILL.md "Nature axis")
-  - Ready to open the Pull Request
+  - **An open Pull Request exists for the ticket** (PR-existence guard — `In Review` without a PR is rejected by the CLI)
+  - Ticket is **not** `nature:bundled-pr` — those go AI Testing → Done directly (no individual PR at this Sub level)
 mandatory_actions:
   - Create the Pull Request (title + description + test plan + test list + reviewers + ticket link)
   - Move ticket to `In Review`
@@ -26,8 +27,10 @@ Code review with mandatory green CI.
 
 ## Ticket type
 
-- **Epic** — **never produces a PR**. Status is **derived** — reflects that every child Story/Task/Issue is itself in `In Review` (one open PR per child). Skip the checklist.
-- **Story / Task / Issue** — full flow below, one PR each.
+- **Epic** — **never produces a PR**. Status is **derived** — reflects that every child Story/Task/Issue is itself in `In Review` (one open PR per child) **or** has gone AI Testing → Done as a
+  `nature:bundled-pr` Sub. When an Epic uses bundled-PR Subs, the Epic itself opens **one** PR at the very end. Skip the checklist for the Epic ticket.
+- **Story / Task / Issue with its own PR** — full flow below, one PR per ticket.
+- **`nature:bundled-pr` Sub** — **never enters `In Review`**. Goes AI Testing → Done directly. The CLI rejects `update-status <ticket> "In review"` for these tickets.
 
 ## Action checklist
 

--- a/.claude/skills/sf-workflow/statuses/7-done.md
+++ b/.claude/skills/sf-workflow/statuses/7-done.md
@@ -2,17 +2,18 @@
 status: Done
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
-  - PR merged into the working branch (verified via `gh pr view <N> --json state` → `MERGED`)
-  - Code is on the target branch
-  - Tickets without a PR (Epic groupers, doc-only chores) skip the merge check
+  - One of:
+      - PR merged into the working branch (verified via `gh pr view <N> --json state` → `MERGED`) — standard path from `In Review`
+      - AI Testing passed + ticket carries `nature:bundled-pr` (skip-In-Review path — see SKILL.md "Nature axis"; no individual PR is opened at this Sub level)
+  - Tickets without a PR (Epic groupers, doc-only chores, `nature:bundled-pr` Subs) skip the merge check
 mandatory_actions:
   - Move ticket to `Done`
-  - Local branch cleanup — checkout working branch, rebase-pull, delete feature branch
-  - Rebase any other in-progress branches on the fresh working branch
+  - Local branch cleanup — checkout working branch, rebase-pull, delete feature branch (skip for `nature:bundled-pr` Subs — they share the parent Epic's branch)
+  - Rebase any other in-progress branches on the fresh working branch (after a real merge)
 exit_conditions:
   - Ticket marked `Done`
-  - Local feature branch deleted
-  - Other in-progress branches rebased
+  - Local feature branch deleted (where applicable)
+  - Other in-progress branches rebased (where applicable)
 next_status: N/A (end of cycle)
 ---
 
@@ -22,8 +23,10 @@ Finalization and cleanup after merge.
 
 ## Ticket type
 
-- **Epic** — `Done` is **derived** only when every child Story/Task/Issue is merged and closed. No branch to delete. Close the Epic issue once the last child reaches `Done`.
-- **Story / Task / Issue** — full cleanup flow below.
+- **Epic** — `Done` is **derived** only when every child Story/Task/Issue is `Done` (each child either merged its own PR or completed AI Testing as a `nature:bundled-pr` Sub). Close the Epic issue
+  once the last child reaches `Done` and, if the Epic uses bundled-PR Subs, after the Epic's own bundled PR is merged.
+- **Story / Task / Issue with its own PR** — full cleanup flow below; merge happens at the ticket level.
+- **`nature:bundled-pr` Sub** — no individual PR. Move directly to `Done` after AI Testing. Branch cleanup is owned by the parent Epic (the shared Epic branch is deleted when the Epic's PR merges).
 
 ## Action checklist
 

--- a/.claude/skills/sf-workflow/workflow-cli.sh
+++ b/.claude/skills/sf-workflow/workflow-cli.sh
@@ -244,17 +244,26 @@ check_complexity_guard() {
 }
 
 # ───────────────────────────────────────────────────────────────────────────
-# Nature guard — Human Testing optional for `nature:internal` tickets
+# Nature guard — Human Testing / In Review optional based on `nature:*`
 # ───────────────────────────────────────────────────────────────────────────
 #
-# A ticket tagged `nature:internal` may transition AI Testing → In Review
-# directly (skip Human Testing). Default behaviour (no `nature:*` label, or
-# `nature:user-facing`) requires the Human Testing step.
+# Three paths controlled by the `nature:*` label:
+#   - `nature:user-facing` (or no label) → AI Testing → Human Testing → In Review → Done
+#   - `nature:internal`                  → AI Testing → In Review → Done (skip Human Testing)
+#   - `nature:bundled-pr`                → AI Testing → Done (skip Human Testing AND In Review)
 #
-# The guard fires only on `update-status … "In Review"` when the current
-# board status is `AI Testing`. Other paths into In Review (Human Testing →
-# In Review) are unaffected. Fails open on label fetch errors (offline / auth)
-# to avoid wedging the workflow. Escape hatch: SF_WORKFLOW_BYPASS_NATURE_GUARD=1.
+# `nature:bundled-pr` is for Sub-stories of an Epic whose merge happens via the
+# Epic's single bundled PR — there is no individual PR to review at this level,
+# so In Review would always be a lie. See SKILL.md "Nature axis".
+#
+# Two firing points:
+#   - `→ In Review` from AI Testing — requires `nature:internal` (or
+#     `nature:bundled-pr` is rejected here, since bundled-pr should not enter
+#     In Review at all).
+#   - `→ Done` from AI Testing — only allowed for `nature:bundled-pr`.
+#
+# Fails open on label fetch errors (offline / auth) to avoid wedging the
+# workflow. Escape hatch: SF_WORKFLOW_BYPASS_NATURE_GUARD=1.
 
 is_in_review_target() {
   local target=$1
@@ -264,7 +273,7 @@ is_in_review_target() {
 }
 
 get_ticket_nature_label() {
-  # Prints `internal`, `user-facing`, or empty if no nature label.
+  # Prints `internal`, `user-facing`, `bundled-pr`, or empty if no nature label.
   # Returns 0 on clean fetch, 1 on fetch error.
   local ticket=$1
   local raw
@@ -278,34 +287,65 @@ check_nature_guard() {
   local target=$2
 
   [[ "${SF_WORKFLOW_BYPASS_NATURE_GUARD:-}" == "1" ]] && return 0
-  is_in_review_target "$target" || return 0
 
   local current_status
   current_status=$(get_current_status "$ticket" 2>/dev/null || true)
   local current_normalized
   current_normalized=$(echo "$current_status" | tr '[:upper:]' '[:lower:]' | awk '{$1=$1;print}')
 
-  # Only fire when coming from AI Testing — the Human Testing → In Review
-  # path is the standard route and never needs a nature label check.
+  # Only fire when coming from AI Testing — Human Testing → In Review and
+  # In Review → Done are the standard routes and need no nature check.
   [[ "$current_normalized" == "ai testing" ]] || return 0
 
   local nature
   nature=$(get_ticket_nature_label "$ticket") || return 0   # fail-open on fetch error
 
-  if [[ "$nature" == "internal" ]]; then
-    return 0
+  if is_in_review_target "$target"; then
+    if [[ "$nature" == "internal" ]]; then
+      return 0
+    fi
+    if [[ "$nature" == "bundled-pr" ]]; then
+      echo -e "${RED}✗ Ticket #${ticket} is 'nature:bundled-pr' — cannot enter 'In Review'.${NC}" >&2
+      echo "" >&2
+      echo "  Bundled-PR tickets have no individual PR (merge happens via the parent" >&2
+      echo "  Epic's single PR). They go AI Testing → Done directly." >&2
+      echo "" >&2
+      echo "  Move to Done instead:" >&2
+      echo "    .claude/skills/sf-workflow/workflow-cli.sh update-status ${ticket} Done" >&2
+      echo "" >&2
+      echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_NATURE_GUARD=1" >&2
+      return 1
+    fi
+    echo -e "${RED}✗ Ticket #${ticket} is in 'AI Testing' and lacks 'nature:internal' — cannot skip Human Testing.${NC}" >&2
+    echo "" >&2
+    echo "  Default workflow requires AI Testing → Human Testing → In Review." >&2
+    echo "  To allow skipping Human Testing, tag the ticket as internal:" >&2
+    echo "    gh issue edit ${ticket} --add-label 'nature:internal'" >&2
+    echo "" >&2
+    echo "  Use 'nature:internal' for refactors, scaffolding, internal tooling, or" >&2
+    echo "  non-terminal stories of a multi-step Epic that ship their own PR." >&2
+    echo "  Use 'nature:bundled-pr' for Subs whose PR is bundled at the Epic level." >&2
+    echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_NATURE_GUARD=1" >&2
+    return 1
   fi
 
-  echo -e "${RED}✗ Ticket #${ticket} is in 'AI Testing' and lacks 'nature:internal' — cannot skip Human Testing.${NC}" >&2
-  echo "" >&2
-  echo "  Default workflow requires AI Testing → Human Testing → In Review." >&2
-  echo "  To allow skipping Human Testing, tag the ticket as internal:" >&2
-  echo "    gh issue edit ${ticket} --add-label 'nature:internal'" >&2
-  echo "" >&2
-  echo "  Use 'nature:internal' for refactors, scaffolding, internal tooling, or" >&2
-  echo "  non-terminal stories of a multi-step Epic — see SKILL.md 'Nature axis'." >&2
-  echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_NATURE_GUARD=1" >&2
-  return 1
+  if is_done_target "$target"; then
+    if [[ "$nature" == "bundled-pr" ]]; then
+      return 0
+    fi
+    echo -e "${RED}✗ Ticket #${ticket} is in 'AI Testing' and lacks 'nature:bundled-pr' — cannot skip 'In Review'.${NC}" >&2
+    echo "" >&2
+    echo "  Default workflow goes through 'In Review' (where the PR is opened, reviewed," >&2
+    echo "  and merged). Only 'nature:bundled-pr' subs may go AI Testing → Done directly." >&2
+    echo "" >&2
+    echo "  Either open a PR and move to In Review, or tag the ticket bundled-pr:" >&2
+    echo "    gh issue edit ${ticket} --add-label 'nature:bundled-pr'" >&2
+    echo "" >&2
+    echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_NATURE_GUARD=1" >&2
+    return 1
+  fi
+
+  return 0
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -367,6 +407,54 @@ check_pr_merged_guard() {
   return 0
 }
 
+# ───────────────────────────────────────────────────────────────────────────
+# PR-existence guard — In Review requires an open PR
+# ───────────────────────────────────────────────────────────────────────────
+#
+# Entering 'In Review' means a Pull Request exists and is awaiting review.
+# Without an open PR there is nothing to review and the status is a board
+# lie. The status doc (statuses/6-in-review.md) lists "Create the PR" as a
+# mandatory entry action — this guard codifies that contract.
+#
+# Tickets tagged `nature:bundled-pr` are blocked separately by the nature
+# guard (they should not enter In Review at all). Tickets without any nature
+# label or with `nature:internal`/`nature:user-facing` need a real PR here.
+#
+# Fail-open on `gh` fetch errors (offline / auth). Escape hatch:
+# SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD=1.
+
+check_pr_existence_guard() {
+  # Returns 0 if the caller may proceed, 1 if blocked (message printed).
+  local ticket=$1
+  local target=$2
+
+  [[ "${SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD:-}" == "1" ]] && return 0
+  is_in_review_target "$target" || return 0
+
+  local pr_number
+  pr_number=$(get_open_pr_for_ticket "$ticket") || return 0   # fail-open on fetch error
+
+  if [[ -z "$pr_number" ]]; then
+    echo -e "${RED}✗ Ticket #${ticket} has no open PR — cannot transition to 'In Review'.${NC}" >&2
+    echo "" >&2
+    echo "  'In Review' means a Pull Request is open and awaiting review." >&2
+    echo "  Without a PR there is nothing to review — the status would be a board lie." >&2
+    echo "" >&2
+    echo "  Open the PR first, then move the ticket:" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh create-pr ${ticket}" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh update-status ${ticket} 'In review'" >&2
+    echo "" >&2
+    echo "  If this Sub's PR is bundled at the parent Epic level, tag it bundled-pr" >&2
+    echo "  and move to Done directly when AI Testing passes:" >&2
+    echo "    gh issue edit ${ticket} --add-label 'nature:bundled-pr'" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh update-status ${ticket} Done" >&2
+    echo "" >&2
+    echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD=1" >&2
+    return 1
+  fi
+  return 0
+}
+
 # Function to show next status
 show_next_status() {
   local current_status=$1
@@ -377,10 +465,15 @@ show_next_status() {
     "Ready") echo "Next: In Progress" ;;
     "In Progress"|"In progress") echo "Next: AI Testing" ;;
     "AI Testing"|"AI testing")
-      # Nature-aware: internal tickets skip Human Testing.
+      # Nature-aware: internal tickets skip Human Testing; bundled-pr subs
+      # skip both Human Testing and In Review (PR is at the parent Epic level).
       if [[ -n "$ticket" ]]; then
         local nature
         nature=$(get_ticket_nature_label "$ticket" 2>/dev/null || true)
+        if [[ "$nature" == "bundled-pr" ]]; then
+          echo "Next: Done (nature:bundled-pr — Human Testing + In Review skipped, PR bundled at parent Epic)"
+          return
+        fi
         if [[ "$nature" == "internal" ]]; then
           echo "Next: In Review (nature:internal — Human Testing skipped)"
           return
@@ -532,6 +625,9 @@ case "$COMMAND" in
       exit 2
     fi
     if ! check_nature_guard "$TICKET" "$TARGET"; then
+      exit 2
+    fi
+    if ! check_pr_existence_guard "$TICKET" "$TARGET"; then
       exit 2
     fi
     if ! check_pr_merged_guard "$TICKET" "$TARGET"; then

--- a/scaffolds/skills-templates/workflow/statuses/6-in-review.md
+++ b/scaffolds/skills-templates/workflow/statuses/6-in-review.md
@@ -5,7 +5,8 @@ entry_conditions:
   - One of:
       - Human Testing validated + non-regression tests created and pushed (`nature:user-facing` path)
       - AI Testing passed + ticket carries `nature:internal` label (skip-Human-Testing path — see SKILL.md "Nature axis")
-  - Ready to open the Pull Request
+  - **An open Pull Request exists for the ticket** (PR-existence guard — `In Review` without a PR is rejected by the CLI)
+  - Ticket is **not** `nature:bundled-pr` — those go AI Testing → Done directly (no individual PR at this Sub level)
 mandatory_actions:
   - Create the Pull Request (title + description + test plan + test list + reviewers + ticket link)
   - Move ticket to `In Review`
@@ -26,8 +27,10 @@ Code review with mandatory green CI.
 
 ## Ticket type
 
-- **Epic** — **never produces a PR**. Status is **derived** — reflects that every child Story/Task/Issue is itself in `In Review` (one open PR per child). Skip the checklist.
-- **Story / Task / Issue** — full flow below, one PR each.
+- **Epic** — **never produces a PR**. Status is **derived** — reflects that every child Story/Task/Issue is itself in `In Review` (one open PR per child) **or** has gone AI Testing → Done as a
+  `nature:bundled-pr` Sub. When an Epic uses bundled-PR Subs, the Epic itself opens **one** PR at the very end. Skip the checklist for the Epic ticket.
+- **Story / Task / Issue with its own PR** — full flow below, one PR per ticket.
+- **`nature:bundled-pr` Sub** — **never enters `In Review`**. Goes AI Testing → Done directly. The CLI rejects `update-status <ticket> "In review"` for these tickets.
 
 ## Action checklist
 

--- a/scaffolds/skills-templates/workflow/statuses/7-done.md
+++ b/scaffolds/skills-templates/workflow/statuses/7-done.md
@@ -2,17 +2,18 @@
 status: Done
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
-  - PR merged into the working branch (verified via `gh pr view <N> --json state` → `MERGED`)
-  - Code is on the target branch
-  - Tickets without a PR (Epic groupers, doc-only chores) skip the merge check
+  - One of:
+      - PR merged into the working branch (verified via `gh pr view <N> --json state` → `MERGED`) — standard path from `In Review`
+      - AI Testing passed + ticket carries `nature:bundled-pr` (skip-In-Review path — see SKILL.md "Nature axis"; no individual PR is opened at this Sub level)
+  - Tickets without a PR (Epic groupers, doc-only chores, `nature:bundled-pr` Subs) skip the merge check
 mandatory_actions:
   - Move ticket to `Done`
-  - Local branch cleanup — checkout working branch, rebase-pull, delete feature branch
-  - Rebase any other in-progress branches on the fresh working branch
+  - Local branch cleanup — checkout working branch, rebase-pull, delete feature branch (skip for `nature:bundled-pr` Subs — they share the parent Epic's branch)
+  - Rebase any other in-progress branches on the fresh working branch (after a real merge)
 exit_conditions:
   - Ticket marked `Done`
-  - Local feature branch deleted
-  - Other in-progress branches rebased
+  - Local feature branch deleted (where applicable)
+  - Other in-progress branches rebased (where applicable)
 next_status: N/A (end of cycle)
 ---
 
@@ -22,8 +23,10 @@ Finalization and cleanup after merge.
 
 ## Ticket type
 
-- **Epic** — `Done` is **derived** only when every child Story/Task/Issue is merged and closed. No branch to delete. Close the Epic issue once the last child reaches `Done`.
-- **Story / Task / Issue** — full cleanup flow below.
+- **Epic** — `Done` is **derived** only when every child Story/Task/Issue is `Done` (each child either merged its own PR or completed AI Testing as a `nature:bundled-pr` Sub). Close the Epic issue
+  once the last child reaches `Done` and, if the Epic uses bundled-PR Subs, after the Epic's own bundled PR is merged.
+- **Story / Task / Issue with its own PR** — full cleanup flow below; merge happens at the ticket level.
+- **`nature:bundled-pr` Sub** — no individual PR. Move directly to `Done` after AI Testing. Branch cleanup is owned by the parent Epic (the shared Epic branch is deleted when the Epic's PR merges).
 
 ## Action checklist
 

--- a/scaffolds/skills-templates/workflow/workflow-cli.sh
+++ b/scaffolds/skills-templates/workflow/workflow-cli.sh
@@ -244,17 +244,26 @@ check_complexity_guard() {
 }
 
 # ───────────────────────────────────────────────────────────────────────────
-# Nature guard — Human Testing optional for `nature:internal` tickets
+# Nature guard — Human Testing / In Review optional based on `nature:*`
 # ───────────────────────────────────────────────────────────────────────────
 #
-# A ticket tagged `nature:internal` may transition AI Testing → In Review
-# directly (skip Human Testing). Default behaviour (no `nature:*` label, or
-# `nature:user-facing`) requires the Human Testing step.
+# Three paths controlled by the `nature:*` label:
+#   - `nature:user-facing` (or no label) → AI Testing → Human Testing → In Review → Done
+#   - `nature:internal`                  → AI Testing → In Review → Done (skip Human Testing)
+#   - `nature:bundled-pr`                → AI Testing → Done (skip Human Testing AND In Review)
 #
-# The guard fires only on `update-status … "In Review"` when the current
-# board status is `AI Testing`. Other paths into In Review (Human Testing →
-# In Review) are unaffected. Fails open on label fetch errors (offline / auth)
-# to avoid wedging the workflow. Escape hatch: SF_WORKFLOW_BYPASS_NATURE_GUARD=1.
+# `nature:bundled-pr` is for Sub-stories of an Epic whose merge happens via the
+# Epic's single bundled PR — there is no individual PR to review at this level,
+# so In Review would always be a lie. See SKILL.md "Nature axis".
+#
+# Two firing points:
+#   - `→ In Review` from AI Testing — requires `nature:internal` (or
+#     `nature:bundled-pr` is rejected here, since bundled-pr should not enter
+#     In Review at all).
+#   - `→ Done` from AI Testing — only allowed for `nature:bundled-pr`.
+#
+# Fails open on label fetch errors (offline / auth) to avoid wedging the
+# workflow. Escape hatch: SF_WORKFLOW_BYPASS_NATURE_GUARD=1.
 
 is_in_review_target() {
   local target=$1
@@ -264,7 +273,7 @@ is_in_review_target() {
 }
 
 get_ticket_nature_label() {
-  # Prints `internal`, `user-facing`, or empty if no nature label.
+  # Prints `internal`, `user-facing`, `bundled-pr`, or empty if no nature label.
   # Returns 0 on clean fetch, 1 on fetch error.
   local ticket=$1
   local raw
@@ -278,34 +287,65 @@ check_nature_guard() {
   local target=$2
 
   [[ "${SF_WORKFLOW_BYPASS_NATURE_GUARD:-}" == "1" ]] && return 0
-  is_in_review_target "$target" || return 0
 
   local current_status
   current_status=$(get_current_status "$ticket" 2>/dev/null || true)
   local current_normalized
   current_normalized=$(echo "$current_status" | tr '[:upper:]' '[:lower:]' | awk '{$1=$1;print}')
 
-  # Only fire when coming from AI Testing — the Human Testing → In Review
-  # path is the standard route and never needs a nature label check.
+  # Only fire when coming from AI Testing — Human Testing → In Review and
+  # In Review → Done are the standard routes and need no nature check.
   [[ "$current_normalized" == "ai testing" ]] || return 0
 
   local nature
   nature=$(get_ticket_nature_label "$ticket") || return 0   # fail-open on fetch error
 
-  if [[ "$nature" == "internal" ]]; then
-    return 0
+  if is_in_review_target "$target"; then
+    if [[ "$nature" == "internal" ]]; then
+      return 0
+    fi
+    if [[ "$nature" == "bundled-pr" ]]; then
+      echo -e "${RED}✗ Ticket #${ticket} is 'nature:bundled-pr' — cannot enter 'In Review'.${NC}" >&2
+      echo "" >&2
+      echo "  Bundled-PR tickets have no individual PR (merge happens via the parent" >&2
+      echo "  Epic's single PR). They go AI Testing → Done directly." >&2
+      echo "" >&2
+      echo "  Move to Done instead:" >&2
+      echo "    .claude/skills/sf-workflow/workflow-cli.sh update-status ${ticket} Done" >&2
+      echo "" >&2
+      echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_NATURE_GUARD=1" >&2
+      return 1
+    fi
+    echo -e "${RED}✗ Ticket #${ticket} is in 'AI Testing' and lacks 'nature:internal' — cannot skip Human Testing.${NC}" >&2
+    echo "" >&2
+    echo "  Default workflow requires AI Testing → Human Testing → In Review." >&2
+    echo "  To allow skipping Human Testing, tag the ticket as internal:" >&2
+    echo "    gh issue edit ${ticket} --add-label 'nature:internal'" >&2
+    echo "" >&2
+    echo "  Use 'nature:internal' for refactors, scaffolding, internal tooling, or" >&2
+    echo "  non-terminal stories of a multi-step Epic that ship their own PR." >&2
+    echo "  Use 'nature:bundled-pr' for Subs whose PR is bundled at the Epic level." >&2
+    echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_NATURE_GUARD=1" >&2
+    return 1
   fi
 
-  echo -e "${RED}✗ Ticket #${ticket} is in 'AI Testing' and lacks 'nature:internal' — cannot skip Human Testing.${NC}" >&2
-  echo "" >&2
-  echo "  Default workflow requires AI Testing → Human Testing → In Review." >&2
-  echo "  To allow skipping Human Testing, tag the ticket as internal:" >&2
-  echo "    gh issue edit ${ticket} --add-label 'nature:internal'" >&2
-  echo "" >&2
-  echo "  Use 'nature:internal' for refactors, scaffolding, internal tooling, or" >&2
-  echo "  non-terminal stories of a multi-step Epic — see SKILL.md 'Nature axis'." >&2
-  echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_NATURE_GUARD=1" >&2
-  return 1
+  if is_done_target "$target"; then
+    if [[ "$nature" == "bundled-pr" ]]; then
+      return 0
+    fi
+    echo -e "${RED}✗ Ticket #${ticket} is in 'AI Testing' and lacks 'nature:bundled-pr' — cannot skip 'In Review'.${NC}" >&2
+    echo "" >&2
+    echo "  Default workflow goes through 'In Review' (where the PR is opened, reviewed," >&2
+    echo "  and merged). Only 'nature:bundled-pr' subs may go AI Testing → Done directly." >&2
+    echo "" >&2
+    echo "  Either open a PR and move to In Review, or tag the ticket bundled-pr:" >&2
+    echo "    gh issue edit ${ticket} --add-label 'nature:bundled-pr'" >&2
+    echo "" >&2
+    echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_NATURE_GUARD=1" >&2
+    return 1
+  fi
+
+  return 0
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -367,6 +407,54 @@ check_pr_merged_guard() {
   return 0
 }
 
+# ───────────────────────────────────────────────────────────────────────────
+# PR-existence guard — In Review requires an open PR
+# ───────────────────────────────────────────────────────────────────────────
+#
+# Entering 'In Review' means a Pull Request exists and is awaiting review.
+# Without an open PR there is nothing to review and the status is a board
+# lie. The status doc (statuses/6-in-review.md) lists "Create the PR" as a
+# mandatory entry action — this guard codifies that contract.
+#
+# Tickets tagged `nature:bundled-pr` are blocked separately by the nature
+# guard (they should not enter In Review at all). Tickets without any nature
+# label or with `nature:internal`/`nature:user-facing` need a real PR here.
+#
+# Fail-open on `gh` fetch errors (offline / auth). Escape hatch:
+# SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD=1.
+
+check_pr_existence_guard() {
+  # Returns 0 if the caller may proceed, 1 if blocked (message printed).
+  local ticket=$1
+  local target=$2
+
+  [[ "${SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD:-}" == "1" ]] && return 0
+  is_in_review_target "$target" || return 0
+
+  local pr_number
+  pr_number=$(get_open_pr_for_ticket "$ticket") || return 0   # fail-open on fetch error
+
+  if [[ -z "$pr_number" ]]; then
+    echo -e "${RED}✗ Ticket #${ticket} has no open PR — cannot transition to 'In Review'.${NC}" >&2
+    echo "" >&2
+    echo "  'In Review' means a Pull Request is open and awaiting review." >&2
+    echo "  Without a PR there is nothing to review — the status would be a board lie." >&2
+    echo "" >&2
+    echo "  Open the PR first, then move the ticket:" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh create-pr ${ticket}" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh update-status ${ticket} 'In review'" >&2
+    echo "" >&2
+    echo "  If this Sub's PR is bundled at the parent Epic level, tag it bundled-pr" >&2
+    echo "  and move to Done directly when AI Testing passes:" >&2
+    echo "    gh issue edit ${ticket} --add-label 'nature:bundled-pr'" >&2
+    echo "    .claude/skills/sf-workflow/workflow-cli.sh update-status ${ticket} Done" >&2
+    echo "" >&2
+    echo "  Escape hatch (rare): SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD=1" >&2
+    return 1
+  fi
+  return 0
+}
+
 # Function to show next status
 show_next_status() {
   local current_status=$1
@@ -377,10 +465,15 @@ show_next_status() {
     "Ready") echo "Next: In Progress" ;;
     "In Progress"|"In progress") echo "Next: AI Testing" ;;
     "AI Testing"|"AI testing")
-      # Nature-aware: internal tickets skip Human Testing.
+      # Nature-aware: internal tickets skip Human Testing; bundled-pr subs
+      # skip both Human Testing and In Review (PR is at the parent Epic level).
       if [[ -n "$ticket" ]]; then
         local nature
         nature=$(get_ticket_nature_label "$ticket" 2>/dev/null || true)
+        if [[ "$nature" == "bundled-pr" ]]; then
+          echo "Next: Done (nature:bundled-pr — Human Testing + In Review skipped, PR bundled at parent Epic)"
+          return
+        fi
         if [[ "$nature" == "internal" ]]; then
           echo "Next: In Review (nature:internal — Human Testing skipped)"
           return
@@ -532,6 +625,9 @@ case "$COMMAND" in
       exit 2
     fi
     if ! check_nature_guard "$TICKET" "$TARGET"; then
+      exit 2
+    fi
+    if ! check_pr_existence_guard "$TICKET" "$TARGET"; then
       exit 2
     fi
     if ! check_pr_merged_guard "$TICKET" "$TARGET"; then

--- a/src/__tests__/unit/skill/workflow-cli.pr-existence-guard.spec.ts
+++ b/src/__tests__/unit/skill/workflow-cli.pr-existence-guard.spec.ts
@@ -1,0 +1,254 @@
+import { execFile } from 'child_process'
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { promisify } from 'util'
+
+const execFileP = promisify(execFile)
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const CLI = path.resolve(REPO_ROOT, '.claude/skills/sf-workflow/workflow-cli.sh')
+const BASH = '/bin/bash'
+
+// The PR-existence guard blocks `update-status N "In review"` when no open PR
+// is found for the ticket. `In Review` without a PR is a board lie: the entry
+// condition for that status (per statuses/6-in-review.md) is "Create the PR".
+// We codified the rule in the CLI itself because the agent kept moving Subs
+// to In Review when their PR was bundled at the parent Epic level — surfaced
+// by the user as "j'ai l'impression du demande souvent de review des ticket
+// sans PR associé".
+
+interface SandboxOptions {
+  ghExitCode?: number
+  natureLabel?: 'internal' | 'user-facing' | 'bundled-pr' | null
+  currentStatus?: string
+}
+
+async function buildSandbox(
+  prListPayload: string,
+  options: SandboxOptions = {}
+): Promise<{
+  dir: string
+  env: NodeJS.ProcessEnv
+  toolLogPath: string
+  ghLogPath: string
+  cleanup: () => Promise<void>
+}> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sf-wfcli-prexist-'))
+  const toolDir = path.join(dir, '.claude/skills/sf-tool-github-projects')
+  const binDir = path.join(dir, 'bin')
+  const toolLogPath = path.join(dir, 'tool-calls.log')
+  const ghLogPath = path.join(dir, 'gh-calls.log')
+  await mkdir(toolDir, { recursive: true })
+  await mkdir(binDir, { recursive: true })
+
+  await writeFile(
+    path.join(dir, '.saasfoundry.json'),
+    JSON.stringify({
+      workflow: {
+        tool: 'github-projects',
+        projectUrl: 'https://github.com/orgs/FakeOrg/projects/42',
+        workingBranch: 'develop'
+      }
+    })
+  )
+
+  // Tool CLI shim — emits a complexity label (so complexity guard never trips)
+  // plus an optional nature label (so we can probe the nature × pr-existence
+  // interaction). `status` returns the simulated current board status.
+  const labels = ['complexity: low']
+  if (options.natureLabel) labels.push(`nature:${options.natureLabel}`)
+  const labelsBlock = labels.map((l) => `printf '%s\\n' '${l}'`).join('\n    ')
+  const currentStatus = options.currentStatus ?? 'AI Testing'
+
+  const toolShim = `#!/bin/bash
+printf '%s\\n' "$*" >> '${toolLogPath}'
+case "$1" in
+  get-labels)
+    ${labelsBlock}
+    ;;
+  status)
+    printf 'Status: %s\\n' "${currentStatus}"
+    ;;
+  update-status)
+    echo "✓ Ticket #$2 → $3"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+  const toolPath = path.join(toolDir, 'github-projects-cli.sh')
+  writeFileSync(toolPath, toolShim)
+  chmodSync(toolPath, 0o755)
+
+  const exitCode = options.ghExitCode ?? 0
+  const escaped = prListPayload.replace(/'/g, "'\\''")
+  const ghShim = `#!/bin/bash
+printf '%s\\n' "$*" >> '${ghLogPath}'
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  if [ "${exitCode}" -ne 0 ]; then
+    echo "gh: simulated failure" >&2
+    exit ${exitCode}
+  fi
+  printf '%s' '${escaped}'
+  exit 0
+fi
+exit 0
+`
+  const ghPath = path.join(binDir, 'gh')
+  writeFileSync(ghPath, ghShim)
+  chmodSync(ghPath, 0o755)
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PWD: dir,
+    PATH: `${binDir}:${process.env.PATH ?? ''}`
+  }
+  return { dir, env, toolLogPath, ghLogPath, cleanup: () => rm(dir, { recursive: true, force: true }) }
+}
+
+async function runCli(args: string[], sandbox: { dir: string; env: NodeJS.ProcessEnv }, envOverrides: NodeJS.ProcessEnv = {}) {
+  try {
+    const { stdout, stderr } = await execFileP(BASH, [CLI, ...args], {
+      cwd: sandbox.dir,
+      env: { ...sandbox.env, ...envOverrides }
+    })
+    return { stdout, stderr, code: 0 }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; code?: number }
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: typeof e.code === 'number' ? e.code : 1 }
+  }
+}
+
+function readLog(logPath: string): string[] {
+  try {
+    return readFileSync(logPath, 'utf8').split('\n').filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+describe('sf-workflow CLI — PR-existence guard (→ In Review)', () => {
+  let sandbox: Awaited<ReturnType<typeof buildSandbox>>
+
+  afterEach(async () => {
+    if (sandbox) await sandbox.cleanup()
+  })
+
+  it('blocks "In review" when no open PR matches the ticket branch', async () => {
+    sandbox = await buildSandbox('[{"number":999,"headRefName":"feature/77-other-ticket"}]', { natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'In review'], sandbox)
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain('has no open PR')
+    expect(res.stderr).toContain("cannot transition to 'In Review'")
+    expect(res.stderr).toContain('SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD=1')
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toEqual([])
+  })
+
+  it('blocks "In review" when the open-PR list is empty', async () => {
+    sandbox = await buildSandbox('[]', { natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'In review'], sandbox)
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain('has no open PR')
+  })
+
+  it('allows "In review" when a matching open PR exists (feature/<N>-…)', async () => {
+    sandbox = await buildSandbox('[{"number":555,"headRefName":"feature/42-add-stuff"}]', { natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'In review'], sandbox)
+    expect(res.code).toBe(0)
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toHaveLength(1)
+  })
+
+  it('allows "In review" when a matching open PR exists (fix/<N>-…)', async () => {
+    sandbox = await buildSandbox('[{"number":556,"headRefName":"fix/42-broken"}]', { natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'In review'], sandbox)
+    expect(res.code).toBe(0)
+  })
+
+  it('does not query gh for non-In-Review targets (guard short-circuits)', async () => {
+    sandbox = await buildSandbox('[]', { natureLabel: 'internal', currentStatus: 'Backlog' })
+    const res = await runCli(['update-status', '42', 'Ready'], sandbox)
+    expect(res.code).toBe(0)
+    const ghCalls = readLog(sandbox.ghLogPath)
+    expect(ghCalls.find((l) => l.startsWith('pr list'))).toBeUndefined()
+  })
+
+  it('matches case-insensitively: "in review" is treated as In Review', async () => {
+    sandbox = await buildSandbox('[]', { natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'in review'], sandbox)
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain('has no open PR')
+  })
+
+  it('bypasses the guard when SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD=1', async () => {
+    sandbox = await buildSandbox('[]', { natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'In review'], sandbox, { SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD: '1' })
+    expect(res.code).toBe(0)
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toHaveLength(1)
+  })
+
+  it('fails open when gh errors (offline / auth issue) — better to allow than to wedge', async () => {
+    sandbox = await buildSandbox('', { ghExitCode: 1, natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'In review'], sandbox)
+    expect(res.code).toBe(0)
+  })
+
+  it('does not match a different ticket whose number is a prefix (4 vs 42)', async () => {
+    sandbox = await buildSandbox('[{"number":888,"headRefName":"feature/420-other"}]', { natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'In review'], sandbox)
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain('has no open PR')
+  })
+})
+
+describe('sf-workflow CLI — bundled-PR path (AI Testing → Done)', () => {
+  let sandbox: Awaited<ReturnType<typeof buildSandbox>>
+
+  afterEach(async () => {
+    if (sandbox) await sandbox.cleanup()
+  })
+
+  it('allows AI Testing → Done when ticket carries nature:bundled-pr', async () => {
+    sandbox = await buildSandbox('[]', { natureLabel: 'bundled-pr' })
+    const res = await runCli(['update-status', '42', 'Done'], sandbox)
+    expect(res.code).toBe(0)
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toHaveLength(1)
+  })
+
+  it('blocks AI Testing → Done when ticket lacks nature:bundled-pr', async () => {
+    sandbox = await buildSandbox('[]', { natureLabel: 'internal' })
+    const res = await runCli(['update-status', '42', 'Done'], sandbox)
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain("lacks 'nature:bundled-pr'")
+    expect(res.stderr).toContain("cannot skip 'In Review'")
+  })
+
+  it('blocks AI Testing → Done when ticket has no nature label', async () => {
+    sandbox = await buildSandbox('[]', { natureLabel: null })
+    const res = await runCli(['update-status', '42', 'Done'], sandbox)
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain("lacks 'nature:bundled-pr'")
+  })
+
+  it('blocks bundled-pr ticket from entering In Review (must go to Done directly)', async () => {
+    sandbox = await buildSandbox('[{"number":555,"headRefName":"feature/42-stuff"}]', { natureLabel: 'bundled-pr' })
+    const res = await runCli(['update-status', '42', 'In review'], sandbox)
+    expect(res.code).toBe(2)
+    expect(res.stderr).toContain("'nature:bundled-pr'")
+    expect(res.stderr).toContain("cannot enter 'In Review'")
+  })
+
+  it('does not block In Review → Done (regression — only AI Testing → Done is gated by nature)', async () => {
+    sandbox = await buildSandbox('[]', { natureLabel: 'internal', currentStatus: 'In Review' })
+    const res = await runCli(['update-status', '42', 'Done'], sandbox)
+    expect(res.code).toBe(0)
+    const toolCalls = readLog(sandbox.toolLogPath).filter((l) => l.startsWith('update-status'))
+    expect(toolCalls).toHaveLength(1)
+  })
+})

--- a/src/__tests__/unit/skill/workflow-cli.pr-merged-guard.spec.ts
+++ b/src/__tests__/unit/skill/workflow-cli.pr-merged-guard.spec.ts
@@ -158,9 +158,9 @@ describe('sf-workflow CLI — PR-merged guard', () => {
     expect(toolCalls).toHaveLength(1)
   })
 
-  it('does not query gh for non-Done targets (guard short-circuits)', async () => {
+  it('does not query gh for non-Done / non-In-Review targets (guard short-circuits)', async () => {
     sandbox = await buildSandbox('[{"number":333,"headRefName":"feature/42-do-the-thing"}]')
-    const res = await runCli(['update-status', '42', 'In review'], sandbox)
+    const res = await runCli(['update-status', '42', 'Ready'], sandbox)
     expect(res.code).toBe(0)
     const ghCalls = readLog(sandbox.ghLogPath)
     expect(ghCalls.find((l) => l.startsWith('pr list'))).toBeUndefined()


### PR DESCRIPTION
## Summary

Closes #347.

Adds two enforcement gaps that surfaced when subs of an Epic-bundled PR were being moved to **In Review** with no PR to review.

- **PR-existence guard on → In Review** — `update-status N "In review"` now rejects when no open PR matches the ticket branch (`feature/<N>-…` or `fix/<N>-…`). Bypass via `SF_WORKFLOW_BYPASS_PR_EXISTENCE_GUARD=1`.
- **`nature:bundled-pr` label** — Subs whose merge happens via the parent Epic's single bundled PR go AI Testing → Done directly (skip Human Testing **and** In Review). Nature guard on → Done from AI Testing now allows **only** `nature:bundled-pr`. Entering In Review with that label is rejected with a redirect message.
- `show_next_status` for AI Testing now: `bundled-pr → Done`, `internal → In Review`, default → `Human Testing`.
- `SKILL.md`, `statuses/6-in-review.md`, `statuses/7-done.md` document the new label, the four guards, and the bundled-PR lifecycle.

## Test plan

- [x] `npm run test:pre-commit` green (107 suites, 1275 tests)
- [x] New `workflow-cli.pr-existence-guard.spec.ts` — 14 tests covering PR-existence guard + bundled-PR path
- [x] Existing `pr-merged-guard` short-circuit test retargeted to `Ready` (since `In Review` now legitimately calls `gh pr list`)
- [x] `tool-skill-drift.spec.ts` green — `scaffolds/skills-templates/workflow/**` synced
- [x] Pre-push docker scenarios (`monorepo-minimal`, `multirepo-minimal`) green

## Notes

- This unblocks the Epic-bundled-PR flow used by #302 typed-api-client: subs #343/#344/#345/#346 are `nature:bundled-pr`, merge happens once at the Epic.
- Escape hatches preserved for offline/auth issues — guards fail open when `gh pr list` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)