### PR TITLE
[#304] Module installers + shared-packages docs (storage/email deposits, AI playbooks)

### DIFF
--- a/scaffolds/blueprints/api/CLAUDE.md
+++ b/scaffolds/blueprints/api/CLAUDE.md
@@ -65,12 +65,23 @@ module-name/
 - `@modules/*` → `src/modules/*`
 - `@common/*` → `src/common/*`
 - `@configs/*` → `src/configs/*`
+- `@shared-types/*` → `src/shared-types/*` (cross-wire TypeScript types)
+- `@shared-validation/*` → `src/shared-validation/*` (Zod schemas reused on the web side)
 - `@/*` → `src/*`
 
 ### Validation
-- **DTOs**: Use Zod schemas for runtime validation
+- **DTOs**: Use Zod schemas via `nestjs-zod`'s `createZodDto`. Schemas are factory functions defined under `src/shared-validation/` and shared with the frontend.
 - **Decorators**: `@ApiProperty()` for OpenAPI docs
 - **Transform**: Use `class-transformer` for type coercion
+
+### 📦 Shared layers (mono vs multi)
+
+This blueprint always carries vendored copies of `src/shared-types/` and `src/shared-validation/` — those are the working source the API actually compiles against. The behavior diverges by topology:
+
+- **In a monorepo** (root has `packages/shared-*`): the same files also exist canonically at `<root>/packages/shared-{types,validation}/src/`, plus a non-vendored `<root>/packages/shared-config/`. **Hand-written types/schemas live in all three places** (canonical workspace + both apps' mirrors) and the SaaSFoundry CLI's drift-guard tests block divergence. **Module-deposited types/constants** (e.g. `EmailOptions`, `STORAGE_LOGO_*`) live in the workspace only and the relevant API service is rewired to import them via `@<root-package-name>/shared-{types,config}` — **do not duplicate them into `src/shared-types/`** or you'll have two sources of truth.
+- **In multirepo** (this app stands alone, no `packages/`): only the vendored copies under `src/shared-{types,validation}/` exist; module-shared values that would live in `shared-config` on mono are **inlined** in the consumer here (e.g. `STORAGE_LOGO_MAX_BYTES` in `organization.controller.ts`, `EmailOptions` interface in `mailersend.service.ts`). Keep the inlined values stable — the SaaSFoundry CLI's docker assertions enforce that the multirepo path stays inlined.
+
+When in doubt, run `sf status --claude-friendly --no-network` to confirm topology before editing shared shapes.
 
 ### Prisma Schema
 - Multi-file schemas in `prisma/schema/`

--- a/scaffolds/blueprints/web/CLAUDE.md
+++ b/scaffolds/blueprints/web/CLAUDE.md
@@ -74,18 +74,38 @@ export function UserProfile() {
 
 ### Path Aliases
 - `@/*` → `./src/*`
+- `@shared-types/*` → `./src/shared-types/*` (cross-wire TypeScript types)
+- `@shared-validation/*` → `./src/shared-validation/*` (Zod schemas reused on the API side)
 
 ### Styling
-- **TailwindCSS** for utility classes
-- **ShadCN** for pre-built components
-- **Radix UI** for accessible primitives
+- **TailwindCSS 4** for utility classes
+- **ShadCN** primitives for the design system (`Button`, `Dialog`, `Form`, …)
+- **Radix UI** for accessible primitives (consumed through ShadCN)
 - Mobile-first responsive design
+- Theme tokens (colors, radii, animations, dark mode) live in a `theme.css` imported once in `src/index.css`
 
 ### API Integration
-- React Query hooks in `src/hooks/api/`
-- Axios for HTTP requests
-- Automatic token refresh
-- Type-safe with TypeScript
+- **Monorepo**: typed React Query hooks come from `@<root-package-name>/api-client/generated/api/<tag>/<tag>` (auto-emitted by orval from the API's OpenAPI snapshot). Hand-written hooks under `src/hooks/api/` are thin wrappers when extra logic is needed.
+- **Multirepo**: hand-written React Query hooks under `src/hooks/api/` consume a typed fetch wrapper directly.
+- Cookie-based auth with automatic refresh
+- Type-safe end-to-end via shared types + auto-generated client (mono) or shared types alone (multi)
+
+### 📦 Shared layers (mono vs multi)
+
+This blueprint always carries vendored copies of `src/shared-types/` and `src/shared-validation/` — that's the working source the web bundle compiles against. The full shared landscape diverges by topology:
+
+- **In a monorepo** (root has `packages/`):
+  - `src/shared-types/` and `src/shared-validation/` are mirrored from `<root>/packages/shared-{types,validation}/src/` — **edit hand-written files in all three places** (canonical + both apps' mirrors). The SaaSFoundry CLI's drift-guard tests block divergence.
+  - **ShadCN primitives** are not in `src/components/ui/shadcn/` — they live in the workspace package and are imported as `@<root-package-name>/ui-primitives/<name>` (see `package.json`). The Tailwind theme is pulled in via `@import "@<root-package-name>/ui-primitives/theme.css"` in `src/index.css`. App-specific compositions (logos, page-loaders, business widgets) stay under `src/components/`.
+  - **Typed API client**: `@<root-package-name>/api-client/generated/api/<tag>/<tag>` exposes `useXxx` React Query hooks generated from the API's OpenAPI snapshot.
+  - **Module-deposited shared constants** (e.g. `STORAGE_LOGO_MAX_BYTES` in `shared-config`) — consume them via the workspace import; don't re-declare locally.
+- **In multirepo** (this app stands alone):
+  - Vendored `src/shared-{types,validation}/` are the only copies.
+  - **ShadCN primitives** live in `src/components/ui/shadcn/` (vendored from the same canonical source as the mono `ui-primitives` package — drift-guarded by the CLI).
+  - No generated API client — hand-write React Query hooks under `src/hooks/api/`.
+  - Module-shared values (storage MIME list, email envelope, …) are inlined per side; keep them stable — the SaaSFoundry CLI's docker assertions enforce the inlined shape.
+
+Run `sf status --claude-friendly --no-network` to confirm topology before changing shared shapes.
 
 ## Git Workflow
 

--- a/scaffolds/overlays/monorepo/root/CLAUDE.md
+++ b/scaffolds/overlays/monorepo/root/CLAUDE.md
@@ -24,24 +24,55 @@ This is a **Turborepo monorepo** with centralized tooling and shared skills.
 │   │   └── CLAUDE.md     # API-specific context
 │   └── web/              # React frontend
 │       └── CLAUDE.md     # Web-specific context
-├── packages/             # Shared packages (consumed by both apps/api and apps/web)
-│   ├── shared-types/     # Pure TypeScript types + z.infer outputs
-│   ├── shared-validation/ # Zod schemas (signup, signin, org CRUD, …)
-│   └── shared-config/    # Runtime constants (routes, flags, locales, …)
+├── packages/             # Shared workspaces consumed by apps/api and apps/web
+│   ├── shared-types/     # TypeScript types (User, Organization, RBAC, …)
+│   ├── shared-validation/# Zod schemas (signup, signin, org CRUD, …)
+│   ├── shared-config/    # Runtime constants (MIME lists, size thresholds, …)
+│   ├── ui-primitives/    # Headless ShadCN/Radix + Tailwind v4 theme tokens
+│   └── api-client/       # Auto-generated typed React Query hooks (via orval)
 ├── turbo.json            # Turborepo configuration
 └── package.json          # Root workspace configuration
 ```
 
 ### 📦 Shared packages — the no-drift contract
 
-`packages/shared-*` is the single source of truth for code that must be identical on both sides of the wire. Each package is a private npm workspace published under `@{{PROJECT_NAME}}/shared-*`:
+`packages/*` is the single source of truth for code that must be identical on both sides of the wire. Each package is a private npm workspace published under `@{{PROJECT_NAME}}/<name>`. **Read each package's `README.md` for the full "what goes in / what does not" rules** — the summary below is just the AI-orientation map.
 
-- **`@{{PROJECT_NAME}}/shared-types`** — Pure TypeScript types and `z.infer` outputs reused by `apps/api` (DTO types) and `apps/web` (props, hook responses).
-- **`@{{PROJECT_NAME}}/shared-validation`** — Zod schemas consumed by NestJS DTOs (via the chosen Zod-Nest bridge) and React Hook Form (`zodResolver`). Define a schema once; both sides validate identically.
-- **`@{{PROJECT_NAME}}/shared-config`** — Runtime constants (public route segments, feature flag defaults, supported locales, validation thresholds) that both apps reference.
-- **`@{{PROJECT_NAME}}/ui-primitives`** — Headless ShadCN/Radix primitives, Tailwind v4 theme tokens, the `cn()` helper, and shared UI hooks (`useIsMobile`). `apps/web` (and any future second frontend) consumes them via `@{{PROJECT_NAME}}/ui-primitives/<name>`. Theme tokens are imported once via `@import "@{{PROJECT_NAME}}/ui-primitives/theme.css"` in the app's root stylesheet.
+| Package                                | Purpose                                                            | Distribution                            | Build artifact         |
+| -------------------------------------- | ------------------------------------------------------------------ | --------------------------------------- | ---------------------- |
+| `@{{PROJECT_NAME}}/shared-types`       | Cross-wire TypeScript types + `z.infer` outputs                    | dist (`tsc`) + vendored mirror per app  | `dist/index.{js,d.ts}` |
+| `@{{PROJECT_NAME}}/shared-validation`  | Zod schemas for both NestJS DTOs and React Hook Form               | dist (`tsc`) + vendored mirror per app  | `dist/index.{js,d.ts}` |
+| `@{{PROJECT_NAME}}/shared-config`      | Runtime constants (MIME lists, size thresholds, public routes, …)  | dist (`tsc`), mono-only (no mirror)     | `dist/index.{js,d.ts}` |
+| `@{{PROJECT_NAME}}/ui-primitives`      | Headless ShadCN/Radix + Tailwind v4 theme tokens                   | source-only (`.tsx` via `exports`)      | none — Vite reads src  |
+| `@{{PROJECT_NAME}}/api-client`         | Auto-generated typed React Query hooks (orval from `apps/api` OAS) | source-only (`.ts` via `exports`)       | none — Vite reads src  |
 
-Module resolution goes through npm workspaces — each package is symlinked into the root `node_modules/@{{PROJECT_NAME}}/shared-*` and consumed via its compiled `dist/` (set as the package's `main`/`types`). Build order is handled by Turborepo (`build` depends on `^build`), so `npm run build` always rebuilds shared packages first. After editing a shared package's source, run `npm run build` (or rely on CI) before the change is picked up by `apps/api` or `apps/web`. Each package ships its own README with the "what goes in / what does not" rules.
+**Module resolution.** Each package is symlinked into the root `node_modules/@{{PROJECT_NAME}}/<name>`. `dist`-based packages need an `npm run build` before consumers see source edits — Turborepo's `build → ^build` topology takes care of that automatically. Source-only packages are picked up immediately by the consumer's bundler (Vite reads `.tsx` directly, TypeScript resolves the `exports` field).
+
+### 🧠 Decision matrix — where does new code go?
+
+When adding a new symbol, ask in order:
+
+1. **Is it a runtime constant or threshold both apps must agree on?** → `packages/shared-config`.
+2. **Is it a Zod schema validated identically on both sides?** → `packages/shared-validation` (factory pattern; web overrides messages with i18n, api uses defaults).
+3. **Is it a TypeScript type / interface / enum used on both sides of the wire?** → `packages/shared-types` (mirror into both blueprints if hand-written; deposit via installer if module-scoped — see "Module deposits" below).
+4. **Is it a headless UI building block (button, dialog, hook used by primitives, theme token)?** → `packages/ui-primitives`. Mirror to `apps/web/src/components/ui/shadcn/` blueprint side via the drift-guard. App-specific compositions (logos, page-loaders, business widgets) stay in `apps/web/src/components/`.
+5. **Is it a backend endpoint?** Add the controller in `apps/api`, regenerate the API client (`npm run codegen`), and consume the new typed hook from `@{{PROJECT_NAME}}/api-client/generated/api/<tag>/<tag>` in `apps/web`.
+6. **Otherwise** → it's app-specific and stays under the relevant `apps/<app>/src/`.
+
+### 🔁 Module deposits (auto-managed shared files)
+
+When SaaSFoundry installed an optional module on this monorepo, it may have deposited a shared file directly into `packages/shared-*`. The deposits are **idempotent** (re-running `sf update` won't duplicate them) and **gated** on the module being installed:
+
+| Module    | Deposits into                              | Consumer rewired to                              |
+| --------- | ------------------------------------------ | ------------------------------------------------ |
+| storage   | `packages/shared-config/src/storage.ts`    | `apps/api/.../organization.controller.ts`        |
+| email     | `packages/shared-types/src/email.ts`       | `apps/api/.../mailersend.service.ts`             |
+
+Edit these files like any other shared file once they exist — they're just canonical seeds, not generated artifacts. **If you delete one without removing the consumer's import, the build will break** — keep the deposit ↔ consumer pair in sync.
+
+### 🛡️ Vendored mirrors — keep them in sync
+
+`shared-types` and `shared-validation` ship as a **canonical workspace package** AND as a **vendored mirror** under each app's `src/shared-{types,validation}/`. The apps actually consume the mirror via the TS alias `@shared-types/*` / `@shared-validation/*` — the workspace package is the documentation source plus the home for module-deposited types/schemas. **When you change a hand-written file, change all three copies** (canonical + each app's mirror). If you only edit one, the other side will silently keep the old shape and types will drift.
 
 ## 🎯 Skills Priority
 

--- a/scaffolds/overlays/monorepo/root/packages/shared-config/README.md
+++ b/scaffolds/overlays/monorepo/root/packages/shared-config/README.md
@@ -21,12 +21,25 @@ Some values are intrinsically the same on both sides of the wire: feature flags,
 - Validation schemas → `@{{PROJECT_NAME}}/shared-validation`
 - App-specific UI constants → keep in the consuming app
 
+## Mono-only — no vendored mirror
+
+Unlike `shared-types` / `shared-validation` (which have byte-equal vendored copies under each app's `src/shared-*`), `shared-config` exists **only in the monorepo workspace**. Multirepo apps inline the same literal values per side — see e.g. `apps/api/src/modules/organizations/controllers/organization.controller.ts` which carries the storage MIME / size literals directly when installed in multirepo. A drift-guard test (`src/__tests__/integration/...storage-installer-multirepo*.spec.ts`) makes sure the multirepo path keeps the inlined values and does not accidentally start importing from a `@{{PROJECT_NAME}}/shared-config` that isn't there.
+
+## Module installers may auto-deposit constants here
+
+When a module that ships shared runtime constants is installed via `sf new` or `sf update`, the installer **deposits a file into `src/` and rewires the consumer to import from `@{{PROJECT_NAME}}/shared-config`** — but only on monorepo. Current deposits:
+
+- **Storage module** — writes `src/storage.ts` (`STORAGE_LOGO_MAX_BYTES`, `STORAGE_LOGO_ALLOWED_MIMES`) and rewires `apps/api/.../organization.controller.ts` to consume them. Activation gate: the storage module's `// TODO storage-service-active:` markers must already be uncommented (i.e. the module is fully installed). On multirepo the same controller keeps inlined literals.
+
+These auto-managed files are idempotent — re-running `sf update` won't duplicate them — and you can edit them like any other shared file once they exist (the installer only writes the initial canonical values).
+
 ## How to add a new shared constant
 
 1. Create or extend a file under `src/` named after the domain (e.g. `src/locales.ts`).
 2. Export the constant from `src/index.ts` so consumers can `import { Foo } from '@{{PROJECT_NAME}}/shared-config'`.
 3. Use a strict `as const` literal whenever possible to keep narrow types.
-4. Update `apps/api` and/or `apps/web` to consume the constant via the path alias.
+4. Update `apps/api` and/or `apps/web` to consume the constant via the package import.
+5. **If multirepo parity matters**, also update the inlined literal in the relevant app file under `scaffolds/blueprints/{api,web}` (or the multirepo overlay) — there is no automatic mirror for `shared-config`.
 
 ## Consumption example
 

--- a/scaffolds/overlays/monorepo/root/packages/shared-types/README.md
+++ b/scaffolds/overlays/monorepo/root/packages/shared-types/README.md
@@ -36,15 +36,42 @@ So in a generated **monorepo** the package exists for two reasons:
 2. It is a real npm workspace so future shared **runtime** code (helpers, constants) can live next
    to the types without re-introducing the topology split.
 
+## Two distribution tracks
+
+There are two ways shared types reach the apps:
+
+1. **Vendored mirror (default for hand-written domain types)** — types ship in
+   each app's `src/shared-types/` and are consumed via the TS alias
+   `@shared-types/*`. The drift-guard test enforces byte-equality across the
+   canonical and the two blueprint copies. This is what the seven domain files
+   (`account.ts`, `auth.ts`, `common.ts`, `entity.ts`, `invitation.ts`,
+   `organization.ts`) use.
+
+2. **Module-deposited (mono-only)** — when an installer adds a module that
+   carries a cross-cutting type, it writes a new file directly into this
+   workspace and rewires the consumer to import from
+   `@{{PROJECT_NAME}}/shared-types`. No vendored copy exists; multirepo apps
+   keep an inlined `interface` per side. Current deposit:
+
+   - **Email module** — writes `src/email.ts` (`EmailOptions`) and rewires
+     `apps/api/.../mailersend.service.ts` to import the type. Activation gate:
+     the email module's `mailersend.service.ts` must already be installed. On
+     multirepo, `mailersend.service.ts` keeps the inlined `export interface
+     EmailOptions { ... }`. The drift-guard / multirepo parity assertions in
+     `tests/docker/assertions.ts` enforce both behaviors.
+
+   These auto-managed files are idempotent (`sf update` won't duplicate them).
+
 ## How to add a new shared type
 
 1. Create or extend a file under `src/` named after the domain (e.g. `src/user.ts`).
 2. Export it from `src/index.ts`.
-3. Mirror the changes into both `scaffolds/blueprints/api/src/shared-types/` and
+3. **Vendored track**: mirror the changes into both `scaffolds/blueprints/api/src/shared-types/` and
    `scaffolds/blueprints/web/src/shared-types/` (or run the drift test — it will tell you what's
-   out of sync).
-4. Consumers import via `import type { Foo } from '@shared-types/index'` (the alias is wired in
-   each app's `tsconfig.json` / `tsconfig.app.json` / `vite.config.ts`).
+   out of sync). Consumers then import via `@shared-types/index`.
+4. **Module-deposit track**: extend the module's installer (`src/installers/<module>.installer.ts`)
+   with a deposit function gated on the module's activation marker. The consumer should keep an
+   inlined fallback for multirepo, and the installer rewires it to the package import on monorepo.
 
 ## Consumption example
 

--- a/src/__tests__/e2e/update-command.spec.ts
+++ b/src/__tests__/e2e/update-command.spec.ts
@@ -112,6 +112,8 @@ describe('update command logic (E2E)', () => {
       const { installEmailModule } = await import('../../installers/email.installer')
       await installEmailModule({
         apiPath: 'apps/existing-project-api',
+        isMonorepo: false,
+        projectName: 'existing-project',
         mailersendApiKey: 'ms-update-key',
         mailersendSenderEmail: 'noreply@updated.com',
         mailersendSenderName: 'Updated'

--- a/src/__tests__/integration/installers/email.installer.spec.ts
+++ b/src/__tests__/integration/installers/email.installer.spec.ts
@@ -26,6 +26,8 @@ describe('installEmailModule (integration)', () => {
   it('should copy MailerSend service file', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'test-key-123',
       mailersendSenderEmail: 'noreply@test.com',
       mailersendSenderName: 'TestApp'
@@ -37,6 +39,8 @@ describe('installEmailModule (integration)', () => {
   it('should uncomment mailer-service-active markers in auth.service.ts', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'test-key-123',
       mailersendSenderEmail: 'noreply@test.com',
       mailersendSenderName: 'TestApp'
@@ -48,6 +52,8 @@ describe('installEmailModule (integration)', () => {
   it('should uncomment mailer-service-active markers in invitation.service.ts', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'test-key-123',
       mailersendSenderEmail: 'noreply@test.com',
       mailersendSenderName: 'TestApp'
@@ -59,6 +65,8 @@ describe('installEmailModule (integration)', () => {
   it('should uncomment mailer-service-active markers in env.service.ts', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'test-key-123',
       mailersendSenderEmail: 'noreply@test.com',
       mailersendSenderName: 'TestApp'
@@ -70,6 +78,8 @@ describe('installEmailModule (integration)', () => {
   it('should uncomment code in email.service.ts and remove console.logs', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'test-key-123',
       mailersendSenderEmail: 'noreply@test.com',
       mailersendSenderName: 'TestApp'
@@ -85,6 +95,8 @@ describe('installEmailModule (integration)', () => {
   it('should add MailerSendService to email.module.ts providers', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'test-key-123',
       mailersendSenderEmail: 'noreply@test.com',
       mailersendSenderName: 'TestApp'
@@ -99,6 +111,8 @@ describe('installEmailModule (integration)', () => {
   it('should rename disabled spec file to active spec file', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'test-key-123',
       mailersendSenderEmail: 'noreply@test.com',
       mailersendSenderName: 'TestApp'
@@ -110,6 +124,8 @@ describe('installEmailModule (integration)', () => {
   it('should update .env with MailerSend credentials', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'ms_test_key_abc123',
       mailersendSenderEmail: 'hello@myapp.com',
       mailersendSenderName: 'MyApp'
@@ -123,6 +139,8 @@ describe('installEmailModule (integration)', () => {
   it('should update .env.test with test credentials', async () => {
     await installEmailModule({
       apiPath,
+      isMonorepo: false,
+      projectName: 'test-project',
       mailersendApiKey: 'ms_test_key_abc123',
       mailersendSenderEmail: 'hello@myapp.com',
       mailersendSenderName: 'MyApp'
@@ -144,6 +162,8 @@ describe('installEmailModule (integration)', () => {
       // Only test if it exists
       await installEmailModule({
         apiPath,
+        isMonorepo: false,
+        projectName: 'test-project',
         mailersendApiKey: 'test-key',
         mailersendSenderEmail: 'noreply@test.com',
         mailersendSenderName: 'Test'

--- a/src/builders/api.builder.ts
+++ b/src/builders/api.builder.ts
@@ -113,6 +113,8 @@ export async function createApiApp({
   if (emailService === 'mailersend') {
     await installEmailModule({
       apiPath,
+      isMonorepo,
+      projectName,
       mailersendApiKey: mailersendApiKey || '',
       mailersendSenderEmail: mailersendSenderEmail || '',
       mailersendSenderName: mailersendSenderName || ''

--- a/src/builders/monorepo.builder.ts
+++ b/src/builders/monorepo.builder.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 import { exec } from 'shelljs'
 
+import { depositStorageSharedConfig } from '../installers/storage.installer'
 import { installToolSkill } from '../installers/tool-skill.installer'
 import { installWorkflowSkill } from '../installers/workflow-skill.installer'
 import { CreateMonorepoRootParams, overlaysPath } from '../types'
@@ -68,6 +69,14 @@ export async function createMonorepoRoot({ projectName, projectDescription, mono
     content = content.replace(/saasfoundry-api/g, `${projectName}-api`)
     await writeFile(deployWebPath, content)
   }
+
+  // Replay shared-config deposits for any module the API installer activated
+  // before the workspace existed. `installStorageModule` runs during
+  // `createApiApp` (i.e. before this builder lays down `packages/shared-config/`),
+  // so its mono-only deposit is a no-op the first time. The deposit fn is
+  // idempotent + gated on activation markers, so calling it here covers
+  // `sf new`, `sf update`, and the docker harness uniformly.
+  await depositStorageSharedConfig({ apiPath: 'apps/api', projectName })
 
   // Install all dependencies at root (npm workspaces hoists everything)
   await exec(`${nvm}npm install > /dev/null 2>&1`)

--- a/src/builders/monorepo.builder.ts
+++ b/src/builders/monorepo.builder.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 import { exec } from 'shelljs'
 
+import { depositEmailSharedTypes } from '../installers/email.installer'
 import { depositStorageSharedConfig } from '../installers/storage.installer'
 import { installToolSkill } from '../installers/tool-skill.installer'
 import { installWorkflowSkill } from '../installers/workflow-skill.installer'
@@ -70,13 +71,15 @@ export async function createMonorepoRoot({ projectName, projectDescription, mono
     await writeFile(deployWebPath, content)
   }
 
-  // Replay shared-config deposits for any module the API installer activated
-  // before the workspace existed. `installStorageModule` runs during
-  // `createApiApp` (i.e. before this builder lays down `packages/shared-config/`),
-  // so its mono-only deposit is a no-op the first time. The deposit fn is
-  // idempotent + gated on activation markers, so calling it here covers
+  // Replay shared-config / shared-types deposits for any module the API
+  // installer activated before the workspace existed. `installStorageModule`
+  // and `installEmailModule` run during `createApiApp` (i.e. before this
+  // builder lays down `packages/shared-config/` and `packages/shared-types/`),
+  // so their mono-only deposits are no-ops the first time. The deposit fns are
+  // idempotent + gated on activation markers, so calling them here covers
   // `sf new`, `sf update`, and the docker harness uniformly.
   await depositStorageSharedConfig({ apiPath: 'apps/api', projectName })
+  await depositEmailSharedTypes({ apiPath: 'apps/api', projectName })
 
   // Install all dependencies at root (npm workspaces hoists everything)
   await exec(`${nvm}npm install > /dev/null 2>&1`)

--- a/src/catalogue/modules.ts
+++ b/src/catalogue/modules.ts
@@ -55,7 +55,8 @@ export const CATALOGUE: ModuleDefinition[] = [
       'apps/api/src/configs/env/services/env.service.ts',
       'apps/api/.env',
       'apps/api/.env.test',
-      'apps/api/deployment.yml'
+      'apps/api/deployment.yml',
+      'packages/shared-types/src/email.ts (monorepo only)'
     ],
     dependencies: ['mailersend']
   },

--- a/src/catalogue/modules.ts
+++ b/src/catalogue/modules.ts
@@ -77,7 +77,8 @@ export const CATALOGUE: ModuleDefinition[] = [
       'apps/api/.env',
       'apps/api/.env.test',
       'apps/web/.env',
-      'docker-compose.dev-services.yml'
+      'docker-compose.dev-services.yml',
+      'packages/shared-config/src/storage.ts (monorepo only)'
     ],
     dependencies: ['@aws-sdk/client-s3', '@types/multer']
   },

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -591,6 +591,8 @@ export async function updateCommand(opts: UpdateCommandOptions = {}) {
       moduleSpinner.text = 'Installing MailerSend email module...'
       await installEmailModule({
         apiPath,
+        isMonorepo,
+        projectName: manifest.projectName,
         mailersendApiKey: emailCredentials.mailersendApiKey,
         mailersendSenderEmail: emailCredentials.mailersendSenderEmail,
         mailersendSenderName: emailCredentials.mailersendSenderName

--- a/src/installers/email.installer.ts
+++ b/src/installers/email.installer.ts
@@ -1,4 +1,5 @@
 import { copy } from 'fs-extra'
+import { existsSync } from 'fs'
 import { readFile, rename, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 
@@ -7,6 +8,8 @@ import { fileExists } from '../utils'
 
 interface InstallEmailModuleParams {
   apiPath: string
+  isMonorepo: boolean
+  projectName: string
   mailersendApiKey: string
   mailersendSenderEmail: string
   mailersendSenderName: string
@@ -23,10 +26,14 @@ interface InstallEmailModuleParams {
  * 5. Updates .env with MailerSend credentials
  * 6. Updates .env.test with test credentials
  * 7. Updates deployment.yml with MailerSend env vars (if file exists)
+ * 8. (Mono only) Deposits `EmailOptions` in `packages/shared-types` and rewires
+ *    the MailerSend service to consume it — gated on the workspace's presence
+ *    (no-op early in `sf new`; replayed by `createMonorepoRoot` after the root
+ *    overlay runs).
  *
  * Used by both `sf new` (during initial project generation) and `sf update` (when adding the module later).
  */
-export async function installEmailModule({ apiPath, mailersendApiKey, mailersendSenderEmail, mailersendSenderName }: InstallEmailModuleParams) {
+export async function installEmailModule({ apiPath, isMonorepo, projectName, mailersendApiKey, mailersendSenderEmail, mailersendSenderName }: InstallEmailModuleParams) {
   // Copy MailerSend service to the API email services directory
   const mailerSendServicePath = resolve(overlaysPath, 'modules/email/services/mailersend.service.ts')
   const apiServicesPath = `${apiPath}/src/modules/email/services`
@@ -105,5 +112,77 @@ export async function installEmailModule({ apiPath, mailersendApiKey, mailersend
       .replace(/# MAILERSEND_SENDER_EMAIL=.*$/m, `MAILERSEND_SENDER_EMAIL=\\"${mailersendSenderEmail}\\"`)
       .replace(/# MAILERSEND_SENDER_NAME=.*$/m, `MAILERSEND_SENDER_NAME=\\"${mailersendSenderName}\\"`)
     await writeFile(deploymentYmlPath, deploymentYmlContent)
+  }
+
+  // Mono-only: deposit `EmailOptions` into @<proj>/shared-types and rewire the
+  // MailerSend service to consume it. Gated on the workspace's presence: in
+  // `sf new` mono flow, `createApiApp` runs BEFORE `createMonorepoRoot` lays
+  // down `packages/shared-types/`, so this is a no-op the first time.
+  // `createMonorepoRoot` calls `depositEmailSharedTypes` again after the root
+  // overlay runs. In `sf update` the workspace already exists, so it deposits
+  // in one pass.
+  if (isMonorepo) {
+    await depositEmailSharedTypes({ apiPath, projectName })
+  }
+}
+
+interface DepositEmailSharedTypesParams {
+  apiPath: string
+  projectName: string
+}
+
+/**
+ * Idempotent deposit of the `EmailOptions` send-envelope type into the
+ * monorepo shared-types workspace + MailerSend service rewire to consume it.
+ *
+ * No-ops when:
+ * - `packages/shared-types/src/` doesn't exist (mono root not yet created)
+ * - `mailersend.service.ts` doesn't exist (email module hasn't been installed
+ *   — the file is copied into place by `installEmailModule`, so its presence
+ *   is the activation gate)
+ *
+ * Multirepo never calls this — it keeps the inlined interface per side.
+ */
+export async function depositEmailSharedTypes({ apiPath, projectName }: DepositEmailSharedTypesParams): Promise<void> {
+  const monorepoRoot = resolve(apiPath, '..', '..')
+  const sharedTypesDir = `${monorepoRoot}/packages/shared-types/src`
+  if (!existsSync(sharedTypesDir)) return
+
+  // Mailer activation gate — only deposit when the email module has been
+  // installed (mailersend.service.ts copied in). Otherwise the shared-types
+  // workspace would carry a dangling `email.ts` even on email-less projects.
+  const mailerServicePath = `${apiPath}/src/modules/email/services/mailersend.service.ts`
+  if (!existsSync(mailerServicePath)) return
+
+  const emailTypeFile = `${sharedTypesDir}/email.ts`
+  await writeFile(
+    emailTypeFile,
+    [
+      '/**',
+      ' * Email send envelope — shared by apps/api (MailerSend wrapper) and any',
+      ' * future apps/web preview/validation. Multirepo equivalents are inlined per',
+      ' * side.',
+      ' */',
+      'export interface EmailOptions {',
+      '  to: string',
+      '  subject: string',
+      '  html: string',
+      '  text?: string',
+      '}',
+      ''
+    ].join('\n')
+  )
+
+  const indexPath = `${sharedTypesDir}/index.ts`
+  const indexContent = await readFile(indexPath, 'utf8')
+  if (!indexContent.includes("from './email'")) {
+    await writeFile(indexPath, `${indexContent.replace(/\s*$/, '')}\nexport * from './email'\n`)
+  }
+
+  let mailerServiceContent = await readFile(mailerServicePath, 'utf8')
+  const inlineInterface = `export interface EmailOptions {\n  to: string\n  subject: string\n  html: string\n  text?: string\n}`
+  if (mailerServiceContent.includes(inlineInterface)) {
+    mailerServiceContent = mailerServiceContent.replace(inlineInterface, `import type { EmailOptions } from '@${projectName}/shared-types'\nexport type { EmailOptions }`)
+    await writeFile(mailerServicePath, mailerServiceContent)
   }
 }

--- a/src/installers/storage.installer.ts
+++ b/src/installers/storage.installer.ts
@@ -1,4 +1,5 @@
 import { copy } from 'fs-extra'
+import { existsSync } from 'fs'
 import { readFile, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 import { exec } from 'shelljs'
@@ -26,6 +27,10 @@ interface InstallStorageModuleParams {
  * 4. Uncomments `// TODO storage-service-active:` markers in env.service, app.module, org module/controller/service
  * 5. Updates API .env and .env.test with S3 credentials
  * 6. Sets VITE_STORAGE_ENABLED=true in web .env
+ * 7. (Mono only) Deposits MIME/size constants in `packages/shared-config` and
+ *    rewires the org controller to consume them — gated on the workspace's
+ *    presence (no-op early in `sf new`; replayed by `new.ts` after
+ *    `createMonorepoRoot`).
  *
  * Used by both `sf new` (during initial project generation) and `sf update` (when adding the module later).
  */
@@ -118,4 +123,74 @@ export async function installStorageModule({ apiPath, webPath, isMonorepo, proje
     webEnvContent = webEnvContent.replace(/VITE_STORAGE_ENABLED=.*$/m, 'VITE_STORAGE_ENABLED="true"')
     await writeFile(webEnvPath, webEnvContent)
   }
+
+  // Mono-only: deposit MIME/size constants into @<proj>/shared-config and
+  // rewire the controller. Gated on the workspace's presence: in `sf new` mono
+  // flow, `createApiApp` runs BEFORE `createMonorepoRoot` lays down
+  // `packages/shared-config/`, so this is a no-op the first time. `new.ts`
+  // calls `depositStorageSharedConfig` again after the root overlay runs.
+  // In `sf update` the workspace already exists, so it deposits in one pass.
+  if (isMonorepo) {
+    await depositStorageSharedConfig({ apiPath, projectName })
+  }
+}
+
+interface DepositStorageSharedConfigParams {
+  apiPath: string
+  projectName: string
+}
+
+/**
+ * Idempotent deposit of `STORAGE_LOGO_*` constants into the monorepo
+ * shared-config workspace + controller rewire to consume them.
+ *
+ * No-ops when:
+ * - `packages/shared-config/src/` doesn't exist (mono root not yet created)
+ * - the org controller still has `// TODO storage-service-active:` markers
+ *   (storage hasn't been activated yet — the rewire targets the uncommented
+ *   live code only)
+ *
+ * Multirepo never calls this — it keeps the inlined literals per side.
+ */
+export async function depositStorageSharedConfig({ apiPath, projectName }: DepositStorageSharedConfigParams): Promise<void> {
+  const monorepoRoot = resolve(apiPath, '..', '..')
+  const sharedConfigDir = `${monorepoRoot}/packages/shared-config/src`
+  if (!existsSync(sharedConfigDir)) return
+
+  // Storage activation gate — only deposit when the storage module has been
+  // installed (markers uncommented). Otherwise the shared-config workspace
+  // would carry a dangling `storage.ts` even on storage-less projects.
+  const orgControllerPath = `${apiPath}/src/modules/organizations/controllers/organization.controller.ts`
+  if (!existsSync(orgControllerPath)) return
+  let orgControllerContent = await readFile(orgControllerPath, 'utf8')
+  if (orgControllerContent.includes('// TODO storage-service-active:')) return
+
+  const storageFile = `${sharedConfigDir}/storage.ts`
+  await writeFile(
+    storageFile,
+    [
+      '/**',
+      ' * Logo upload contract — shared by apps/api (FileInterceptor) and any future',
+      ' * apps/web preview/validation. Multirepo equivalents are inlined per side.',
+      ' */',
+      'export const STORAGE_LOGO_MAX_BYTES = 5 * 1024 * 1024',
+      "export const STORAGE_LOGO_ALLOWED_MIMES: readonly string[] = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml']",
+      ''
+    ].join('\n')
+  )
+
+  const indexPath = `${sharedConfigDir}/index.ts`
+  const indexContent = await readFile(indexPath, 'utf8')
+  if (!indexContent.includes("from './storage'")) {
+    await writeFile(indexPath, `${indexContent.replace(/\s*$/, '')}\nexport * from './storage'\n`)
+  }
+
+  const importLine = `import { STORAGE_LOGO_ALLOWED_MIMES, STORAGE_LOGO_MAX_BYTES } from '@${projectName}/shared-config'\n`
+  if (!orgControllerContent.includes(importLine)) {
+    orgControllerContent = orgControllerContent.replace(`import { FileInterceptor } from '@nestjs/platform-express'\n`, `import { FileInterceptor } from '@nestjs/platform-express'\n${importLine}`)
+  }
+  orgControllerContent = orgControllerContent
+    .replace('fileSize: 5 * 1024 * 1024', 'fileSize: STORAGE_LOGO_MAX_BYTES')
+    .replace(`const allowedMimes = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml']`, `const allowedMimes = STORAGE_LOGO_ALLOWED_MIMES`)
+  await writeFile(orgControllerPath, orgControllerContent)
 }

--- a/tests/docker/assertions.ts
+++ b/tests/docker/assertions.ts
@@ -192,6 +192,43 @@ export function assertMonorepoUiPrimitives(projectPath: string, projectName: str
 }
 
 /**
+ * Verify storage-on-monorepo deposits MIME/size constants in shared-config and
+ * the org controller consumes them (instead of the inline literals it carries
+ * in multirepo). Mirrors the no-drift contract: a single source of truth for
+ * the upload bounds when both apps live in the same workspace.
+ */
+export function assertMonorepoStorageSharedConfig(projectPath: string, projectName: string): AssertionResult[] {
+  const results: AssertionResult[] = []
+
+  const storageFile = join(projectPath, 'packages', 'shared-config', 'src', 'storage.ts')
+  results.push(assertFileExists(storageFile))
+  results.push(assertFileContains(storageFile, 'STORAGE_LOGO_MAX_BYTES'))
+  results.push(assertFileContains(storageFile, 'STORAGE_LOGO_ALLOWED_MIMES'))
+
+  const indexFile = join(projectPath, 'packages', 'shared-config', 'src', 'index.ts')
+  results.push(assertFileContains(indexFile, `from './storage'`))
+
+  const orgController = join(projectPath, 'apps', 'api', 'src', 'modules', 'organizations', 'controllers', 'organization.controller.ts')
+  results.push(assertFileContains(orgController, `from '@${projectName}/shared-config'`))
+  results.push(assertFileContains(orgController, 'STORAGE_LOGO_MAX_BYTES'))
+  results.push(assertFileContains(orgController, 'STORAGE_LOGO_ALLOWED_MIMES'))
+  // The inlined literals are gone in monorepo (proves the rewrite happened).
+  results.push(assertFileNotContains(orgController, 'fileSize: 5 * 1024 * 1024'))
+
+  return results
+}
+
+/**
+ * Verify the multirepo storage path keeps the inlined literals (parity guard:
+ * no shared-config deposit leaks into multirepo, where the package doesn't
+ * exist).
+ */
+export function assertMultirepoStorageInlined(apiPath: string): AssertionResult[] {
+  const orgController = join(apiPath, 'src', 'modules', 'organizations', 'controllers', 'organization.controller.ts')
+  return [assertFileContains(orgController, 'fileSize: 5 * 1024 * 1024'), assertFileNotContains(orgController, '/shared-config'), assertFileNotContains(orgController, 'STORAGE_LOGO_MAX_BYTES')]
+}
+
+/**
  * Verify the multirepo web app keeps the vendored shadcn primitives in place
  * (no monorepo-only side effects leak into the multirepo topology).
  */

--- a/tests/docker/assertions.ts
+++ b/tests/docker/assertions.ts
@@ -229,6 +229,39 @@ export function assertMultirepoStorageInlined(apiPath: string): AssertionResult[
 }
 
 /**
+ * Verify email-on-monorepo deposits `EmailOptions` in shared-types and the
+ * MailerSend service consumes it (instead of declaring the inlined interface
+ * it carries in multirepo). Mirrors the storage no-drift contract.
+ */
+export function assertMonorepoEmailSharedTypes(projectPath: string, projectName: string): AssertionResult[] {
+  const results: AssertionResult[] = []
+
+  const emailFile = join(projectPath, 'packages', 'shared-types', 'src', 'email.ts')
+  results.push(assertFileExists(emailFile))
+  results.push(assertFileContains(emailFile, 'EmailOptions'))
+
+  const indexFile = join(projectPath, 'packages', 'shared-types', 'src', 'index.ts')
+  results.push(assertFileContains(indexFile, `from './email'`))
+
+  const mailerService = join(projectPath, 'apps', 'api', 'src', 'modules', 'email', 'services', 'mailersend.service.ts')
+  results.push(assertFileContains(mailerService, `from '@${projectName}/shared-types'`))
+  // The inlined interface body is gone in monorepo (proves the rewrite happened).
+  results.push(assertFileNotContains(mailerService, 'export interface EmailOptions {'))
+
+  return results
+}
+
+/**
+ * Verify the multirepo email path keeps the inlined `EmailOptions` interface
+ * (parity guard: no shared-types deposit leaks into multirepo, where the
+ * package doesn't exist).
+ */
+export function assertMultirepoEmailInlined(apiPath: string): AssertionResult[] {
+  const mailerService = join(apiPath, 'src', 'modules', 'email', 'services', 'mailersend.service.ts')
+  return [assertFileContains(mailerService, 'export interface EmailOptions {'), assertFileNotContains(mailerService, '/shared-types')]
+}
+
+/**
  * Verify the multirepo web app keeps the vendored shadcn primitives in place
  * (no monorepo-only side effects leak into the multirepo topology).
  */

--- a/tests/docker/generate-and-build.ts
+++ b/tests/docker/generate-and-build.ts
@@ -17,8 +17,10 @@ import {
   assertClaudeMdConfigured,
   assertMonorepoBuildOutput,
   assertMonorepoSharedPackages,
+  assertMonorepoEmailSharedTypes,
   assertMonorepoStorageSharedConfig,
   assertMonorepoUiPrimitives,
+  assertMultirepoEmailInlined,
   assertMultirepoStorageInlined,
   assertMultirepoUiPrimitivesUntouched,
   assertMonorepoSkills,
@@ -215,18 +217,21 @@ async function runGenerationScenario(scenario: GenerationScenario): Promise<bool
   const results: AssertionResult[] = []
 
   const storageInstalled = scenario.s3Setup !== 'manual'
+  const emailInstalled = scenario.emailService === 'mailersend'
 
   if (scenario.isMonorepo) {
     results.push(...assertMonorepoBuildOutput(projectDir))
     results.push(...assertMonorepoSharedPackages(projectDir, scenario.projectName))
     results.push(...assertMonorepoUiPrimitives(projectDir, scenario.projectName))
     if (storageInstalled) results.push(...assertMonorepoStorageSharedConfig(projectDir, scenario.projectName))
+    if (emailInstalled) results.push(...assertMonorepoEmailSharedTypes(projectDir, scenario.projectName))
   } else {
     const apiPath = join(projectDir, 'apps', `${scenario.projectName}-api`)
     results.push(...assertApiBuildOutput(apiPath))
     results.push(...assertWebBuildOutput(join(projectDir, 'apps', `${scenario.projectName}-web`)))
     results.push(...assertMultirepoUiPrimitivesUntouched(join(projectDir, 'apps', `${scenario.projectName}-web`)))
     if (storageInstalled) results.push(...assertMultirepoStorageInlined(apiPath))
+    if (emailInstalled) results.push(...assertMultirepoEmailInlined(apiPath))
   }
 
   results.push(scanForUnreplacedPlaceholders(projectDir))
@@ -261,6 +266,8 @@ async function runUpdateScenario(scenario: UpdateScenario): Promise<boolean> {
       const { installEmailModule } = await import(join(CLI_PATH, 'dist', 'installers', 'email.installer'))
       await installEmailModule({
         apiPath,
+        isMonorepo: scenario.base.isMonorepo,
+        projectName: scenario.base.projectName,
         mailersendApiKey: 'ms-test-key',
         mailersendSenderEmail: 'noreply@test.com',
         mailersendSenderName: 'Test'
@@ -315,12 +322,14 @@ async function runUpdateScenario(scenario: UpdateScenario): Promise<boolean> {
     results.push(...assertMonorepoSharedPackages(projectDir, scenario.base.projectName))
     results.push(...assertMonorepoUiPrimitives(projectDir, scenario.base.projectName))
     if (scenario.addModules.storage) results.push(...assertMonorepoStorageSharedConfig(projectDir, scenario.base.projectName))
+    if (scenario.addModules.email) results.push(...assertMonorepoEmailSharedTypes(projectDir, scenario.base.projectName))
   } else {
     const apiPath = join(projectDir, 'apps', `${scenario.base.projectName}-api`)
     results.push(...assertApiBuildOutput(apiPath))
     results.push(...assertWebBuildOutput(join(projectDir, 'apps', `${scenario.base.projectName}-web`)))
     results.push(...assertMultirepoUiPrimitivesUntouched(join(projectDir, 'apps', `${scenario.base.projectName}-web`)))
     if (scenario.addModules.storage) results.push(...assertMultirepoStorageInlined(apiPath))
+    if (scenario.addModules.email) results.push(...assertMultirepoEmailInlined(apiPath))
   }
 
   results.push(scanForUnreplacedPlaceholders(projectDir))

--- a/tests/docker/generate-and-build.ts
+++ b/tests/docker/generate-and-build.ts
@@ -17,7 +17,9 @@ import {
   assertClaudeMdConfigured,
   assertMonorepoBuildOutput,
   assertMonorepoSharedPackages,
+  assertMonorepoStorageSharedConfig,
   assertMonorepoUiPrimitives,
+  assertMultirepoStorageInlined,
   assertMultirepoUiPrimitivesUntouched,
   assertMonorepoSkills,
   assertMultirepoSkills,
@@ -212,14 +214,19 @@ async function runGenerationScenario(scenario: GenerationScenario): Promise<bool
   // Assertions
   const results: AssertionResult[] = []
 
+  const storageInstalled = scenario.s3Setup !== 'manual'
+
   if (scenario.isMonorepo) {
     results.push(...assertMonorepoBuildOutput(projectDir))
     results.push(...assertMonorepoSharedPackages(projectDir, scenario.projectName))
     results.push(...assertMonorepoUiPrimitives(projectDir, scenario.projectName))
+    if (storageInstalled) results.push(...assertMonorepoStorageSharedConfig(projectDir, scenario.projectName))
   } else {
-    results.push(...assertApiBuildOutput(join(projectDir, 'apps', `${scenario.projectName}-api`)))
+    const apiPath = join(projectDir, 'apps', `${scenario.projectName}-api`)
+    results.push(...assertApiBuildOutput(apiPath))
     results.push(...assertWebBuildOutput(join(projectDir, 'apps', `${scenario.projectName}-web`)))
     results.push(...assertMultirepoUiPrimitivesUntouched(join(projectDir, 'apps', `${scenario.projectName}-web`)))
+    if (storageInstalled) results.push(...assertMultirepoStorageInlined(apiPath))
   }
 
   results.push(scanForUnreplacedPlaceholders(projectDir))
@@ -307,10 +314,13 @@ async function runUpdateScenario(scenario: UpdateScenario): Promise<boolean> {
     results.push(...assertMonorepoBuildOutput(projectDir))
     results.push(...assertMonorepoSharedPackages(projectDir, scenario.base.projectName))
     results.push(...assertMonorepoUiPrimitives(projectDir, scenario.base.projectName))
+    if (scenario.addModules.storage) results.push(...assertMonorepoStorageSharedConfig(projectDir, scenario.base.projectName))
   } else {
-    results.push(...assertApiBuildOutput(join(projectDir, 'apps', `${scenario.base.projectName}-api`)))
+    const apiPath = join(projectDir, 'apps', `${scenario.base.projectName}-api`)
+    results.push(...assertApiBuildOutput(apiPath))
     results.push(...assertWebBuildOutput(join(projectDir, 'apps', `${scenario.base.projectName}-web`)))
     results.push(...assertMultirepoUiPrimitivesUntouched(join(projectDir, 'apps', `${scenario.base.projectName}-web`)))
+    if (scenario.addModules.storage) results.push(...assertMultirepoStorageInlined(apiPath))
   }
 
   results.push(scanForUnreplacedPlaceholders(projectDir))


### PR DESCRIPTION
Resolves #304 (parent Story under Epic #298)
Bundled-PR for subs #357, #358, #359 (`nature:bundled-pr`).

## Summary

- **#357** — Storage installer deposits MIME/size constants into `packages/shared-config/src/storage.ts` (mono only) and rewires `apps/api/.../organization.controller.ts` to consume them. Multirepo keeps inlined literals.
- **#358** — Email installer deposits `EmailOptions` into `packages/shared-types/src/email.ts` (mono only) and rewires `apps/api/.../mailersend.service.ts` to consume it. Multirepo keeps inlined `interface`.
- **#359** — README audit (`shared-config`, `shared-types`) + substantial AI playbook updates in `scaffolds/overlays/monorepo/root/CLAUDE.md` and `scaffolds/blueprints/{api,web}/CLAUDE.md` (5-package table, decision matrix, module-deposit + vendored-mirror discipline, topology-aware shared-layers section).

User-facing docs (`docs/guide/monorepo-vs-multirepo.md`, `docs/cli/sf-update.md`) intentionally split off to Epic #318.

## Architecture

Single chokepoint via `createMonorepoRoot` (`src/builders/monorepo.builder.ts`) replays both deposits idempotently after the root overlay is laid down. Covers `sf new`, `sf update`, and the docker harness uniformly. Each deposit is gated on its own activation marker (`mailersend.service.ts` presence for email; uncommented `// TODO storage-service-active:` markers for storage), so opt-out projects don't carry dangling shared files.

## Test plan

- [x] Pre-commit: `npm run test:pre-commit` — 1304/1304 jest, lint/format/types clean
- [x] Pre-push: `npm run test:pre-push` — `monorepo-minimal` + `multirepo-minimal` docker scenarios green
- [x] Targeted docker scenarios:
  - `monorepo-email-analytics` — 45/45 assertions
  - `multirepo-email-only` — 11/11 assertions
  - `update-add-email-monorepo` — 45/45 assertions
- [x] User-validated `sf new` mono + multi on sandbox project (test-four)
- [x] No `{{PROJECT_NAME}}` / `{{VERSION}}` leakage (smoke `assertNoUnreplacedPlaceholders`)
- [x] Drift-guard tests (`shared-types-drift`, `shared-validation-drift`, `ui-primitives-drift`) green
- [x] Multirepo parity assertions (`assertMultirepoEmailInlined`, storage equivalent) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)