### PR TITLE
feat(#310): manifest + module migration framework (v2.0.0 cross-version update path)

### DIFF
--- a/.claude/docs/architecture-modules.md
+++ b/.claude/docs/architecture-modules.md
@@ -63,7 +63,7 @@ Generated projects carry a `.saasfoundry.json` manifest at the project root:
   "structure": "monorepo",
   "projectName": "my-project",
   "modules": {
-    "emailService": "none",
+    "email": { "provider": "none", "version": 1 },
     "s3Setup": "manual",
     "dbSetup": "docker",
     "includeAnalytics": false

--- a/.claude/docs/migration-framework.md
+++ b/.claude/docs/migration-framework.md
@@ -1,0 +1,207 @@
+# Migration framework
+
+> Where: `src/migrations/`. Owner: anyone shipping a breaking change.
+> Status: ships in v2.0.0 (Epic #310). Closes release objective C4.
+
+SaaSFoundry runs `sf update` against projects that may be many CLI versions
+behind. Two things have to migrate together:
+
+1. **Manifest shape** — the `.saasfoundry.json` schema (e.g. renaming a field,
+   restructuring a sub-block).
+2. **Module on-disk shape** — files inside the user's project that an installer
+   originally laid down (e.g. renaming a service file, adding a new env var).
+
+Both run through the same registry pattern: a contiguous chain of numbered,
+single-step migrations the dispatcher walks until it reaches the current
+target.
+
+---
+
+## Manifest migrations
+
+**Where**: `src/migrations/manifest/NNN-<kebab-name>.ts`.
+
+**Contract** (`src/migrations/manifest/types.ts`):
+
+```ts
+export interface ManifestMigration {
+  from: number
+  to: number
+  name: string
+  up(manifest: SaaSFoundryManifest): SaaSFoundryManifest
+}
+```
+
+- `from` and `to` are monotonic; `to === from + 1`.
+- `up` is **pure** and **idempotent** — running it twice on its own output
+  must be a no-op. The dispatcher relies on this so a half-applied chain can
+  be re-run safely.
+- `up` MUST set `manifestVersion = to` on the returned manifest.
+
+### How to add one
+
+1. Find the next number: `ls src/migrations/manifest/` — the last shipped
+   migration's `to` is your new `from`.
+2. Create `NNN-<name>.ts`. Export a `migrationNNN: ManifestMigration`. Keep
+   it small — one schema concern per migration.
+3. Register it in `src/migrations/manifest/index.ts` by appending to the
+   `manifestMigrations` array. Order matters: the registry is contiguity-
+   checked at boot.
+4. Bump the JSON Schema in `schemas/saasfoundry-manifest.schema.json` so
+   IDE validation matches the new shape.
+5. Add a golden fixture pair under
+   `src/__tests__/unit/migrations/fixtures/NNN-<name>/`:
+   - `before.json` — a manifest at the `from` shape
+   - `after.json` — the same manifest after `up()` runs
+   The harness in `src/__tests__/unit/migrations/golden-fixtures.spec.ts`
+   picks them up automatically.
+6. Run `npm run test:pre-commit` to validate the chain end-to-end.
+7. Run `npm run test:docker -- --scenario migration-v0-to-current` to
+   exercise the full dispatcher inside a generated project.
+
+### Worked example — renaming a manifest field
+
+`modules.emailService` (flat enum) → `modules.email = { provider, version }`
+(versioned object). Lifting a flat enum into a versioned object also gives
+future module migrations a per-module `version` key to dispatch on.
+
+See:
+
+- Migration: `src/migrations/manifest/002-restructure-email.ts`
+- Fixtures: `src/__tests__/unit/migrations/fixtures/002-restructure-email/`
+- Schema delta: `email` block added to
+  `schemas/saasfoundry-manifest.schema.json`, `emailService` removed from
+  `required`
+- Read sites updated in lockstep:
+  `src/commands/{new,update,modules}.ts`,
+  `scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js`
+  (latter ships in generated projects — must read both shapes for
+  backward compat with un-migrated projects)
+
+The dispatcher logs `Manifest migrated: vX → vY` per run, with one line per
+applied migration. Idempotent — a second `sf update` is a no-op.
+
+---
+
+## Module migrations
+
+**Where**: declared on the installer via the `migrations: ModuleMigration[]`
+array exported from each `<name>.installer.ts` (currently empty in v2.0.0 —
+the framework is what ships).
+
+**Contract** (`src/migrations/module/types.ts`):
+
+```ts
+export interface ModuleMigration {
+  from: number
+  to: number
+  name: string
+  up(projectDir: string, manifest: SaaSFoundryManifest): Promise<void>
+}
+
+export interface ModuleInstaller {
+  name: string
+  currentVersion: number
+  migrations: ModuleMigration[]
+}
+```
+
+- Same `from`/`to`/`name` discipline as manifest migrations, but per module.
+- `up` mutates files in `projectDir`. The dispatcher (not the migration)
+  bumps `manifest.modules.<name>.version` on success.
+- Use `writeMigratedFile` from `src/migrations/module/conflict.ts` instead
+  of `fs.writeFile` so user-edited files fall back to a `.saasfoundry.new`
+  sidecar — same UX as the 3-way template merge.
+
+### How to add one
+
+1. Find the next number for the module: `installer.migrations.at(-1)?.to ?? 0`
+   is your new `from`.
+2. Add the migration to the installer file's `migrations` array (or pull
+   into a sibling file and re-export — a `migrations/NNN-<name>.ts` folder
+   per installer is fine once the chain grows).
+3. Bump the installer's `currentVersion` to match the new `to`.
+4. Register a synthetic-fixture integration test in
+   `src/__tests__/integration/commands/update.module-migrations.spec.ts`
+   if the migration touches files (the harness mocks the installer
+   registry so you can drop in a single-migration installer for the test).
+5. Run `npm run test:pre-commit`.
+
+### Worked example — splitting a service file across two files
+
+You ship `MailerSendService` originally as one file
+(`mailersend.service.ts`) and decide to split it into a thin entrypoint +
+helper module (`mailersend.service.ts` + `mailersend.helpers.ts`).
+
+```ts
+// src/installers/email.installer.ts
+export const emailInstallerMeta: ModuleInstaller = {
+  name: 'email',
+  currentVersion: 2, // bumped from 1
+  migrations: [
+    {
+      from: 1,
+      to: 2,
+      name: 'split-mailersend-helpers',
+      up: async (projectDir, manifest) => {
+        const apiPath = manifest.structure === 'monorepo' ? 'apps/api' : '.'
+        const servicePath = `${apiPath}/src/modules/email/services/mailersend.service.ts`
+        const helpersPath = `${apiPath}/src/modules/email/services/mailersend.helpers.ts`
+
+        const current = await fs.readFile(`${projectDir}/${servicePath}`, 'utf8')
+        const { trimmedService, helpers } = splitOutHelpers(current)
+
+        await writeMigratedFile(projectDir, servicePath, trimmedService, manifest)
+        await writeMigratedFile(projectDir, helpersPath, helpers, manifest)
+      }
+    }
+  ]
+}
+```
+
+If the user has hand-edited `mailersend.service.ts`, both writes land as
+`.saasfoundry.new` sidecars and the user reconciles manually. If untouched,
+the migration runs in-place and `modules.email.version` jumps to 2.
+
+---
+
+## When NOT to add a migration
+
+- **Adding a new optional field to the manifest with a sensible default** —
+  the JSON schema keeps validating older manifests; no migration needed.
+- **Pure refactor that doesn't change on-disk shape** — fixing a typo in a
+  comment, renaming a variable inside an installer that doesn't reach files
+  in the user's project.
+- **Changes only to `sf new`** — migration framework only matters for users
+  upgrading from an older CLI version. New projects start at the latest
+  shape by definition.
+
+If unsure, ask: "Will a project scaffolded one CLI version ago see a
+correctness regression after `sf update`?" If yes, you need a migration.
+
+---
+
+## Reference: registry layout
+
+```
+src/migrations/
+├── manifest/
+│   ├── 001-add-schema-url.ts
+│   ├── 002-restructure-email.ts
+│   ├── index.ts            # exports `manifestMigrations` array
+│   ├── registry.ts         # `runManifestMigrations`, `targetManifestVersion`
+│   └── types.ts            # `ManifestMigration`
+└── module/
+    ├── conflict.ts         # `writeMigratedFile` (sidecar-aware writer)
+    ├── registry.ts         # `runModuleMigrations`
+    └── types.ts            # `ModuleMigration`, `ModuleInstaller`
+
+src/installers/
+├── registry.ts             # `moduleInstallers` (single source of truth)
+└── <name>.installer.ts     # each exports `<name>InstallerMeta`
+```
+
+The two dispatchers run in order inside `src/commands/update.ts`:
+manifest first (so module migrations see the upgraded shape), modules
+second (so any subsequent template regeneration sees the post-migration
+versions).

--- a/.claude/docs/migration-framework.md
+++ b/.claude/docs/migration-framework.md
@@ -1,19 +1,13 @@
 # Migration framework
 
-> Where: `src/migrations/`. Owner: anyone shipping a breaking change.
-> Status: ships in v2.0.0 (Epic #310). Closes release objective C4.
+> Where: `src/migrations/`. Owner: anyone shipping a breaking change. Status: ships in v2.0.0 (Epic #310). Closes release objective C4.
 
-SaaSFoundry runs `sf update` against projects that may be many CLI versions
-behind. Two things have to migrate together:
+SaaSFoundry runs `sf update` against projects that may be many CLI versions behind. Two things have to migrate together:
 
-1. **Manifest shape** — the `.saasfoundry.json` schema (e.g. renaming a field,
-   restructuring a sub-block).
-2. **Module on-disk shape** — files inside the user's project that an installer
-   originally laid down (e.g. renaming a service file, adding a new env var).
+1. **Manifest shape** — the `.saasfoundry.json` schema (e.g. renaming a field, restructuring a sub-block).
+2. **Module on-disk shape** — files inside the user's project that an installer originally laid down (e.g. renaming a service file, adding a new env var).
 
-Both run through the same registry pattern: a contiguous chain of numbered,
-single-step migrations the dispatcher walks until it reaches the current
-target.
+Both run through the same registry pattern: a contiguous chain of numbered, single-step migrations the dispatcher walks until it reaches the current target.
 
 ---
 
@@ -33,61 +27,41 @@ export interface ManifestMigration {
 ```
 
 - `from` and `to` are monotonic; `to === from + 1`.
-- `up` is **pure** and **idempotent** — running it twice on its own output
-  must be a no-op. The dispatcher relies on this so a half-applied chain can
-  be re-run safely.
+- `up` is **pure** and **idempotent** — running it twice on its own output must be a no-op. The dispatcher relies on this so a half-applied chain can be re-run safely.
 - `up` MUST set `manifestVersion = to` on the returned manifest.
 
 ### How to add one
 
-1. Find the next number: `ls src/migrations/manifest/` — the last shipped
-   migration's `to` is your new `from`.
-2. Create `NNN-<name>.ts`. Export a `migrationNNN: ManifestMigration`. Keep
-   it small — one schema concern per migration.
-3. Register it in `src/migrations/manifest/index.ts` by appending to the
-   `manifestMigrations` array. Order matters: the registry is contiguity-
-   checked at boot.
-4. Bump the JSON Schema in `schemas/saasfoundry-manifest.schema.json` so
-   IDE validation matches the new shape.
-5. Add a golden fixture pair under
-   `src/__tests__/unit/migrations/fixtures/NNN-<name>/`:
+1. Find the next number: `ls src/migrations/manifest/` — the last shipped migration's `to` is your new `from`.
+2. Create `NNN-<name>.ts`. Export a `migrationNNN: ManifestMigration`. Keep it small — one schema concern per migration.
+3. Register it in `src/migrations/manifest/index.ts` by appending to the `manifestMigrations` array. Order matters: the registry is contiguity- checked at boot.
+4. Bump the JSON Schema in `schemas/saasfoundry-manifest.schema.json` so IDE validation matches the new shape.
+5. Add a golden fixture pair under `src/__tests__/unit/migrations/fixtures/NNN-<name>/`:
    - `before.json` — a manifest at the `from` shape
-   - `after.json` — the same manifest after `up()` runs
-   The harness in `src/__tests__/unit/migrations/golden-fixtures.spec.ts`
-   picks them up automatically.
+   - `after.json` — the same manifest after `up()` runs The harness in `src/__tests__/unit/migrations/golden-fixtures.spec.ts` picks them up automatically.
 6. Run `npm run test:pre-commit` to validate the chain end-to-end.
-7. Run `npm run test:docker -- --scenario migration-v0-to-current` to
-   exercise the full dispatcher inside a generated project.
+7. Run `npm run test:docker -- --scenario migration-v0-to-current` to exercise the full dispatcher inside a generated project.
 
 ### Worked example — renaming a manifest field
 
-`modules.emailService` (flat enum) → `modules.email = { provider, version }`
-(versioned object). Lifting a flat enum into a versioned object also gives
-future module migrations a per-module `version` key to dispatch on.
+`modules.emailService` (flat enum) → `modules.email = { provider, version }` (versioned object). Lifting a flat enum into a versioned object also gives future module migrations a per-module `version`
+key to dispatch on.
 
 See:
 
 - Migration: `src/migrations/manifest/002-restructure-email.ts`
 - Fixtures: `src/__tests__/unit/migrations/fixtures/002-restructure-email/`
-- Schema delta: `email` block added to
-  `schemas/saasfoundry-manifest.schema.json`, `emailService` removed from
-  `required`
-- Read sites updated in lockstep:
-  `src/commands/{new,update,modules}.ts`,
-  `scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js`
-  (latter ships in generated projects — must read both shapes for
-  backward compat with un-migrated projects)
+- Schema delta: `email` block added to `schemas/saasfoundry-manifest.schema.json`, `emailService` removed from `required`
+- Read sites updated in lockstep: `src/commands/{new,update,modules}.ts`, `scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js` (latter ships in generated projects — must read both
+  shapes for backward compat with un-migrated projects)
 
-The dispatcher logs `Manifest migrated: vX → vY` per run, with one line per
-applied migration. Idempotent — a second `sf update` is a no-op.
+The dispatcher logs `Manifest migrated: vX → vY` per run, with one line per applied migration. Idempotent — a second `sf update` is a no-op.
 
 ---
 
 ## Module migrations
 
-**Where**: declared on the installer via the `migrations: ModuleMigration[]`
-array exported from each `<name>.installer.ts` (currently empty in v2.0.0 —
-the framework is what ships).
+**Where**: declared on the installer via the `migrations: ModuleMigration[]` array exported from each `<name>.installer.ts` (currently empty in v2.0.0 — the framework is what ships).
 
 **Contract** (`src/migrations/module/types.ts`):
 
@@ -107,31 +81,21 @@ export interface ModuleInstaller {
 ```
 
 - Same `from`/`to`/`name` discipline as manifest migrations, but per module.
-- `up` mutates files in `projectDir`. The dispatcher (not the migration)
-  bumps `manifest.modules.<name>.version` on success.
-- Use `writeMigratedFile` from `src/migrations/module/conflict.ts` instead
-  of `fs.writeFile` so user-edited files fall back to a `.saasfoundry.new`
-  sidecar — same UX as the 3-way template merge.
+- `up` mutates files in `projectDir`. The dispatcher (not the migration) bumps `manifest.modules.<name>.version` on success.
+- Use `writeMigratedFile` from `src/migrations/module/conflict.ts` instead of `fs.writeFile` so user-edited files fall back to a `.saasfoundry.new` sidecar — same UX as the 3-way template merge.
 
 ### How to add one
 
-1. Find the next number for the module: `installer.migrations.at(-1)?.to ?? 0`
-   is your new `from`.
-2. Add the migration to the installer file's `migrations` array (or pull
-   into a sibling file and re-export — a `migrations/NNN-<name>.ts` folder
-   per installer is fine once the chain grows).
+1. Find the next number for the module: `installer.migrations.at(-1)?.to ?? 0` is your new `from`.
+2. Add the migration to the installer file's `migrations` array (or pull into a sibling file and re-export — a `migrations/NNN-<name>.ts` folder per installer is fine once the chain grows).
 3. Bump the installer's `currentVersion` to match the new `to`.
-4. Register a synthetic-fixture integration test in
-   `src/__tests__/integration/commands/update.module-migrations.spec.ts`
-   if the migration touches files (the harness mocks the installer
-   registry so you can drop in a single-migration installer for the test).
+4. Register a synthetic-fixture integration test in `src/__tests__/integration/commands/update.module-migrations.spec.ts` if the migration touches files (the harness mocks the installer registry so
+   you can drop in a single-migration installer for the test).
 5. Run `npm run test:pre-commit`.
 
 ### Worked example — splitting a service file across two files
 
-You ship `MailerSendService` originally as one file
-(`mailersend.service.ts`) and decide to split it into a thin entrypoint +
-helper module (`mailersend.service.ts` + `mailersend.helpers.ts`).
+You ship `MailerSendService` originally as one file (`mailersend.service.ts`) and decide to split it into a thin entrypoint + helper module (`mailersend.service.ts` + `mailersend.helpers.ts`).
 
 ```ts
 // src/installers/email.installer.ts
@@ -159,25 +123,18 @@ export const emailInstallerMeta: ModuleInstaller = {
 }
 ```
 
-If the user has hand-edited `mailersend.service.ts`, both writes land as
-`.saasfoundry.new` sidecars and the user reconciles manually. If untouched,
-the migration runs in-place and `modules.email.version` jumps to 2.
+If the user has hand-edited `mailersend.service.ts`, both writes land as `.saasfoundry.new` sidecars and the user reconciles manually. If untouched, the migration runs in-place and
+`modules.email.version` jumps to 2.
 
 ---
 
 ## When NOT to add a migration
 
-- **Adding a new optional field to the manifest with a sensible default** —
-  the JSON schema keeps validating older manifests; no migration needed.
-- **Pure refactor that doesn't change on-disk shape** — fixing a typo in a
-  comment, renaming a variable inside an installer that doesn't reach files
-  in the user's project.
-- **Changes only to `sf new`** — migration framework only matters for users
-  upgrading from an older CLI version. New projects start at the latest
-  shape by definition.
+- **Adding a new optional field to the manifest with a sensible default** — the JSON schema keeps validating older manifests; no migration needed.
+- **Pure refactor that doesn't change on-disk shape** — fixing a typo in a comment, renaming a variable inside an installer that doesn't reach files in the user's project.
+- **Changes only to `sf new`** — migration framework only matters for users upgrading from an older CLI version. New projects start at the latest shape by definition.
 
-If unsure, ask: "Will a project scaffolded one CLI version ago see a
-correctness regression after `sf update`?" If yes, you need a migration.
+If unsure, ask: "Will a project scaffolded one CLI version ago see a correctness regression after `sf update`?" If yes, you need a migration.
 
 ---
 
@@ -201,7 +158,5 @@ src/installers/
 └── <name>.installer.ts     # each exports `<name>InstallerMeta`
 ```
 
-The two dispatchers run in order inside `src/commands/update.ts`:
-manifest first (so module migrations see the upgraded shape), modules
-second (so any subsequent template regeneration sees the post-migration
-versions).
+The two dispatchers run in order inside `src/commands/update.ts`: manifest first (so module migrations see the upgraded shape), modules second (so any subsequent template regeneration sees the
+post-migration versions).

--- a/.claude/docs/release-objectives.md
+++ b/.claude/docs/release-objectives.md
@@ -25,7 +25,7 @@
 | C1  | One-command project creation                        | `sf new`                                                                                                              |
 | C2  | Modular generation                                  | User picks only what they need                                                                                        |
 | C3  | **Add a previously-skipped module later**           | Post-install module installation on an existing project                                                               |
-| C4  | **Cross-version update path**                       | Project scaffolded with v1.0 → upgrade CLI to v1.3 → `sf update` migrates project safely + can adopt new v1.3 modules |
+| C4  | **Cross-version update path** ✅ v2.0.0              | Closed by Epic #310 — manifest + module migration framework. See `.claude/docs/migration-framework.md`                |
 | C5  | Install **AI tool skills** for ticketing/services   | GitHub + GitHub Projects today; Notion / Jira / ClickUp / Linear later — uniform install pattern                      |
 | C6  | Install **AI tool skills** for SRS backends         | Notion today; Confluence + others later                                                                               |
 | C7  | Install **strategic ticketing skill** (workflow AI) | Actions adapt to ticket complexity; dispatched on whichever ticketing tool is configured                              |

--- a/.claude/docs/release-objectives.md
+++ b/.claude/docs/release-objectives.md
@@ -20,16 +20,16 @@
 
 ## 2. CLI (`sf`)
 
-| #   | Objective                                           | Notes                                                                                                                 |
-| --- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| C1  | One-command project creation                        | `sf new`                                                                                                              |
-| C2  | Modular generation                                  | User picks only what they need                                                                                        |
-| C3  | **Add a previously-skipped module later**           | Post-install module installation on an existing project                                                               |
-| C4  | **Cross-version update path** ✅ v2.0.0              | Closed by Epic #310 — manifest + module migration framework. See `.claude/docs/migration-framework.md`                |
-| C5  | Install **AI tool skills** for ticketing/services   | GitHub + GitHub Projects today; Notion / Jira / ClickUp / Linear later — uniform install pattern                      |
-| C6  | Install **AI tool skills** for SRS backends         | Notion today; Confluence + others later                                                                               |
-| C7  | Install **strategic ticketing skill** (workflow AI) | Actions adapt to ticket complexity; dispatched on whichever ticketing tool is configured                              |
-| C8  | Install **strategic SRS skill**                     | Drafts/maintains SRS on whichever doc tool is configured                                                              |
+| #   | Objective                                           | Notes                                                                                                  |
+| --- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| C1  | One-command project creation                        | `sf new`                                                                                               |
+| C2  | Modular generation                                  | User picks only what they need                                                                         |
+| C3  | **Add a previously-skipped module later**           | Post-install module installation on an existing project                                                |
+| C4  | **Cross-version update path** ✅ v2.0.0             | Closed by Epic #310 — manifest + module migration framework. See `.claude/docs/migration-framework.md` |
+| C5  | Install **AI tool skills** for ticketing/services   | GitHub + GitHub Projects today; Notion / Jira / ClickUp / Linear later — uniform install pattern       |
+| C6  | Install **AI tool skills** for SRS backends         | Notion today; Confluence + others later                                                                |
+| C7  | Install **strategic ticketing skill** (workflow AI) | Actions adapt to ticket complexity; dispatched on whichever ticketing tool is configured               |
+| C8  | Install **strategic SRS skill**                     | Drafts/maintains SRS on whichever doc tool is configured                                               |
 
 ## 3. AI layer (Claude skills)
 

--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -251,6 +251,10 @@ see its `## Conversational eval hook (SUB-10)` section. This skill only referenc
    `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody`. The
    `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section below. The escape hatch exists for meta tickets (SRS refactors,
    tooling) but must never be used to duplicate an FR that already has a page.
+9. **MIGRATION FRAMEWORK ON BREAKING CHANGES** — when transitioning a ticket whose diff touches `src/types.ts`, `schemas/saasfoundry-manifest.schema.json`, any installer's deposited templates under
+   `scaffolds/`, or any file under `src/migrations/`, verify the change ships a numbered migration (`src/migrations/manifest/NNN-*.ts` for manifest shape changes, a `ModuleMigration` on the
+   installer's `migrations` array for module file-set changes). Inline manifest mutations and "let users fix it manually" shortcuts are forbidden by `CLAUDE.md`'s "Migration framework — NEVER bypass"
+   section. Read `.claude/docs/migration-framework.md` before approving the transition.
 
 ## Implementation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,26 @@ must come from `.saasfoundry.json`, not from a fresh dialogue.
 - **Commit + push BEFORE moving to AI Testing.** Code must be on remote before any testing phase.
 - **Subtasks must be real GitHub issues** (not checkboxes), created via `.claude/skills/sf-tool-github-projects/github-projects-cli.sh create-subtask`
 
+### Migration framework — NEVER bypass
+
+The migration framework (Epic #310) only delivers value if every breaking change runs through it. Inline shims in `sf update`, ad-hoc type mutations, and "the user can fix their manifest manually"
+shortcuts reintroduce exactly the cross-version drift the framework was built to prevent.
+
+- **Manifest shape changes** — Any breaking change to `SaaSFoundryManifest` (renaming a field, removing one, restructuring a sub-block) MUST ship as a numbered migration in
+  `src/migrations/manifest/NNN-<name>.ts` with a registered entry in `src/migrations/manifest/index.ts`, a JSON-schema delta in `schemas/saasfoundry-manifest.schema.json`, and a golden fixture pair
+  under `src/__tests__/unit/migrations/fixtures/NNN-<name>/`. Never mutate manifests inline in commands; never bump `manifestVersion` without registering a migration.
+- **Module file-set changes** — Any breaking change to a module's installed file set (renaming a service file, splitting an installer's deposited files, requiring a new env var) MUST bump the
+  installer's `currentVersion` in `<name>.installer.ts` AND ship a `ModuleMigration` on its `migrations` array. Use `writeMigratedFile` from `src/migrations/module/conflict.ts` so user-edited files
+  fall back to a `.saasfoundry.new` sidecar.
+- **Read the playbook first** — Before editing `src/types.ts`, `schemas/saasfoundry-manifest.schema.json`, any installer's deposited templates, or any file under `src/migrations/`, read
+  `.claude/docs/migration-framework.md`. It covers the registry pattern, the file-naming convention, the conflict-aware writer, and worked examples for both manifest renames and module file splits.
+
 ### Reading before acting
 
 - Workflow: `.claude/skills/sf-workflow/SKILL.md` and the `statuses/` files
 - Module architecture (adding/modifying modules): `.claude/docs/architecture-modules.md`
 - Skills architecture (adding/modifying skills): `.claude/docs/architecture-skills.md`
+- Migration framework (any breaking manifest/module change): `.claude/docs/migration-framework.md`
 - Workflow configuration: `.saasfoundry.json` (source of truth — never hardcode branch names, status names, etc.)
 
 ## Tech Stack

--- a/README.md
+++ b/README.md
@@ -589,6 +589,16 @@ We welcome contributions! Whether you're fixing bugs, improving documentation, o
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
+### Shipping a breaking change?
+
+Manifest field renames, restructured `modules.<x>` blocks, or any change
+that would corrupt a project scaffolded with an older CLI version go
+through the migration framework. Read
+[`.claude/docs/migration-framework.md`](.claude/docs/migration-framework.md)
+before opening the PR — it covers the registry pattern, the file naming
+convention, and the golden-fixture test you need to ship alongside the
+migration.
+
 ### Commit Message Guidelines
 
 We follow conventional commits for better versioning and changelog generation. While you can bypass checks with `--no-verify`, we encourage following these guidelines:

--- a/README.md
+++ b/README.md
@@ -591,13 +591,9 @@ We welcome contributions! Whether you're fixing bugs, improving documentation, o
 
 ### Shipping a breaking change?
 
-Manifest field renames, restructured `modules.<x>` blocks, or any change
-that would corrupt a project scaffolded with an older CLI version go
-through the migration framework. Read
-[`.claude/docs/migration-framework.md`](.claude/docs/migration-framework.md)
-before opening the PR — it covers the registry pattern, the file naming
-convention, and the golden-fixture test you need to ship alongside the
-migration.
+Manifest field renames, restructured `modules.<x>` blocks, or any change that would corrupt a project scaffolded with an older CLI version go through the migration framework. Read
+[`.claude/docs/migration-framework.md`](.claude/docs/migration-framework.md) before opening the PR — it covers the registry pattern, the file naming convention, and the golden-fixture test you need to
+ship alongside the migration.
 
 ### Commit Message Guidelines
 

--- a/scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js
+++ b/scaffolds/skills-templates/tool-saasfoundry/scripts/read-project.js
@@ -65,7 +65,11 @@ if (!Array.isArray(catalogue)) {
 function deriveInstalled(m) {
   const installed = []
   const mods = m.modules || {}
-  if (mods.emailService && mods.emailService !== 'none') installed.push('email')
+  // Support both legacy `emailService` (manifestVersion < 2) and the current
+  // nested `email.provider` shape — read-project may be invoked against an
+  // un-migrated manifest in older projects.
+  const emailProvider = (mods.email && mods.email.provider) || mods.emailService
+  if (emailProvider && emailProvider !== 'none') installed.push('email')
   if (mods.s3Setup) installed.push('storage')
   if (mods.includeAnalytics === true) installed.push('analytics')
   if (Array.isArray(mods.advancedSkills)) {

--- a/schemas/saasfoundry-manifest.schema.json
+++ b/schemas/saasfoundry-manifest.schema.json
@@ -36,10 +36,19 @@
     },
     "modules": {
       "type": "object",
-      "required": ["emailService", "s3Setup", "dbSetup", "includeAnalytics", "advancedSkills"],
+      "required": ["email", "s3Setup", "dbSetup", "includeAnalytics", "advancedSkills"],
       "additionalProperties": false,
       "properties": {
-        "emailService": { "type": "string", "enum": ["none", "mailersend"] },
+        "email": {
+          "type": "object",
+          "required": ["provider", "version"],
+          "additionalProperties": false,
+          "description": "Email module — versioned shape introduced in manifestVersion 2 (Epic #310). `provider` replaces the legacy flat `emailService` string; `version` is the per-module installed version, used by module-level migrations.",
+          "properties": {
+            "provider": { "type": "string", "enum": ["none", "mailersend"] },
+            "version": { "type": "integer", "minimum": 0 }
+          }
+        },
         "s3Setup": { "type": "string", "enum": ["docker", "credentials", "manual"] },
         "dbSetup": { "type": "string", "enum": ["docker", "credentials", "manual"] },
         "includeAnalytics": { "type": "boolean" },

--- a/schemas/saasfoundry-manifest.schema.json
+++ b/schemas/saasfoundry-manifest.schema.json
@@ -11,6 +11,11 @@
       "type": "string",
       "description": "Optional pointer to this schema for IDE live validation."
     },
+    "manifestVersion": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Schema-shape version, monotonic integer, bumped by registered manifest migrations. Treat absence as 0 (manifest predates the migration framework)."
+    },
     "version": {
       "type": "string",
       "description": "CLI version that generated the manifest (semver, e.g. 1.0.0-beta)."

--- a/src/__tests__/e2e/new-command.spec.ts
+++ b/src/__tests__/e2e/new-command.spec.ts
@@ -120,7 +120,7 @@ describe('newCommand flow (E2E)', () => {
       structure: config.isMonorepo ? 'monorepo' : 'multirepo',
       projectName: config.projectName,
       modules: {
-        emailService: config.emailService,
+        email: { provider: config.emailService, version: 1 },
         s3Setup: config.s3Setup,
         dbSetup: config.dbSetup,
         includeAnalytics: config.includeAnalytics,
@@ -168,7 +168,7 @@ describe('newCommand flow (E2E)', () => {
       })
 
       expect(manifest.structure).toBe('monorepo')
-      expect(manifest.modules!.emailService).toBe('mailersend')
+      expect(manifest.modules!.email).toEqual({ provider: 'mailersend', version: 1 })
       expect(manifest.modules!.includeAnalytics).toBe(true)
 
       await expectFileExists(join(tempDir, 'full-mono/apps/api/src/main.ts'))
@@ -211,7 +211,7 @@ describe('newCommand flow (E2E)', () => {
         includeAnalytics: false
       })
 
-      expect(manifest.modules!.emailService).toBe('mailersend')
+      expect(manifest.modules!.email).toEqual({ provider: 'mailersend', version: 1 })
 
       const emailService = await readFile(join(tempDir, 'email-only/apps/api/src/modules/email/services/email.service.ts'), 'utf8')
       expect(emailService).not.toContain("console.log('html', html)")

--- a/src/__tests__/e2e/update-command.spec.ts
+++ b/src/__tests__/e2e/update-command.spec.ts
@@ -97,7 +97,7 @@ describe('update command logic (E2E)', () => {
         structure: 'multirepo',
         projectName: 'existing-project',
         modules: {
-          emailService: 'none',
+          email: { provider: 'none', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'docker',
           includeAnalytics: false,

--- a/src/__tests__/e2e/workflow-command.spec.ts
+++ b/src/__tests__/e2e/workflow-command.spec.ts
@@ -49,7 +49,7 @@ describe('workflow command logic (E2E)', () => {
         structure: 'monorepo',
         generatedAt: new Date().toISOString(),
         modules: {
-          emailService: 'none',
+          email: { provider: 'none', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'docker',
           includeAnalytics: false,
@@ -72,7 +72,7 @@ describe('workflow command logic (E2E)', () => {
         structure: 'multirepo',
         generatedAt: new Date().toISOString(),
         modules: {
-          emailService: 'mailersend',
+          email: { provider: 'mailersend', version: 1 },
           s3Setup: 'docker',
           dbSetup: 'docker',
           includeAnalytics: true,
@@ -90,7 +90,7 @@ describe('workflow command logic (E2E)', () => {
 
       const manifest = await readManifest(tempDir)
       expect(manifest?.projectName).toBe('update-test')
-      expect(manifest?.modules?.emailService).toBe('mailersend')
+      expect(manifest?.modules?.email).toEqual({ provider: 'mailersend', version: 1 })
       expect(manifest?.workflow?.tool).toBe('jira')
     })
 
@@ -101,7 +101,7 @@ describe('workflow command logic (E2E)', () => {
         structure: 'monorepo',
         generatedAt: new Date().toISOString(),
         modules: {
-          emailService: 'none',
+          email: { provider: 'none', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'docker',
           includeAnalytics: false,
@@ -127,7 +127,7 @@ describe('workflow command logic (E2E)', () => {
         structure: 'monorepo',
         generatedAt: new Date().toISOString(),
         modules: {
-          emailService: 'none',
+          email: { provider: 'none', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'docker',
           includeAnalytics: false,
@@ -163,7 +163,7 @@ describe('workflow command logic (E2E)', () => {
         structure: 'multirepo',
         generatedAt: new Date().toISOString(),
         modules: {
-          emailService: 'none',
+          email: { provider: 'none', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'manual',
           includeAnalytics: false,

--- a/src/__tests__/helpers/fixtures.ts
+++ b/src/__tests__/helpers/fixtures.ts
@@ -80,7 +80,7 @@ export function manifestFixture(overrides: Partial<SaaSFoundryManifest> = {}): S
     structure: 'monorepo',
     projectName: DEFAULT_PROJECT_NAME,
     modules: {
-      emailService: 'none',
+      email: { provider: 'none', version: 1 },
       s3Setup: 'manual',
       dbSetup: 'docker',
       includeAnalytics: false,

--- a/src/__tests__/integration/commands/modules.spec.ts
+++ b/src/__tests__/integration/commands/modules.spec.ts
@@ -19,7 +19,7 @@ describe('modulesCommand (integration)', () => {
     structure: 'monorepo',
     projectName: 'modules-integration',
     modules: {
-      emailService: 'none',
+      email: { provider: 'none', version: 1 },
       s3Setup: 'manual',
       dbSetup: 'docker',
       includeAnalytics: false,
@@ -82,7 +82,7 @@ describe('modulesCommand (integration)', () => {
     })
 
     it('should mark email as installed when manifest has mailersend', async () => {
-      await writeManifest(buildManifest({ emailService: 'mailersend' }))
+      await writeManifest(buildManifest({ email: { provider: 'mailersend', version: 1 } }))
       await modulesCommand('list', '--json')
       const payload = getJsonOutput()
       const email = payload.modules.find((m: { name: string }) => m.name === 'email')

--- a/src/__tests__/integration/commands/new.non-interactive.spec.ts
+++ b/src/__tests__/integration/commands/new.non-interactive.spec.ts
@@ -179,7 +179,7 @@ describe('newCommand (non-interactive integration)', () => {
       projectName: 'acme',
       structure: 'monorepo',
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'manual',
         dbSetup: 'manual',
         includeAnalytics: true,

--- a/src/__tests__/integration/commands/new.non-interactive.spec.ts
+++ b/src/__tests__/integration/commands/new.non-interactive.spec.ts
@@ -16,7 +16,7 @@ jest.mock('../../../builders/api.builder', () => ({ createApiApp: jest.fn() }))
 jest.mock('../../../builders/web.builder', () => ({ createWebApp: jest.fn() }))
 jest.mock('../../../builders/monorepo.builder', () => ({ createMonorepoRoot: jest.fn() }))
 jest.mock('../../../builders/dev-services.builder', () => ({ createDevServicesCompose: jest.fn() }))
-jest.mock('../../../installers/skills.installer', () => ({ installSkills: jest.fn() }))
+jest.mock('../../../installers/skills.installer', () => ({ ...jest.requireActual('../../../installers/skills.installer'), installSkills: jest.fn() }))
 
 jest.mock('../../../runners/database.runner', () => ({ initAndStartDb: jest.fn() }))
 jest.mock('../../../runners/s3.runner', () => ({ initAndStartS3: jest.fn() }))

--- a/src/__tests__/integration/commands/update.module-migrations.spec.ts
+++ b/src/__tests__/integration/commands/update.module-migrations.spec.ts
@@ -1,0 +1,149 @@
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import shelljs from 'shelljs'
+
+import { SaaSFoundryManifest } from '../../../types'
+import { version as cliVersion } from '../../../../package.json'
+
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual('../../../utils'),
+  checkNodeVersion: jest.fn()
+}))
+
+jest.mock('../../../prompts/update.prompts', () => ({
+  ...jest.requireActual('../../../prompts/update.prompts'),
+  getModuleSelections: jest.fn(),
+  getEmailModuleCredentials: jest.fn(),
+  getStorageModuleConfig: jest.fn(),
+  getSkillCredentials: jest.fn()
+}))
+
+jest.mock('../../../prompts/srs.prompts', () => ({ promptSrsConfiguration: jest.fn() }))
+jest.mock('../../../installers/email.installer', () => ({ installEmailModule: jest.fn() }))
+jest.mock('../../../installers/storage.installer', () => ({ installStorageModule: jest.fn() }))
+jest.mock('../../../installers/analytics.installer', () => ({ installAnalyticsModule: jest.fn() }))
+jest.mock('../../../installers/skills.installer', () => ({ installSkills: jest.fn() }))
+jest.mock('../../../installers/srs-skill.installer', () => ({ installSrsSkill: jest.fn() }))
+jest.mock('../../../runners/srs.runner', () => ({ bootstrapSrs: jest.fn() }))
+jest.mock('../../../tools/notion/srs.adapter', () => ({ NotionSrsAdapter: jest.fn() }))
+jest.mock('../../../builders/api.builder', () => ({ createApiApp: jest.fn() }))
+jest.mock('../../../builders/web.builder', () => ({ createWebApp: jest.fn() }))
+jest.mock('../../../builders/monorepo.builder', () => ({ createMonorepoRoot: jest.fn() }))
+jest.mock('../../../builders/dev-services.builder', () => ({ createDevServicesCompose: jest.fn() }))
+
+jest.mock('ora', () => () => ({ start: () => ({ text: '', succeed: jest.fn(), fail: jest.fn() }) }))
+
+const recordedRuns: { name: string; manifestVersion: number | undefined }[] = []
+
+// Synthetic installer registry — exercises the dispatcher end-to-end without
+// shipping a real module migration (none exist in v2.0.0; the framework is
+// what's released). The migration uses `writeMigratedFile` so we also cover
+// the conflict-aware writer path through `sf update`.
+jest.mock('../../../installers/registry', () => {
+  const conflict = jest.requireActual('../../../migrations/module/conflict')
+  return {
+    moduleInstallers: [
+      {
+        name: 'email',
+        currentVersion: 2,
+        migrations: [
+          {
+            from: 1,
+            to: 2,
+            name: 'rename-mailersend-config',
+            up: async (projectDir: string, manifest: SaaSFoundryManifest) => {
+              recordedRuns.push({ name: 'rename-mailersend-config', manifestVersion: manifest.manifestVersion })
+              await conflict.writeMigratedFile(projectDir, 'email/config.txt', 'PROVIDER=mailersend\n', manifest)
+            }
+          }
+        ]
+      }
+    ],
+    getModuleInstaller: jest.fn()
+  }
+})
+
+import { updateCommand } from '../../../commands/update'
+import { getModuleSelections } from '../../../prompts/update.prompts'
+
+const mockedGetModuleSelections = getModuleSelections as jest.MockedFunction<typeof getModuleSelections>
+
+describe('updateCommand — module migration dispatch', () => {
+  let tempDir: string
+  let originalCwd: string
+  let logSpy: jest.SpyInstance
+  let errorSpy: jest.SpyInstance
+  let exitSpy: jest.SpyInstance
+  let shellSpy: jest.SpyInstance
+
+  const buildManifest = (overrides: Partial<SaaSFoundryManifest> = {}): SaaSFoundryManifest => ({
+    version: cliVersion,
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    structure: 'monorepo',
+    projectName: 'mig-int',
+    modules: {
+      email: { provider: 'mailersend', version: 1 },
+      s3Setup: 'manual',
+      dbSetup: 'docker',
+      includeAnalytics: false,
+      advancedSkills: []
+    },
+    ...overrides
+  })
+
+  beforeEach(async () => {
+    recordedRuns.length = 0
+    tempDir = join(tmpdir(), `sf-int-mod-mig-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    originalCwd = process.cwd()
+    await mkdir(tempDir, { recursive: true })
+    process.chdir(tempDir)
+
+    jest.clearAllMocks()
+    mockedGetModuleSelections.mockResolvedValue([])
+
+    shellSpy = jest.spyOn(shelljs, 'exec').mockImplementation((() => ({ code: 0, stdout: '10.0.0', stderr: '' })) as never)
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never)
+  })
+
+  afterEach(async () => {
+    shellSpy.mockRestore()
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
+    process.chdir(originalCwd)
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('runs pending email migration, bumps modules.email.version, persists manifest', async () => {
+    await writeFile('.saasfoundry.json', JSON.stringify(buildManifest()))
+
+    await updateCommand()
+
+    expect(recordedRuns).toEqual([{ name: 'rename-mailersend-config', manifestVersion: expect.any(Number) }])
+    const written = JSON.parse(await readFile('.saasfoundry.json', 'utf8')) as SaaSFoundryManifest
+    const email = (written.modules as { email: { provider: string; version: number } }).email
+    expect(email.version).toBe(2)
+    expect(await readFile(join(tempDir, 'email/config.txt'), 'utf8')).toBe('PROVIDER=mailersend\n')
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Migrated module 'email' v1 → v2"))
+  })
+
+  it('is a no-op when modules.email.version already matches the installer currentVersion', async () => {
+    const upToDate = buildManifest({
+      manifestVersion: 2,
+      modules: { email: { provider: 'mailersend', version: 2 }, s3Setup: 'manual', dbSetup: 'docker', includeAnalytics: false, advancedSkills: [] }
+    })
+    await writeFile('.saasfoundry.json', JSON.stringify(upToDate))
+
+    await updateCommand()
+
+    expect(recordedRuns).toEqual([])
+    const written = JSON.parse(await readFile('.saasfoundry.json', 'utf8')) as SaaSFoundryManifest
+    const email = (written.modules as { email: { provider: string; version: number } }).email
+    expect(email.version).toBe(2)
+  })
+})

--- a/src/__tests__/integration/commands/update.non-interactive.spec.ts
+++ b/src/__tests__/integration/commands/update.non-interactive.spec.ts
@@ -15,10 +15,10 @@ jest.mock('../../../utils', () => ({
   checkNodeVersion: jest.fn()
 }))
 
-jest.mock('../../../installers/email.installer', () => ({ installEmailModule: jest.fn() }))
-jest.mock('../../../installers/storage.installer', () => ({ installStorageModule: jest.fn() }))
-jest.mock('../../../installers/analytics.installer', () => ({ installAnalyticsModule: jest.fn() }))
-jest.mock('../../../installers/skills.installer', () => ({ installSkills: jest.fn() }))
+jest.mock('../../../installers/email.installer', () => ({ ...jest.requireActual('../../../installers/email.installer'), installEmailModule: jest.fn() }))
+jest.mock('../../../installers/storage.installer', () => ({ ...jest.requireActual('../../../installers/storage.installer'), installStorageModule: jest.fn() }))
+jest.mock('../../../installers/analytics.installer', () => ({ ...jest.requireActual('../../../installers/analytics.installer'), installAnalyticsModule: jest.fn() }))
+jest.mock('../../../installers/skills.installer', () => ({ ...jest.requireActual('../../../installers/skills.installer'), installSkills: jest.fn() }))
 jest.mock('../../../builders/dev-services.builder', () => ({ createDevServicesCompose: jest.fn() }))
 
 jest.mock('ora', () => () => ({

--- a/src/__tests__/integration/commands/update.non-interactive.spec.ts
+++ b/src/__tests__/integration/commands/update.non-interactive.spec.ts
@@ -46,7 +46,7 @@ const baseManifest = (overrides: Partial<SaaSFoundryManifest> = {}): SaaSFoundry
   structure: 'monorepo',
   projectName: 'acme',
   modules: {
-    emailService: 'none',
+    email: { provider: 'none', version: 1 },
     s3Setup: 'manual',
     dbSetup: 'docker',
     includeAnalytics: false,
@@ -113,7 +113,7 @@ describe('updateCommand (non-interactive integration)', () => {
     )
 
     const saved = JSON.parse(await readFile('.saasfoundry.json', 'utf8'))
-    expect(saved.modules.emailService).toBe('mailersend')
+    expect(saved.modules.email).toEqual({ provider: 'mailersend', version: 1 })
   })
 
   it('propagates storage flags (credentials) to the storage installer', async () => {
@@ -175,9 +175,9 @@ describe('updateCommand (non-interactive integration)', () => {
     const npmInstallCalls = shellSpy.mock.calls.filter((c) => String(c[0]).includes('npm install'))
     expect(npmInstallCalls).toHaveLength(0)
 
-    // Manifest remains unchanged (emailService stays 'none').
+    // Manifest remains unchanged (email.provider stays 'none').
     const saved = JSON.parse(await readFile('.saasfoundry.json', 'utf8'))
-    expect(saved.modules.emailService).toBe('none')
+    expect(saved.modules.email).toEqual({ provider: 'none', version: 1 })
 
     // Report is emitted between the sentinel markers so callers can parse it.
     const combined = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
@@ -262,7 +262,7 @@ describe('updateCommand (non-interactive integration)', () => {
   it('skips an already-installed module requested via --add-modules without re-installing', async () => {
     const manifest = baseManifest({
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'manual',
         dbSetup: 'docker',
         includeAnalytics: true,
@@ -285,7 +285,7 @@ describe('updateCommand (non-interactive integration)', () => {
   it('skips installed modules but proceeds with the installable ones in the same --add-modules', async () => {
     const manifest = baseManifest({
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'manual',
         dbSetup: 'docker',
         includeAnalytics: true,

--- a/src/__tests__/integration/commands/update.spec.ts
+++ b/src/__tests__/integration/commands/update.spec.ts
@@ -30,11 +30,11 @@ jest.mock('../../../prompts/srs.prompts', () => ({
   })
 }))
 
-jest.mock('../../../installers/email.installer', () => ({ installEmailModule: jest.fn() }))
-jest.mock('../../../installers/storage.installer', () => ({ installStorageModule: jest.fn() }))
-jest.mock('../../../installers/analytics.installer', () => ({ installAnalyticsModule: jest.fn() }))
-jest.mock('../../../installers/skills.installer', () => ({ installSkills: jest.fn() }))
-jest.mock('../../../installers/srs-skill.installer', () => ({ installSrsSkill: jest.fn() }))
+jest.mock('../../../installers/email.installer', () => ({ ...jest.requireActual('../../../installers/email.installer'), installEmailModule: jest.fn() }))
+jest.mock('../../../installers/storage.installer', () => ({ ...jest.requireActual('../../../installers/storage.installer'), installStorageModule: jest.fn() }))
+jest.mock('../../../installers/analytics.installer', () => ({ ...jest.requireActual('../../../installers/analytics.installer'), installAnalyticsModule: jest.fn() }))
+jest.mock('../../../installers/skills.installer', () => ({ ...jest.requireActual('../../../installers/skills.installer'), installSkills: jest.fn() }))
+jest.mock('../../../installers/srs-skill.installer', () => ({ ...jest.requireActual('../../../installers/srs-skill.installer'), installSrsSkill: jest.fn() }))
 jest.mock('../../../runners/srs.runner', () => ({
   bootstrapSrs: jest.fn().mockResolvedValue({
     rootPage: { id: 'root-id', url: 'https://notion/root', name: 'Root' }

--- a/src/__tests__/integration/commands/update.spec.ts
+++ b/src/__tests__/integration/commands/update.spec.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import shelljs from 'shelljs'
 
+import { targetManifestVersion } from '../../../migrations/manifest/registry'
 import { SaaSFoundryManifest } from '../../../types'
 import { version as cliVersion } from '../../../../package.json'
 
@@ -81,7 +82,7 @@ describe('updateCommand (integration)', () => {
     structure: 'monorepo',
     projectName: 'integration-project',
     modules: {
-      emailService: 'none',
+      email: { provider: 'none', version: 1 },
       s3Setup: 'manual',
       dbSetup: 'docker',
       includeAnalytics: false,
@@ -188,7 +189,7 @@ describe('updateCommand (integration)', () => {
       await updateCommand()
 
       const written = JSON.parse(await readFile('.saasfoundry.json', 'utf8')) as SaaSFoundryManifest
-      expect(written.manifestVersion).toBe(1)
+      expect(written.manifestVersion).toBe(targetManifestVersion())
       expect(written.$schema).toBe(SCHEMA_URL)
     })
   })
@@ -197,7 +198,7 @@ describe('updateCommand (integration)', () => {
     it('returns early when everything is already installed', async () => {
       const manifest = buildBaseManifest({
         modules: {
-          emailService: 'mailersend',
+          email: { provider: 'mailersend', version: 1 },
           s3Setup: 'docker',
           dbSetup: 'docker',
           includeAnalytics: true,
@@ -255,7 +256,7 @@ describe('updateCommand (integration)', () => {
       )
 
       const saved = JSON.parse(await readFile('.saasfoundry.json', 'utf8'))
-      expect(saved.modules.emailService).toBe('mailersend')
+      expect(saved.modules.email).toEqual({ provider: 'mailersend', version: 1 })
     })
 
     it('skips email module when user cancels credentials', async () => {
@@ -328,7 +329,7 @@ describe('updateCommand (integration)', () => {
     it('installs a single skill and merges with existing skills in the manifest', async () => {
       const manifest = buildBaseManifest({
         modules: {
-          emailService: 'none',
+          email: { provider: 'none', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'docker',
           includeAnalytics: false,

--- a/src/__tests__/integration/commands/update.spec.ts
+++ b/src/__tests__/integration/commands/update.spec.ts
@@ -177,6 +177,20 @@ describe('updateCommand (integration)', () => {
 
       expect(await readFile('.saasfoundry.json', 'utf8')).toBe(original)
     })
+
+    it('stamps manifestVersion alongside $schema (migration framework)', async () => {
+      mockedGetModuleSelections.mockResolvedValue([])
+      const manifest = buildBaseManifest()
+      delete (manifest as Partial<SaaSFoundryManifest>).$schema
+      delete (manifest as Partial<SaaSFoundryManifest>).manifestVersion
+      await writeFile('.saasfoundry.json', JSON.stringify(manifest))
+
+      await updateCommand()
+
+      const written = JSON.parse(await readFile('.saasfoundry.json', 'utf8')) as SaaSFoundryManifest
+      expect(written.manifestVersion).toBe(1)
+      expect(written.$schema).toBe(SCHEMA_URL)
+    })
   })
 
   describe('no modules available', () => {

--- a/src/__tests__/unit/installers/registry.spec.ts
+++ b/src/__tests__/unit/installers/registry.spec.ts
@@ -1,0 +1,30 @@
+import { moduleInstallers, getModuleInstaller } from '../../../installers/registry'
+
+const EXPECTED_INSTALLERS = ['email', 'storage', 'analytics', 'srs-skill', 'skills', 'core-skills', 'tool-skill', 'workflow-skill'] as const
+
+describe('moduleInstallers registry', () => {
+  it('exposes every installer named by the framework spec', () => {
+    const names = moduleInstallers.map((installer) => installer.name).sort()
+    expect(names).toEqual([...EXPECTED_INSTALLERS].sort())
+  })
+
+  it.each(EXPECTED_INSTALLERS)('%s installer carries currentVersion=1 and an empty migrations array', (name) => {
+    const installer = getModuleInstaller(name)
+    expect(installer).toBeDefined()
+    expect(installer!.currentVersion).toBe(1)
+    expect(installer!.migrations).toEqual([])
+  })
+
+  it('every installer migrations array is contiguous (vacuously true today)', () => {
+    // Same shape-check the manifest registry enforces. Today every installer
+    // ships `migrations: []` so the loop is a no-op — but the assertion is
+    // here so the first installer to add a real migration without keeping the
+    // chain contiguous fails loudly.
+    for (const installer of moduleInstallers) {
+      installer.migrations.forEach((migration, index) => {
+        expect(migration.from).toBe(index)
+        expect(migration.to).toBe(index + 1)
+      })
+    }
+  })
+})

--- a/src/__tests__/unit/migrations/001-add-schema-url.spec.ts
+++ b/src/__tests__/unit/migrations/001-add-schema-url.spec.ts
@@ -1,0 +1,74 @@
+import { migration001 } from '../../../migrations/manifest/001-add-schema-url'
+import { manifestSchemaUrl, type SaaSFoundryManifest } from '../../../types'
+
+describe('migration 001 — add-schema-url', () => {
+  const baseManifest: SaaSFoundryManifest = {
+    version: '1.0.0-beta',
+    generatedAt: '2026-04-01T00:00:00.000Z',
+    structure: 'cli',
+    projectName: 'demo'
+  }
+
+  it('declares from=0, to=1', () => {
+    expect(migration001.from).toBe(0)
+    expect(migration001.to).toBe(1)
+    expect(migration001.name).toBe('add-schema-url')
+  })
+
+  it('stamps $schema and bumps manifestVersion when missing', () => {
+    const result = migration001.up({ ...baseManifest })
+
+    expect(result.$schema).toBe(manifestSchemaUrl)
+    expect(result.manifestVersion).toBe(1)
+  })
+
+  it('puts $schema as the first key when stamped', () => {
+    const result = migration001.up({ ...baseManifest })
+
+    expect(Object.keys(result)[0]).toBe('$schema')
+  })
+
+  it('preserves a user-overridden $schema', () => {
+    const customUrl = 'https://example.com/custom-schema.json'
+    const result = migration001.up({ ...baseManifest, $schema: customUrl })
+
+    expect(result.$schema).toBe(customUrl)
+    expect(result.manifestVersion).toBe(1)
+  })
+
+  it('is idempotent — running twice yields the same output', () => {
+    const once = migration001.up({ ...baseManifest })
+    const twice = migration001.up(once)
+
+    expect(twice).toEqual(once)
+  })
+
+  it('does not mutate the input manifest', () => {
+    const input: SaaSFoundryManifest = { ...baseManifest }
+    const snapshot = JSON.parse(JSON.stringify(input))
+
+    migration001.up(input)
+
+    expect(input).toEqual(snapshot)
+  })
+
+  it('preserves all other manifest fields', () => {
+    const rich: SaaSFoundryManifest = {
+      ...baseManifest,
+      modules: {
+        emailService: 'mailersend',
+        s3Setup: 'docker',
+        dbSetup: 'docker',
+        includeAnalytics: true,
+        advancedSkills: ['srs']
+      },
+      workflow: { tool: 'github-projects' }
+    }
+
+    const result = migration001.up(rich)
+
+    expect(result.modules).toEqual(rich.modules)
+    expect(result.workflow).toEqual(rich.workflow)
+    expect(result.projectName).toBe('demo')
+  })
+})

--- a/src/__tests__/unit/migrations/001-add-schema-url.spec.ts
+++ b/src/__tests__/unit/migrations/001-add-schema-url.spec.ts
@@ -52,8 +52,12 @@ describe('migration 001 — add-schema-url', () => {
     expect(input).toEqual(snapshot)
   })
 
-  it('preserves all other manifest fields', () => {
-    const rich: SaaSFoundryManifest = {
+  it('preserves all other manifest fields (legacy v0 modules shape)', () => {
+    // Migration 001 runs against pre-v1 manifests where `modules.emailService`
+    // is still flat — that shape predates the v2 restructure (migration 002).
+    // Cast through unknown so we can assert preservation without type-checking
+    // the input against the current `SaaSFoundryManifest` shape.
+    const rich = {
       ...baseManifest,
       modules: {
         emailService: 'mailersend',
@@ -63,7 +67,7 @@ describe('migration 001 — add-schema-url', () => {
         advancedSkills: ['srs']
       },
       workflow: { tool: 'github-projects' }
-    }
+    } as unknown as SaaSFoundryManifest
 
     const result = migration001.up(rich)
 

--- a/src/__tests__/unit/migrations/drift-guard.spec.ts
+++ b/src/__tests__/unit/migrations/drift-guard.spec.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { targetManifestVersion } from '../../../migrations/manifest/registry'
+
+/**
+ * Drift-guard for the migration framework (Sub #388 stretch goal).
+ *
+ * Snapshots the top-level keys of `SaaSFoundryManifest` paired with the
+ * current `targetManifestVersion()`. Any structural edit to the interface
+ * forces the contributor to either revert the change or ship a numbered
+ * manifest migration (which bumps the target). Both arms of the snapshot
+ * must move together — that is the invariant the migration framework
+ * relies on (`.claude/docs/migration-framework.md`).
+ */
+
+function extractTopLevelKeys(): string[] {
+  const source = readFileSync(join(__dirname, '../../../types.ts'), 'utf8')
+  const match = source.match(/export interface SaaSFoundryManifest \{([\s\S]*?)\n\}/)
+  if (!match) throw new Error('Could not locate SaaSFoundryManifest interface in src/types.ts')
+  const body = match[1]
+  const keys: string[] = []
+  let depth = 0
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.replace(/\/\/.*$/, '').trim()
+    if (!line) continue
+    if (depth === 0) {
+      const keyMatch = line.match(/^(\$?\w+)\??\s*:/)
+      if (keyMatch) keys.push(keyMatch[1])
+    }
+    for (const ch of line) {
+      if (ch === '{') depth++
+      else if (ch === '}') depth--
+    }
+  }
+  return keys
+}
+
+describe('SaaSFoundryManifest drift-guard', () => {
+  it('top-level shape and targetManifestVersion stay in lock-step', () => {
+    const snapshot = {
+      targetVersion: targetManifestVersion(),
+      keys: extractTopLevelKeys()
+    }
+    expect(snapshot).toEqual({
+      targetVersion: 2,
+      keys: ['$schema', 'manifestVersion', 'version', 'generatedAt', 'structure', 'projectName', 'modules', 'skillsAccounts', 'fileHashes', 'workflow', 'aiRules', 'tools']
+    })
+  })
+})

--- a/src/__tests__/unit/migrations/fixtures/001-add-schema-url/after.json
+++ b/src/__tests__/unit/migrations/fixtures/001-add-schema-url/after.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json",
+  "version": "1.0.0-beta",
+  "generatedAt": "2026-04-01T00:00:00.000Z",
+  "structure": "multirepo",
+  "projectName": "fixture-app",
+  "modules": {
+    "emailService": "mailersend",
+    "s3Setup": "docker",
+    "dbSetup": "docker",
+    "includeAnalytics": false,
+    "advancedSkills": []
+  },
+  "workflow": {
+    "tool": "github-projects"
+  },
+  "manifestVersion": 1
+}

--- a/src/__tests__/unit/migrations/fixtures/001-add-schema-url/before.json
+++ b/src/__tests__/unit/migrations/fixtures/001-add-schema-url/before.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0-beta",
+  "generatedAt": "2026-04-01T00:00:00.000Z",
+  "structure": "multirepo",
+  "projectName": "fixture-app",
+  "modules": {
+    "emailService": "mailersend",
+    "s3Setup": "docker",
+    "dbSetup": "docker",
+    "includeAnalytics": false,
+    "advancedSkills": []
+  },
+  "workflow": {
+    "tool": "github-projects"
+  }
+}

--- a/src/__tests__/unit/migrations/fixtures/002-restructure-email/after.json
+++ b/src/__tests__/unit/migrations/fixtures/002-restructure-email/after.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json",
+  "manifestVersion": 2,
+  "version": "1.0.0-beta",
+  "generatedAt": "2026-04-01T00:00:00.000Z",
+  "structure": "multirepo",
+  "projectName": "fixture-app",
+  "modules": {
+    "s3Setup": "docker",
+    "dbSetup": "docker",
+    "includeAnalytics": false,
+    "advancedSkills": [],
+    "email": {
+      "provider": "mailersend",
+      "version": 1
+    }
+  },
+  "workflow": {
+    "tool": "github-projects"
+  }
+}

--- a/src/__tests__/unit/migrations/fixtures/002-restructure-email/before.json
+++ b/src/__tests__/unit/migrations/fixtures/002-restructure-email/before.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json",
+  "manifestVersion": 1,
+  "version": "1.0.0-beta",
+  "generatedAt": "2026-04-01T00:00:00.000Z",
+  "structure": "multirepo",
+  "projectName": "fixture-app",
+  "modules": {
+    "emailService": "mailersend",
+    "s3Setup": "docker",
+    "dbSetup": "docker",
+    "includeAnalytics": false,
+    "advancedSkills": []
+  },
+  "workflow": {
+    "tool": "github-projects"
+  }
+}

--- a/src/__tests__/unit/migrations/fixtures/v0-legacy.json
+++ b/src/__tests__/unit/migrations/fixtures/v0-legacy.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.9.0",
+  "generatedAt": "2026-01-15T00:00:00.000Z",
+  "structure": "monorepo",
+  "projectName": "legacy-app",
+  "modules": {
+    "emailService": "none",
+    "s3Setup": "manual",
+    "dbSetup": "credentials",
+    "includeAnalytics": true,
+    "advancedSkills": ["context7"]
+  },
+  "fileHashes": {
+    "apps/api/package.json": "abc123"
+  }
+}

--- a/src/__tests__/unit/migrations/golden-fixtures.spec.ts
+++ b/src/__tests__/unit/migrations/golden-fixtures.spec.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { manifestMigrations } from '../../../migrations/manifest'
+import { runManifestMigrations, targetManifestVersion } from '../../../migrations/manifest/registry'
+import { manifestSchemaUrl, type SaaSFoundryManifest } from '../../../types'
+
+const FIXTURES_DIR = join(__dirname, 'fixtures')
+
+const readJsonFixture = (relativePath: string): unknown => JSON.parse(readFileSync(join(FIXTURES_DIR, relativePath), 'utf8'))
+
+/**
+ * Golden-fixture harness — every registered migration MUST ship a
+ * `before.json` + `after.json` pair under `fixtures/<NNN>-<name>/`. The
+ * harness drives `migration.up(before)` and asserts the result equals
+ * `after`, byte-for-byte at the JSON level. This lets reviewers eyeball
+ * the data shape transition in PR diffs instead of inferring it from
+ * imperative code.
+ */
+describe('manifest migration — golden fixtures', () => {
+  for (const migration of manifestMigrations) {
+    const fixtureKey = `${String(migration.from + 1).padStart(3, '0')}-${migration.name}`
+
+    describe(`${fixtureKey}`, () => {
+      it('matches before/after fixtures', () => {
+        const before = readJsonFixture(`${fixtureKey}/before.json`) as SaaSFoundryManifest
+        const after = readJsonFixture(`${fixtureKey}/after.json`) as SaaSFoundryManifest
+
+        const result = migration.up(before)
+
+        expect(result).toEqual(after)
+      })
+
+      it('after fixture has manifestVersion === migration.to', () => {
+        const after = readJsonFixture(`${fixtureKey}/after.json`) as SaaSFoundryManifest
+        expect(after.manifestVersion).toBe(migration.to)
+      })
+    })
+  }
+})
+
+/**
+ * Full-chain assertion — feed a frozen "as it shipped" v0 manifest through
+ * the dispatcher and pin the resulting shape. This catches accidental
+ * regressions where a new migration changes the end-state of older fields
+ * without updating the chain expectation.
+ */
+describe('manifest migration — full chain (v0 → current)', () => {
+  it('upgrades a legacy v0 manifest to the current target version', () => {
+    const legacy = readJsonFixture('v0-legacy.json') as SaaSFoundryManifest
+
+    const result = runManifestMigrations(legacy)
+
+    expect(result.fromVersion).toBe(0)
+    expect(result.toVersion).toBe(targetManifestVersion())
+    expect(result.appliedMigrations).toHaveLength(manifestMigrations.length)
+    expect(result.manifest.manifestVersion).toBe(targetManifestVersion())
+    expect(result.manifest.$schema).toBe(manifestSchemaUrl)
+  })
+
+  it('preserves all original fields through the chain', () => {
+    const legacy = readJsonFixture('v0-legacy.json') as SaaSFoundryManifest
+
+    const { manifest } = runManifestMigrations(legacy)
+
+    expect(manifest.version).toBe(legacy.version)
+    expect(manifest.projectName).toBe(legacy.projectName)
+    expect(manifest.structure).toBe(legacy.structure)
+    expect(manifest.modules).toEqual(legacy.modules)
+    expect(manifest.fileHashes).toEqual(legacy.fileHashes)
+  })
+
+  it('produces a manifest that conforms to the JSON schema', async () => {
+    // Defer the ajv import so this suite stays cheap when the chain is empty.
+    const Ajv = (await import('ajv')).default
+    const addFormats = (await import('ajv-formats')).default
+    const schema = readJsonFixture('../../../../../schemas/saasfoundry-manifest.schema.json')
+
+    const ajv = new Ajv({ strict: false, allErrors: true })
+    addFormats(ajv)
+    const validate = ajv.compile(schema as object)
+
+    const legacy = readJsonFixture('v0-legacy.json') as SaaSFoundryManifest
+    const { manifest } = runManifestMigrations(legacy)
+
+    const valid = validate(manifest)
+    if (!valid) {
+      throw new Error(`Migrated manifest failed schema validation: ${JSON.stringify(validate.errors, null, 2)}`)
+    }
+    expect(valid).toBe(true)
+  })
+})

--- a/src/__tests__/unit/migrations/golden-fixtures.spec.ts
+++ b/src/__tests__/unit/migrations/golden-fixtures.spec.ts
@@ -58,16 +58,26 @@ describe('manifest migration — full chain (v0 → current)', () => {
     expect(result.manifest.$schema).toBe(manifestSchemaUrl)
   })
 
-  it('preserves all original fields through the chain', () => {
+  it('preserves top-level fields and migrates the modules block through the chain', () => {
     const legacy = readJsonFixture('v0-legacy.json') as SaaSFoundryManifest
+    const legacyModules = (legacy.modules ?? {}) as { emailService?: 'none' | 'mailersend'; s3Setup?: string; dbSetup?: string; includeAnalytics?: boolean; advancedSkills?: string[] }
 
     const { manifest } = runManifestMigrations(legacy)
 
     expect(manifest.version).toBe(legacy.version)
     expect(manifest.projectName).toBe(legacy.projectName)
     expect(manifest.structure).toBe(legacy.structure)
-    expect(manifest.modules).toEqual(legacy.modules)
     expect(manifest.fileHashes).toEqual(legacy.fileHashes)
+
+    // Migration 002 lifts the flat `emailService` enum into `email.{provider, version}`
+    // while leaving the rest of the modules block untouched.
+    expect(manifest.modules).toEqual({
+      s3Setup: legacyModules.s3Setup,
+      dbSetup: legacyModules.dbSetup,
+      includeAnalytics: legacyModules.includeAnalytics,
+      advancedSkills: legacyModules.advancedSkills,
+      email: { provider: legacyModules.emailService, version: 1 }
+    })
   })
 
   it('produces a manifest that conforms to the JSON schema', async () => {

--- a/src/__tests__/unit/migrations/module-conflict.spec.ts
+++ b/src/__tests__/unit/migrations/module-conflict.spec.ts
@@ -1,0 +1,69 @@
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { writeMigratedFile } from '../../../migrations/module/conflict'
+import type { SaaSFoundryManifest } from '../../../types'
+import { hashFileContent } from '../../../utils'
+
+const baseManifest = (fileHashes?: Record<string, string>): SaaSFoundryManifest => ({
+  version: '1.0.0-beta',
+  generatedAt: '2026-04-01T00:00:00.000Z',
+  structure: 'cli',
+  projectName: 'demo',
+  manifestVersion: 2,
+  fileHashes
+})
+
+describe('writeMigratedFile', () => {
+  let projectDir: string
+
+  beforeEach(async () => {
+    projectDir = join(tmpdir(), `sf-mig-conflict-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(projectDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true })
+  })
+
+  it('writes a brand-new file in-place and reports `created`', async () => {
+    const outcome = await writeMigratedFile(projectDir, 'src/email.ts', 'export const x = 1\n', baseManifest())
+    expect(outcome).toBe('created')
+    expect(await readFile(join(projectDir, 'src/email.ts'), 'utf8')).toBe('export const x = 1\n')
+  })
+
+  it('overwrites a tracked file in-place when the user has not edited it', async () => {
+    const original = 'export const x = 1\n'
+    await mkdir(join(projectDir, 'src'), { recursive: true })
+    await writeFile(join(projectDir, 'src/email.ts'), original)
+
+    const manifest = baseManifest({ 'src/email.ts': hashFileContent(original) })
+    const outcome = await writeMigratedFile(projectDir, 'src/email.ts', 'export const x = 2\n', manifest)
+
+    expect(outcome).toBe('inplace')
+    expect(await readFile(join(projectDir, 'src/email.ts'), 'utf8')).toBe('export const x = 2\n')
+  })
+
+  it('writes a sidecar when the user has edited a tracked file', async () => {
+    const original = 'export const x = 1\n'
+    const userEdited = 'export const x = 999 // tweaked locally\n'
+    await mkdir(join(projectDir, 'src'), { recursive: true })
+    await writeFile(join(projectDir, 'src/email.ts'), userEdited)
+
+    const manifest = baseManifest({ 'src/email.ts': hashFileContent(original) })
+    const outcome = await writeMigratedFile(projectDir, 'src/email.ts', 'export const x = 2\n', manifest)
+
+    expect(outcome).toBe('sidecar')
+    expect(await readFile(join(projectDir, 'src/email.ts'), 'utf8')).toBe(userEdited)
+    expect(await readFile(join(projectDir, 'src/email.ts.saasfoundry.new'), 'utf8')).toBe('export const x = 2\n')
+  })
+
+  it('writes in-place when the file is missing on disk even if tracked (regenerated path)', async () => {
+    const manifest = baseManifest({ 'src/email.ts': hashFileContent('whatever\n') })
+    const outcome = await writeMigratedFile(projectDir, 'src/email.ts', 'export const x = 2\n', manifest)
+
+    expect(outcome).toBe('inplace')
+    expect(await readFile(join(projectDir, 'src/email.ts'), 'utf8')).toBe('export const x = 2\n')
+  })
+})

--- a/src/__tests__/unit/migrations/module-registry.spec.ts
+++ b/src/__tests__/unit/migrations/module-registry.spec.ts
@@ -1,0 +1,173 @@
+import { runModuleMigrations } from '../../../migrations/module/registry'
+import type { ModuleMigration } from '../../../migrations/module/types'
+import type { SaaSFoundryManifest } from '../../../types'
+
+jest.mock('../../../installers/registry', () => ({
+  moduleInstallers: [] as never[]
+}))
+
+const installersMock = jest.requireMock('../../../installers/registry') as { moduleInstallers: { name: string; currentVersion: number; migrations: ModuleMigration[] }[] }
+
+const baseManifest = (overrides: Partial<SaaSFoundryManifest> = {}): SaaSFoundryManifest => ({
+  version: '1.0.0-beta',
+  generatedAt: '2026-04-01T00:00:00.000Z',
+  structure: 'cli',
+  projectName: 'demo',
+  manifestVersion: 2,
+  ...overrides
+})
+
+const recordedRuns: { module: string; name: string; projectDir: string; manifestVersion: number | undefined }[] = []
+const trackingMigration = (module: string, from: number, name = `${module}-${from}`): ModuleMigration => ({
+  from,
+  to: from + 1,
+  name,
+  up: async (projectDir, manifest) => {
+    recordedRuns.push({ module, name, projectDir, manifestVersion: manifest.manifestVersion })
+  }
+})
+
+beforeEach(() => {
+  recordedRuns.length = 0
+  installersMock.moduleInstallers.length = 0
+})
+
+describe('runModuleMigrations', () => {
+  it('returns empty applied when manifest has no modules', async () => {
+    const result = await runModuleMigrations(baseManifest(), '/proj')
+    expect(result.applied).toEqual([])
+    expect(result.manifest).toEqual(baseManifest())
+  })
+
+  it('runs pending migrations and bumps version on success', async () => {
+    installersMock.moduleInstallers.push({
+      name: 'email',
+      currentVersion: 3,
+      migrations: [trackingMigration('email', 0), trackingMigration('email', 1), trackingMigration('email', 2)]
+    })
+
+    const manifest = baseManifest({
+      modules: { email: { provider: 'mailersend', version: 1 } } as SaaSFoundryManifest['modules']
+    })
+
+    const result = await runModuleMigrations(manifest, '/proj')
+
+    expect(result.applied).toEqual([{ module: 'email', fromVersion: 1, toVersion: 3, migrations: ['email-1', 'email-2'] }])
+    expect(recordedRuns.map((r) => r.name)).toEqual(['email-1', 'email-2'])
+    expect(result.manifest.modules).toEqual({ email: { provider: 'mailersend', version: 3 } })
+  })
+
+  it('skips when module already at the latest version', async () => {
+    installersMock.moduleInstallers.push({
+      name: 'email',
+      currentVersion: 1,
+      migrations: []
+    })
+
+    const manifest = baseManifest({
+      modules: { email: { provider: 'mailersend', version: 1 } } as SaaSFoundryManifest['modules']
+    })
+
+    const result = await runModuleMigrations(manifest, '/proj')
+
+    expect(result.applied).toEqual([])
+    expect(result.manifest).toBe(manifest)
+  })
+
+  it('ignores modules without a numeric version (legacy / non-versioned shape)', async () => {
+    installersMock.moduleInstallers.push({
+      name: 'analytics',
+      currentVersion: 1,
+      migrations: [trackingMigration('analytics', 0)]
+    })
+
+    const manifest = baseManifest({
+      modules: { analytics: 'enabled' } as unknown as SaaSFoundryManifest['modules']
+    })
+
+    const result = await runModuleMigrations(manifest, '/proj')
+
+    expect(result.applied).toEqual([])
+    expect(recordedRuns).toEqual([])
+  })
+
+  it('ignores modules whose installer is not registered', async () => {
+    const manifest = baseManifest({
+      modules: { unknownModule: { version: 0 } } as unknown as SaaSFoundryManifest['modules']
+    })
+
+    const result = await runModuleMigrations(manifest, '/proj')
+
+    expect(result.applied).toEqual([])
+  })
+
+  it('passes projectDir and the upgraded manifest into each migration', async () => {
+    installersMock.moduleInstallers.push({
+      name: 'email',
+      currentVersion: 1,
+      migrations: [trackingMigration('email', 0)]
+    })
+
+    const manifest = baseManifest({
+      modules: { email: { provider: 'none', version: 0 } } as SaaSFoundryManifest['modules']
+    })
+
+    await runModuleMigrations(manifest, '/some/proj')
+
+    expect(recordedRuns).toEqual([{ module: 'email', name: 'email-0', projectDir: '/some/proj', manifestVersion: 2 }])
+  })
+
+  it('runs each module independently (multiple modules, mixed pending state)', async () => {
+    installersMock.moduleInstallers.push(
+      { name: 'email', currentVersion: 2, migrations: [trackingMigration('email', 0), trackingMigration('email', 1)] },
+      { name: 'storage', currentVersion: 1, migrations: [] }
+    )
+
+    const manifest = baseManifest({
+      modules: {
+        email: { provider: 'mailersend', version: 0 },
+        storage: { version: 1 }
+      } as unknown as SaaSFoundryManifest['modules']
+    })
+
+    const result = await runModuleMigrations(manifest, '/proj')
+
+    expect(result.applied).toEqual([{ module: 'email', fromVersion: 0, toVersion: 2, migrations: ['email-0', 'email-1'] }])
+  })
+
+  it('does not mutate the input manifest object', async () => {
+    installersMock.moduleInstallers.push({
+      name: 'email',
+      currentVersion: 1,
+      migrations: [trackingMigration('email', 0)]
+    })
+
+    const manifest = baseManifest({
+      modules: { email: { provider: 'mailersend', version: 0 } } as SaaSFoundryManifest['modules']
+    })
+    const snapshot = JSON.parse(JSON.stringify(manifest))
+
+    const result = await runModuleMigrations(manifest, '/proj')
+
+    expect(manifest).toEqual(snapshot)
+    expect(result.manifest).not.toBe(manifest)
+  })
+
+  it('propagates errors from a failing migration', async () => {
+    const failing: ModuleMigration = {
+      from: 0,
+      to: 1,
+      name: 'boom',
+      up: async () => {
+        throw new Error('boom')
+      }
+    }
+    installersMock.moduleInstallers.push({ name: 'email', currentVersion: 1, migrations: [failing] })
+
+    const manifest = baseManifest({
+      modules: { email: { provider: 'mailersend', version: 0 } } as SaaSFoundryManifest['modules']
+    })
+
+    await expect(runModuleMigrations(manifest, '/proj')).rejects.toThrow(/boom/)
+  })
+})

--- a/src/__tests__/unit/migrations/registry.spec.ts
+++ b/src/__tests__/unit/migrations/registry.spec.ts
@@ -53,8 +53,11 @@ describe('targetManifestVersion', () => {
     expect(targetManifestVersion([fakeMigration(0), fakeMigration(1), fakeMigration(2)])).toBe(3)
   })
 
-  it('reports the live registry target (currently 1)', () => {
-    expect(targetManifestVersion()).toBe(1)
+  it('reports the live registry target (matches the last shipped migration)', () => {
+    // Reads the live registry rather than pinning a magic number, so adding a
+    // new migration only requires touching the migrations folder + index.
+    const expected = manifestMigrations[manifestMigrations.length - 1].to
+    expect(targetManifestVersion()).toBe(expected)
   })
 })
 
@@ -62,21 +65,23 @@ describe('runManifestMigrations', () => {
   it('runs every migration on a manifest with no manifestVersion (treated as 0)', () => {
     const result = runManifestMigrations(baseManifest)
 
+    const target = manifestMigrations[manifestMigrations.length - 1].to
     expect(result.fromVersion).toBe(0)
-    expect(result.toVersion).toBe(1)
-    expect(result.appliedMigrations).toHaveLength(1)
+    expect(result.toVersion).toBe(target)
+    expect(result.appliedMigrations).toHaveLength(manifestMigrations.length)
     expect(result.appliedMigrations[0].name).toBe('add-schema-url')
     expect(result.manifest.$schema).toBe(manifestSchemaUrl)
-    expect(result.manifest.manifestVersion).toBe(1)
+    expect(result.manifest.manifestVersion).toBe(target)
   })
 
   it('skips when manifest is already at target version', () => {
-    const upToDate: SaaSFoundryManifest = { ...baseManifest, manifestVersion: 1, $schema: manifestSchemaUrl }
+    const target = manifestMigrations[manifestMigrations.length - 1].to
+    const upToDate: SaaSFoundryManifest = { ...baseManifest, manifestVersion: target, $schema: manifestSchemaUrl }
     const result = runManifestMigrations(upToDate)
 
     expect(result.appliedMigrations).toHaveLength(0)
-    expect(result.fromVersion).toBe(1)
-    expect(result.toVersion).toBe(1)
+    expect(result.fromVersion).toBe(target)
+    expect(result.toVersion).toBe(target)
     expect(result.manifest).toBe(upToDate)
   })
 

--- a/src/__tests__/unit/migrations/registry.spec.ts
+++ b/src/__tests__/unit/migrations/registry.spec.ts
@@ -1,0 +1,119 @@
+import { manifestMigrations } from '../../../migrations/manifest'
+import { assertContiguousRegistry, runManifestMigrations, targetManifestVersion } from '../../../migrations/manifest/registry'
+import type { ManifestMigration } from '../../../migrations/manifest/types'
+import { manifestSchemaUrl, type SaaSFoundryManifest } from '../../../types'
+
+const baseManifest: SaaSFoundryManifest = {
+  version: '1.0.0-beta',
+  generatedAt: '2026-04-01T00:00:00.000Z',
+  structure: 'cli',
+  projectName: 'demo'
+}
+
+const fakeMigration = (from: number, name = `mig-${from}`): ManifestMigration => ({
+  from,
+  to: from + 1,
+  name,
+  up: (m) => ({ ...m, manifestVersion: from + 1 })
+})
+
+describe('assertContiguousRegistry', () => {
+  it('accepts an empty registry', () => {
+    expect(() => assertContiguousRegistry([])).not.toThrow()
+  })
+
+  it('accepts a contiguous chain starting at 0', () => {
+    expect(() => assertContiguousRegistry([fakeMigration(0), fakeMigration(1), fakeMigration(2)])).not.toThrow()
+  })
+
+  it('rejects a chain that does not start at 0', () => {
+    expect(() => assertContiguousRegistry([fakeMigration(1)])).toThrow(/gap at version 0/)
+  })
+
+  it('rejects a gap between consecutive migrations', () => {
+    expect(() => assertContiguousRegistry([fakeMigration(0), fakeMigration(2)])).toThrow(/gap at version 1/)
+  })
+
+  it('rejects a migration whose to !== from + 1', () => {
+    const broken: ManifestMigration = { from: 0, to: 5, name: 'jump', up: (m) => m }
+    expect(() => assertContiguousRegistry([broken])).toThrow(/to === from \+ 1/)
+  })
+
+  it('validates the live registry shipped with the CLI', () => {
+    expect(() => assertContiguousRegistry(manifestMigrations)).not.toThrow()
+  })
+})
+
+describe('targetManifestVersion', () => {
+  it('returns 0 for an empty registry', () => {
+    expect(targetManifestVersion([])).toBe(0)
+  })
+
+  it('returns the highest to value', () => {
+    expect(targetManifestVersion([fakeMigration(0), fakeMigration(1), fakeMigration(2)])).toBe(3)
+  })
+
+  it('reports the live registry target (currently 1)', () => {
+    expect(targetManifestVersion()).toBe(1)
+  })
+})
+
+describe('runManifestMigrations', () => {
+  it('runs every migration on a manifest with no manifestVersion (treated as 0)', () => {
+    const result = runManifestMigrations(baseManifest)
+
+    expect(result.fromVersion).toBe(0)
+    expect(result.toVersion).toBe(1)
+    expect(result.appliedMigrations).toHaveLength(1)
+    expect(result.appliedMigrations[0].name).toBe('add-schema-url')
+    expect(result.manifest.$schema).toBe(manifestSchemaUrl)
+    expect(result.manifest.manifestVersion).toBe(1)
+  })
+
+  it('skips when manifest is already at target version', () => {
+    const upToDate: SaaSFoundryManifest = { ...baseManifest, manifestVersion: 1, $schema: manifestSchemaUrl }
+    const result = runManifestMigrations(upToDate)
+
+    expect(result.appliedMigrations).toHaveLength(0)
+    expect(result.fromVersion).toBe(1)
+    expect(result.toVersion).toBe(1)
+    expect(result.manifest).toBe(upToDate)
+  })
+
+  it('runs only the remaining migrations when partially applied', () => {
+    const registry = [fakeMigration(0, 'a'), fakeMigration(1, 'b'), fakeMigration(2, 'c')]
+    const partial: SaaSFoundryManifest = { ...baseManifest, manifestVersion: 1 }
+
+    const result = runManifestMigrations(partial, registry)
+
+    expect(result.appliedMigrations.map((m) => m.name)).toEqual(['b', 'c'])
+    expect(result.fromVersion).toBe(1)
+    expect(result.toVersion).toBe(3)
+    expect(result.manifest.manifestVersion).toBe(3)
+  })
+
+  it('is idempotent — running the dispatcher twice produces the same result', () => {
+    const once = runManifestMigrations(baseManifest)
+    const twice = runManifestMigrations(once.manifest)
+
+    expect(twice.appliedMigrations).toHaveLength(0)
+    expect(twice.manifest).toEqual(once.manifest)
+  })
+
+  it('asserts registry contiguity before mutating the manifest', () => {
+    const broken = [fakeMigration(0), fakeMigration(2)]
+    expect(() => runManifestMigrations(baseManifest, broken)).toThrow(/gap at version 1/)
+  })
+
+  it('propagates errors from a failing migration', () => {
+    const failing: ManifestMigration = {
+      from: 0,
+      to: 1,
+      name: 'boom',
+      up: () => {
+        throw new Error('boom')
+      }
+    }
+    expect(() => runManifestMigrations(baseManifest, [failing])).toThrow(/boom/)
+  })
+})

--- a/src/__tests__/unit/prompts/update.prompts.spec.ts
+++ b/src/__tests__/unit/prompts/update.prompts.spec.ts
@@ -5,7 +5,7 @@ describe('getAvailableModules', () => {
   it('should return all modules when nothing is installed', () => {
     const manifest = manifestFixture({
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'manual',
         dbSetup: 'docker',
         includeAnalytics: false,
@@ -23,7 +23,7 @@ describe('getAvailableModules', () => {
   it('should exclude email when mailersend is already installed', () => {
     const manifest = manifestFixture({
       modules: {
-        emailService: 'mailersend',
+        email: { provider: 'mailersend', version: 1 },
         s3Setup: 'manual',
         dbSetup: 'docker',
         includeAnalytics: false,
@@ -39,7 +39,7 @@ describe('getAvailableModules', () => {
   it('should exclude storage when s3Setup is not manual', () => {
     const manifest = manifestFixture({
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'docker',
         dbSetup: 'docker',
         includeAnalytics: false,
@@ -55,7 +55,7 @@ describe('getAvailableModules', () => {
   it('should also exclude storage when s3Setup is credentials', () => {
     const manifest = manifestFixture({
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'credentials',
         dbSetup: 'docker',
         includeAnalytics: false,
@@ -71,7 +71,7 @@ describe('getAvailableModules', () => {
   it('should exclude analytics when already enabled', () => {
     const manifest = manifestFixture({
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'manual',
         dbSetup: 'docker',
         includeAnalytics: true,
@@ -87,7 +87,7 @@ describe('getAvailableModules', () => {
   it('should exclude installed advanced skills', () => {
     const manifest = manifestFixture({
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'manual',
         dbSetup: 'docker',
         includeAnalytics: false,
@@ -106,7 +106,7 @@ describe('getAvailableModules', () => {
   it('should exclude srs when already enabled in the manifest', () => {
     const manifest = manifestFixture({
       modules: {
-        emailService: 'none',
+        email: { provider: 'none', version: 1 },
         s3Setup: 'manual',
         dbSetup: 'docker',
         includeAnalytics: false,
@@ -123,7 +123,7 @@ describe('getAvailableModules', () => {
   it('should return empty array when everything is installed', () => {
     const manifest = manifestFixture({
       modules: {
-        emailService: 'mailersend',
+        email: { provider: 'mailersend', version: 1 },
         s3Setup: 'docker',
         dbSetup: 'docker',
         includeAnalytics: true,

--- a/src/__tests__/unit/skill/manifest-schema.spec.ts
+++ b/src/__tests__/unit/skill/manifest-schema.spec.ts
@@ -33,7 +33,7 @@ describe('saasfoundry-manifest.schema.json — canonical shapes', () => {
     const full = {
       ...baseManifest,
       modules: {
-        emailService: 'mailersend',
+        email: { provider: 'mailersend', version: 1 },
         s3Setup: 'docker',
         dbSetup: 'credentials',
         includeAnalytics: true,

--- a/src/__tests__/unit/skill/read-project.spec.ts
+++ b/src/__tests__/unit/skill/read-project.spec.ts
@@ -64,7 +64,7 @@ describe('skill/read-project', () => {
           structure: 'monorepo',
           version: '1.0.0-beta',
           generatedAt: '2026-04-01T10:00:00Z',
-          modules: { emailService: 'mailersend' }
+          modules: { email: { provider: 'mailersend', version: 1 } }
         },
         catalogue: fullCatalogue
       })
@@ -89,7 +89,7 @@ describe('skill/read-project', () => {
           structure: 'multirepo',
           version: '1.0.0-beta',
           modules: {
-            emailService: 'mailersend',
+            email: { provider: 'mailersend', version: 1 },
             s3Setup: 'docker',
             includeAnalytics: true,
             advancedSkills: ['context7', 'notion']
@@ -127,7 +127,7 @@ describe('skill/read-project', () => {
           projectName: 'stale',
           structure: 'monorepo',
           version: '1.0.0-beta',
-          modules: { emailService: 'mailersend', s3Setup: 'docker' }
+          modules: { email: { provider: 'mailersend', version: 1 }, s3Setup: 'docker' }
         },
         catalogue: [
           { name: 'email', minCliVersion: '1.1.0' },
@@ -144,7 +144,7 @@ describe('skill/read-project', () => {
           projectName: 'lean',
           structure: 'monorepo',
           version: '1.0.0-beta',
-          modules: { emailService: 'mailersend' }
+          modules: { email: { provider: 'mailersend', version: 1 } }
         },
         catalogue: [
           { name: 'email', minCliVersion: '1.0.0-beta' },
@@ -163,7 +163,7 @@ describe('skill/read-project', () => {
           projectName: 'offline',
           structure: 'monorepo',
           version: '1.0.0-beta',
-          modules: { emailService: 'mailersend' }
+          modules: { email: { provider: 'mailersend', version: 1 } }
         },
         catalogue: []
       })
@@ -189,12 +189,12 @@ describe('skill/read-project', () => {
       expect(report.modules.installed).toEqual([])
     })
 
-    it('treats emailService="none" as not installed', async () => {
+    it('treats email.provider="none" as not installed', async () => {
       const report = await runAndParse({
         manifest: {
           projectName: 'no-email',
           version: '1.0.0-beta',
-          modules: { emailService: 'none', includeAnalytics: true }
+          modules: { email: { provider: 'none', version: 1 }, includeAnalytics: true }
         },
         catalogue: fullCatalogue
       })

--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -320,7 +320,7 @@ describe('utils', () => {
         structure: 'monorepo',
         projectName: 'test-project',
         modules: {
-          emailService: 'none',
+          email: { provider: 'none', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'docker',
           includeAnalytics: false,
@@ -356,7 +356,7 @@ describe('utils', () => {
         structure: 'monorepo',
         projectName: 'srs-enabled',
         modules: {
-          emailService: 'none',
+          email: { provider: 'none', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'docker',
           includeAnalytics: false,
@@ -390,7 +390,7 @@ describe('utils', () => {
         structure: 'multirepo',
         projectName: 'legacy',
         modules: {
-          emailService: 'mailersend',
+          email: { provider: 'mailersend', version: 1 },
           s3Setup: 'manual',
           dbSetup: 'docker',
           includeAnalytics: true,

--- a/src/commands/modules.ts
+++ b/src/commands/modules.ts
@@ -84,7 +84,7 @@ function isInstalled(module: ModuleDefinition, manifest: SaaSFoundryManifest | n
 
   switch (module.name) {
     case 'email':
-      return manifest.modules.emailService === 'mailersend'
+      return manifest.modules.email.provider === 'mailersend'
     case 'storage':
       return manifest.modules.s3Setup === 'docker' || manifest.modules.s3Setup === 'credentials'
     case 'analytics':

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -252,7 +252,7 @@ export async function newCommand(opts: NewCommandOptions = {}) {
       structure: startProjectAnswers.isMonorepo ? 'monorepo' : 'multirepo',
       projectName: startProjectAnswers.projectName,
       modules: {
-        emailService: startProjectAnswers.emailService,
+        email: { provider: startProjectAnswers.emailService, version: 1 },
         s3Setup: startProjectAnswers.s3Setup,
         dbSetup: startProjectAnswers.dbSetup,
         includeAnalytics: startProjectAnswers.includeAnalytics,

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -17,6 +17,7 @@ import { initAndStartS3 } from '../runners/s3.runner'
 import { startBackend, startFrontend, startMonorepoApps, waitForServer } from '../runners/server.runner'
 import { bootstrapSrs } from '../runners/srs.runner'
 import { getHuskySetupCommand, openTerminal } from '../runners/terminal.runner'
+import { targetManifestVersion } from '../migrations/manifest/registry'
 import { NotionSrsAdapter } from '../tools/notion/srs.adapter'
 import { manifestSchemaUrl, SaaSFoundryManifest, SrsToolConfig } from '../types'
 import { upsertEnvKey } from '../utils/env-file'
@@ -245,6 +246,7 @@ export async function newCommand(opts: NewCommandOptions = {}) {
     const fileHashes = await computeFileHashes('.')
     const manifest: SaaSFoundryManifest = {
       $schema: manifestSchemaUrl,
+      manifestVersion: targetManifestVersion(),
       version: cliVersion,
       generatedAt: new Date().toISOString(),
       structure: startProjectAnswers.isMonorepo ? 'monorepo' : 'multirepo',

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -70,10 +70,10 @@ async function regenerateInTempDir(manifest: SaaSFoundryManifest): Promise<{ tem
       backendRepoUrl: '',
       dbCredentials: { host: 'localhost', port: '5435', user: 'user', password: 'pass', database: 'db', dbType: 'postgresql' },
       mainBranch: 'main',
-      emailService: manifest.modules.emailService,
-      mailersendApiKey: manifest.modules.emailService === 'mailersend' ? 'dummy-key' : undefined,
-      mailersendSenderEmail: manifest.modules.emailService === 'mailersend' ? 'noreply@example.com' : undefined,
-      mailersendSenderName: manifest.modules.emailService === 'mailersend' ? 'App' : undefined,
+      emailService: manifest.modules.email.provider,
+      mailersendApiKey: manifest.modules.email.provider === 'mailersend' ? 'dummy-key' : undefined,
+      mailersendSenderEmail: manifest.modules.email.provider === 'mailersend' ? 'noreply@example.com' : undefined,
+      mailersendSenderName: manifest.modules.email.provider === 'mailersend' ? 'App' : undefined,
       s3Setup: manifest.modules.s3Setup,
       s3Credentials: manifest.modules.s3Setup === 'credentials' ? { endpoint: '', accessKey: '', secretKey: '', bucket: '', region: '' } : undefined,
       advancedSkills: manifest.modules.advancedSkills || []
@@ -603,7 +603,7 @@ export async function updateCommand(opts: UpdateCommandOptions = {}) {
         mailersendSenderEmail: emailCredentials.mailersendSenderEmail,
         mailersendSenderName: emailCredentials.mailersendSenderName
       })
-      manifest.modules!.emailService = 'mailersend'
+      manifest.modules!.email = { provider: 'mailersend', version: 1 }
     }
 
     if (selectedModules.includes('storage') && storageConfig) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -22,7 +22,8 @@ import { AdvancedSkillCredentials } from '../prompts/skills.prompts'
 import { promptSrsConfiguration } from '../prompts/srs.prompts'
 import { bootstrapSrs } from '../runners/srs.runner'
 import { NotionSrsAdapter } from '../tools/notion/srs.adapter'
-import { manifestSchemaUrl, SaaSFoundryManifest, SrsToolConfig } from '../types'
+import { runManifestMigrations } from '../migrations/manifest/registry'
+import { SaaSFoundryManifest, SrsToolConfig } from '../types'
 import { upsertEnvKey } from '../utils/env-file'
 import { ensureGitignorePatterns } from '../utils/gitignore'
 import { checkNodeVersion, computeFileHashes, fileExists, getNvmPrefix } from '../utils'
@@ -284,12 +285,17 @@ export async function updateCommand(opts: UpdateCommandOptions = {}) {
 
   let manifest: SaaSFoundryManifest = JSON.parse(await readFile(manifestPath, 'utf8'))
 
-  // Idempotent $schema migration: stamp the canonical URL on legacy manifests
-  // and persist immediately so the field survives early-return paths (dry-run
-  // aside — we never mutate the disk in dry-run mode). Preserves user-customized
-  // values. Rebuilt with $schema first to match the sf new output shape.
-  if (!manifest.$schema) {
-    manifest = { $schema: manifestSchemaUrl, ...manifest }
+  // Run the manifest migration chain. Idempotent at the chain level — a
+  // manifest already at the target version returns unchanged with an empty
+  // appliedMigrations list. Persisted immediately so any subsequent early-
+  // return path (skill install, dry-run aside) sees the upgraded shape.
+  const migrationResult = runManifestMigrations(manifest)
+  if (migrationResult.appliedMigrations.length > 0) {
+    manifest = migrationResult.manifest
+    console.log(chalk.gray(`  Manifest migrated: v${migrationResult.fromVersion} → v${migrationResult.toVersion}`))
+    for (const m of migrationResult.appliedMigrations) {
+      console.log(chalk.gray(`    • ${String(m.from).padStart(3, '0')} → ${String(m.to).padStart(3, '0')}  ${m.name}`))
+    }
     if (!dryRun) {
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2))
     }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -23,6 +23,7 @@ import { promptSrsConfiguration } from '../prompts/srs.prompts'
 import { bootstrapSrs } from '../runners/srs.runner'
 import { NotionSrsAdapter } from '../tools/notion/srs.adapter'
 import { runManifestMigrations } from '../migrations/manifest/registry'
+import { runModuleMigrations } from '../migrations/module/registry'
 import { SaaSFoundryManifest, SrsToolConfig } from '../types'
 import { upsertEnvKey } from '../utils/env-file'
 import { ensureGitignorePatterns } from '../utils/gitignore'
@@ -295,6 +296,23 @@ export async function updateCommand(opts: UpdateCommandOptions = {}) {
     console.log(chalk.gray(`  Manifest migrated: v${migrationResult.fromVersion} → v${migrationResult.toVersion}`))
     for (const m of migrationResult.appliedMigrations) {
       console.log(chalk.gray(`    • ${String(m.from).padStart(3, '0')} → ${String(m.to).padStart(3, '0')}  ${m.name}`))
+    }
+    if (!dryRun) {
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2))
+    }
+  }
+
+  // Per-module migration chain — runs after the manifest chain so each
+  // migration sees the upgraded shape, and before any template regeneration so
+  // the regenerated project uses the post-migration module versions. Mutations
+  // to user files go through `writeMigratedFile`, which falls back to a
+  // `.saasfoundry.new` sidecar when the user has hand-edited the target.
+  const moduleMigrationResult = await runModuleMigrations(manifest, '.')
+  if (moduleMigrationResult.applied.length > 0) {
+    manifest = moduleMigrationResult.manifest
+    for (const a of moduleMigrationResult.applied) {
+      const chain = a.migrations.map((name, i) => `${String(a.fromVersion + i).padStart(3, '0')}→${String(a.fromVersion + i + 1).padStart(3, '0')} ${name}`).join(', ')
+      console.log(chalk.gray(`  Migrated module '${a.module}' v${a.fromVersion} → v${a.toVersion} via [${chain}]`))
     }
     if (!dryRun) {
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2))

--- a/src/installers/analytics.installer.ts
+++ b/src/installers/analytics.installer.ts
@@ -2,8 +2,15 @@ import { copy } from 'fs-extra'
 import { readFile, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 
+import type { ModuleInstaller } from '../migrations/module/types'
 import { overlaysPath } from '../types'
 import { fileExists } from '../utils'
+
+export const analyticsInstallerMeta: ModuleInstaller = {
+  name: 'analytics',
+  currentVersion: 1,
+  migrations: []
+}
 
 interface InstallAnalyticsModuleParams {
   webPath: string

--- a/src/installers/core-skills.installer.ts
+++ b/src/installers/core-skills.installer.ts
@@ -2,7 +2,14 @@ import { copy } from 'fs-extra'
 import { mkdir } from 'fs/promises'
 import { join } from 'path'
 
+import type { ModuleInstaller } from '../migrations/module/types'
 import { skillsTemplatesPath } from '../types'
+
+export const coreSkillsInstallerMeta: ModuleInstaller = {
+  name: 'core-skills',
+  currentVersion: 1,
+  migrations: []
+}
 
 interface InstallCoreSkillsParams {
   targetPath: string

--- a/src/installers/email.installer.ts
+++ b/src/installers/email.installer.ts
@@ -3,8 +3,15 @@ import { existsSync } from 'fs'
 import { readFile, rename, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 
+import type { ModuleInstaller } from '../migrations/module/types'
 import { overlaysPath } from '../types'
 import { fileExists } from '../utils'
+
+export const emailInstallerMeta: ModuleInstaller = {
+  name: 'email',
+  currentVersion: 1,
+  migrations: []
+}
 
 interface InstallEmailModuleParams {
   apiPath: string

--- a/src/installers/registry.ts
+++ b/src/installers/registry.ts
@@ -1,0 +1,36 @@
+import { analyticsInstallerMeta } from './analytics.installer'
+import { coreSkillsInstallerMeta } from './core-skills.installer'
+import { emailInstallerMeta } from './email.installer'
+import { skillsInstallerMeta } from './skills.installer'
+import { srsSkillInstallerMeta } from './srs-skill.installer'
+import { storageInstallerMeta } from './storage.installer'
+import { toolSkillInstallerMeta } from './tool-skill.installer'
+import { workflowSkillInstallerMeta } from './workflow-skill.installer'
+import type { ModuleInstaller } from '../migrations/module/types'
+
+/**
+ * Single source of truth for all module installers the dispatcher (#386)
+ * needs to know about. Each entry pairs a module's `name` with the
+ * `currentVersion` a fresh install stamps onto `manifest.modules.<name>.version`
+ * and the ordered `migrations` chain replayed against modules already installed
+ * at an older version.
+ *
+ * Modules ship empty `migrations: []` until the first breaking change to their
+ * on-disk shape; at that point the installer file gains a `migrations/` folder
+ * with `001-<name>.ts`, the registry call below picks it up automatically, and
+ * `currentVersion` bumps in lockstep.
+ */
+export const moduleInstallers: ModuleInstaller[] = [
+  emailInstallerMeta,
+  storageInstallerMeta,
+  analyticsInstallerMeta,
+  srsSkillInstallerMeta,
+  skillsInstallerMeta,
+  coreSkillsInstallerMeta,
+  toolSkillInstallerMeta,
+  workflowSkillInstallerMeta
+]
+
+export function getModuleInstaller(name: string): ModuleInstaller | undefined {
+  return moduleInstallers.find((installer) => installer.name === name)
+}

--- a/src/installers/skills.installer.ts
+++ b/src/installers/skills.installer.ts
@@ -3,7 +3,14 @@ import { readFile, writeFile } from 'fs/promises'
 import { installClaudeDocs } from './claude-docs.installer'
 import { installCoreSkills } from './core-skills.installer'
 import { installOptionalSkills } from './optional-skills.installer'
+import type { ModuleInstaller } from '../migrations/module/types'
 import { fileExists } from '../utils'
+
+export const skillsInstallerMeta: ModuleInstaller = {
+  name: 'skills',
+  currentVersion: 1,
+  migrations: []
+}
 
 interface InstallSkillsParams {
   isMonorepo: boolean

--- a/src/installers/srs-skill.installer.ts
+++ b/src/installers/srs-skill.installer.ts
@@ -2,7 +2,14 @@ import { copy, pathExists } from 'fs-extra'
 import { chmod, stat } from 'fs/promises'
 import { join, resolve } from 'path'
 
+import type { ModuleInstaller } from '../migrations/module/types'
 import { skillsTemplatesPath } from '../types'
+
+export const srsSkillInstallerMeta: ModuleInstaller = {
+  name: 'srs-skill',
+  currentVersion: 1,
+  migrations: []
+}
 
 interface InstallSrsSkillParams {
   targetPath: string

--- a/src/installers/storage.installer.ts
+++ b/src/installers/storage.installer.ts
@@ -4,8 +4,15 @@ import { readFile, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 import { exec } from 'shelljs'
 
+import type { ModuleInstaller } from '../migrations/module/types'
 import { overlaysPath, S3Credentials } from '../types'
 import { fileExists, getNvmPrefix } from '../utils'
+
+export const storageInstallerMeta: ModuleInstaller = {
+  name: 'storage',
+  currentVersion: 1,
+  migrations: []
+}
 
 interface InstallStorageModuleParams {
   apiPath: string

--- a/src/installers/tool-skill.installer.ts
+++ b/src/installers/tool-skill.installer.ts
@@ -2,7 +2,14 @@ import { copy } from 'fs-extra'
 import { mkdir, writeFile } from 'fs/promises'
 import { join } from 'path'
 
+import type { ModuleInstaller } from '../migrations/module/types'
 import { skillsTemplatesPath } from '../types'
+
+export const toolSkillInstallerMeta: ModuleInstaller = {
+  name: 'tool-skill',
+  currentVersion: 1,
+  migrations: []
+}
 
 interface InstallToolSkillParams {
   targetPath: string

--- a/src/installers/workflow-skill.installer.ts
+++ b/src/installers/workflow-skill.installer.ts
@@ -2,8 +2,15 @@ import { copy } from 'fs-extra'
 import { readFile, writeFile } from 'fs/promises'
 import { resolve } from 'path'
 
+import type { ModuleInstaller } from '../migrations/module/types'
 import { WorkflowConfig, skillsTemplatesPath } from '../types'
 import { fileExists } from '../utils'
+
+export const workflowSkillInstallerMeta: ModuleInstaller = {
+  name: 'workflow-skill',
+  currentVersion: 1,
+  migrations: []
+}
 
 interface InstallWorkflowSkillParams {
   targetPath: string

--- a/src/migrations/manifest/001-add-schema-url.ts
+++ b/src/migrations/manifest/001-add-schema-url.ts
@@ -1,0 +1,24 @@
+import { manifestSchemaUrl, type SaaSFoundryManifest } from '../../types'
+import type { ManifestMigration } from './types'
+
+/**
+ * Migration 001: stamp `$schema` URL on legacy manifests.
+ *
+ * Manifests generated before PR #290 lack the `$schema` pointer, which prevents
+ * IDE live validation. This migration adds it (preserving any user override) and
+ * sets `manifestVersion = 1` so the dispatcher knows the manifest is up to this
+ * shape revision.
+ *
+ * Replaces the inline `$schema` stamp previously embedded in `sf update` once
+ * the dispatcher is wired (see Epic #310 — sub S1.C).
+ */
+export const migration001: ManifestMigration = {
+  from: 0,
+  to: 1,
+  name: 'add-schema-url',
+  up(manifest) {
+    const next: SaaSFoundryManifest = manifest.$schema ? { ...manifest } : { $schema: manifestSchemaUrl, ...manifest }
+    next.manifestVersion = 1
+    return next
+  }
+}

--- a/src/migrations/manifest/002-restructure-email.ts
+++ b/src/migrations/manifest/002-restructure-email.ts
@@ -1,0 +1,43 @@
+import type { SaaSFoundryManifest } from '../../types'
+import type { ManifestMigration } from './types'
+
+/**
+ * Migration 002: restructure `modules.emailService` (flat enum) into the
+ * versioned `modules.email = { provider, version }` shape introduced in
+ * manifestVersion 2.
+ *
+ * Why: per-module migrations (Epic #310 — S3.B/S3.C) need a place to record
+ * the installed module version. Lifting the email setting from a bare enum
+ * into an object is the smallest change that lets future module migrations
+ * dispatch off `email.version` without another schema bump.
+ *
+ * The legacy `emailService` field is removed — the JSON schema rejects
+ * unknown properties at the modules level, so leaving it would fail
+ * post-migration validation.
+ */
+export const migration002: ManifestMigration = {
+  from: 1,
+  to: 2,
+  name: 'restructure-email',
+  up(manifest) {
+    const next: SaaSFoundryManifest = { ...manifest, manifestVersion: 2 }
+
+    if (manifest.modules) {
+      // The pre-migration shape has `emailService` (flat) but the post-migration
+      // type does not — read it through a defensive cast that does not assume
+      // either shape, so the migration is safe to run on partially-migrated
+      // input (e.g. hand-edited manifests).
+      const legacyModules = manifest.modules as typeof manifest.modules & { emailService?: 'none' | 'mailersend' }
+      const provider = legacyModules.email?.provider ?? legacyModules.emailService ?? 'none'
+
+      const { emailService: _drop, ...rest } = legacyModules
+      void _drop
+      next.modules = {
+        ...rest,
+        email: { provider, version: 1 }
+      }
+    }
+
+    return next
+  }
+}

--- a/src/migrations/manifest/002-restructure-email.ts
+++ b/src/migrations/manifest/002-restructure-email.ts
@@ -29,12 +29,16 @@ export const migration002: ManifestMigration = {
       // input (e.g. hand-edited manifests).
       const legacyModules = manifest.modules as typeof manifest.modules & { emailService?: 'none' | 'mailersend' }
       const provider = legacyModules.email?.provider ?? legacyModules.emailService ?? 'none'
+      // Preserve any pre-existing `email.version` so a hand-edited manifest
+      // with a future module-migration target isn't downgraded by this run.
+      // Fresh manifests without the nested shape default to version 1.
+      const version = legacyModules.email?.version ?? 1
 
       const { emailService: _drop, ...rest } = legacyModules
       void _drop
       next.modules = {
         ...rest,
-        email: { provider, version: 1 }
+        email: { provider, version }
       }
     }
 

--- a/src/migrations/manifest/index.ts
+++ b/src/migrations/manifest/index.ts
@@ -1,0 +1,13 @@
+import { migration001 } from './001-add-schema-url'
+import type { ManifestMigration } from './types'
+
+/**
+ * Ordered registry of every manifest migration shipped by the CLI.
+ *
+ * To add a new migration:
+ * 1. Create `NNN-<name>.ts` in this folder, exporting a `ManifestMigration`
+ *    with `from = N - 1`, `to = N`.
+ * 2. Append it here in order. The dispatcher validates contiguity at runtime —
+ *    a gap or duplicate `to` value throws before any user manifest is touched.
+ */
+export const manifestMigrations: ManifestMigration[] = [migration001]

--- a/src/migrations/manifest/index.ts
+++ b/src/migrations/manifest/index.ts
@@ -1,4 +1,5 @@
 import { migration001 } from './001-add-schema-url'
+import { migration002 } from './002-restructure-email'
 import type { ManifestMigration } from './types'
 
 /**
@@ -10,4 +11,4 @@ import type { ManifestMigration } from './types'
  * 2. Append it here in order. The dispatcher validates contiguity at runtime —
  *    a gap or duplicate `to` value throws before any user manifest is touched.
  */
-export const manifestMigrations: ManifestMigration[] = [migration001]
+export const manifestMigrations: ManifestMigration[] = [migration001, migration002]

--- a/src/migrations/manifest/registry.ts
+++ b/src/migrations/manifest/registry.ts
@@ -1,0 +1,73 @@
+import type { SaaSFoundryManifest } from '../../types'
+import { manifestMigrations } from './index'
+import type { ManifestMigration } from './types'
+
+export interface ManifestMigrationRunResult {
+  manifest: SaaSFoundryManifest
+  appliedMigrations: ManifestMigration[]
+  fromVersion: number
+  toVersion: number
+}
+
+/**
+ * Returns the highest `to` value across the registry — i.e. the schema-shape
+ * version any newly-generated manifest should claim. Returns 0 when no
+ * migrations are registered (defensive — should never happen in production).
+ */
+export function targetManifestVersion(registry: ManifestMigration[] = manifestMigrations): number {
+  if (registry.length === 0) return 0
+  return registry[registry.length - 1].to
+}
+
+/**
+ * Validates that the registry is a contiguous chain starting at 0.
+ *
+ * Throws if any migration has `to !== from + 1`, if there is a gap between
+ * two consecutive migrations, or if the chain does not start at `from = 0`.
+ * Called eagerly by `runManifestMigrations` so a malformed registry fails
+ * fast at the boundary, before mutating any user manifest.
+ */
+export function assertContiguousRegistry(registry: ManifestMigration[]): void {
+  if (registry.length === 0) return
+  let expected = 0
+  for (const m of registry) {
+    if (m.to !== m.from + 1) {
+      throw new Error(`Manifest migration "${m.name}" must have to === from + 1 (got from=${m.from}, to=${m.to}).`)
+    }
+    if (m.from !== expected) {
+      throw new Error(`Manifest migration registry has a gap at version ${expected}: next migration is "${m.name}" (from=${m.from}).`)
+    }
+    expected = m.to
+  }
+}
+
+/**
+ * Runs every registered migration whose `from` is at or above the manifest's
+ * current `manifestVersion` (treating absence as 0). Idempotent at the chain
+ * level — a manifest already at the target version is returned unchanged with
+ * an empty `appliedMigrations` list.
+ *
+ * Each migration's `up` is expected to be pure; this function does not catch
+ * exceptions — a thrown migration aborts the chain so the caller can persist
+ * the partial result up to (but excluding) the failing step if it chooses.
+ */
+export function runManifestMigrations(manifest: SaaSFoundryManifest, registry: ManifestMigration[] = manifestMigrations): ManifestMigrationRunResult {
+  assertContiguousRegistry(registry)
+
+  const fromVersion = manifest.manifestVersion ?? 0
+  const target = targetManifestVersion(registry)
+
+  if (fromVersion >= target) {
+    return { manifest, appliedMigrations: [], fromVersion, toVersion: fromVersion }
+  }
+
+  let current = manifest
+  const applied: ManifestMigration[] = []
+  for (const m of registry) {
+    if (m.from < fromVersion) continue
+    current = m.up(current)
+    applied.push(m)
+  }
+
+  return { manifest: current, appliedMigrations: applied, fromVersion, toVersion: target }
+}

--- a/src/migrations/manifest/types.ts
+++ b/src/migrations/manifest/types.ts
@@ -1,0 +1,18 @@
+import type { SaaSFoundryManifest } from '../../types'
+
+/**
+ * A manifest migration upgrades a manifest from one schema-shape version to the next.
+ *
+ * Contract:
+ * - `from` and `to` are monotonic integers; `to === from + 1`.
+ * - `up` MUST be pure and idempotent: running it twice on the same input yields
+ *   the same output as running it once. The dispatcher relies on this so a half-
+ *   applied migration can be re-run safely.
+ * - `up` MUST set `manifestVersion = to` on the returned manifest.
+ */
+export interface ManifestMigration {
+  from: number
+  to: number
+  name: string
+  up(manifest: SaaSFoundryManifest): SaaSFoundryManifest
+}

--- a/src/migrations/module/conflict.ts
+++ b/src/migrations/module/conflict.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'fs'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+
+import type { SaaSFoundryManifest } from '../../types'
+import { hashFileContent } from '../../utils'
+
+export type WriteOutcome = 'inplace' | 'sidecar' | 'created'
+
+/**
+ * Conflict-aware writer module migrations should use instead of `fs.writeFile`
+ * when mutating files in the user's project. Mirrors the 3-way merge UX from
+ * `sf update`'s template-update flow:
+ *
+ * 1. New file (no entry in `manifest.fileHashes`)             → write in-place,
+ *    return `'created'`.
+ * 2. Tracked file matching its recorded hash (no user edits)  → write in-place,
+ *    return `'inplace'`.
+ * 3. Tracked file whose current hash diverges from the recorded one (user
+ *    edited it)                                                → write to
+ *    `<path>.saasfoundry.new`, return `'sidecar'`. The user reconciles the
+ *    sidecar manually, same as for template updates.
+ *
+ * Migrations stay pure with respect to user intent: we never silently overwrite
+ * customised code.
+ */
+export async function writeMigratedFile(projectDir: string, relPath: string, newContent: string, manifest: SaaSFoundryManifest): Promise<WriteOutcome> {
+  const fullPath = join(projectDir, relPath)
+  const tracked = manifest.fileHashes?.[relPath]
+
+  if (tracked && existsSync(fullPath)) {
+    const current = await readFile(fullPath, 'utf8')
+    if (hashFileContent(current) !== tracked) {
+      await mkdir(dirname(fullPath), { recursive: true })
+      await writeFile(`${fullPath}.saasfoundry.new`, newContent)
+      return 'sidecar'
+    }
+    await writeFile(fullPath, newContent)
+    return 'inplace'
+  }
+
+  await mkdir(dirname(fullPath), { recursive: true })
+  await writeFile(fullPath, newContent)
+  return tracked ? 'inplace' : 'created'
+}

--- a/src/migrations/module/registry.ts
+++ b/src/migrations/module/registry.ts
@@ -1,0 +1,84 @@
+import { moduleInstallers } from '../../installers/registry'
+import type { SaaSFoundryManifest } from '../../types'
+import type { ModuleInstaller, ModuleMigration } from './types'
+
+export interface AppliedModuleMigrations {
+  module: string
+  fromVersion: number
+  toVersion: number
+  migrations: string[]
+}
+
+export interface ModuleMigrationResult {
+  applied: AppliedModuleMigrations[]
+  manifest: SaaSFoundryManifest
+}
+
+/**
+ * Walks every entry in `manifest.modules`, looks up the matching installer,
+ * filters its migrations to those `from >= installed-version`, and runs them
+ * in order. Each migration receives `(projectDir, manifest)` and may mutate
+ * files via `writeMigratedFile` (or any other side effect). On success, the
+ * dispatcher bumps `manifest.modules.<name>.version` to the migration's `to`
+ * — module migrations don't touch the manifest themselves, mirroring how
+ * the manifest dispatcher owns `manifestVersion`.
+ *
+ * Returns the (possibly mutated) manifest and an `applied` summary the caller
+ * can log + persist. Modules without an entry in the installer registry are
+ * skipped silently — they may be legacy modules removed from the catalogue,
+ * and the dispatcher should not crash on them.
+ *
+ * Idempotent at the chain level: running it twice on a fully-up-to-date
+ * project returns `applied: []` and the manifest unchanged.
+ */
+export async function runModuleMigrations(manifest: SaaSFoundryManifest, projectDir: string): Promise<ModuleMigrationResult> {
+  if (!manifest.modules) return { applied: [], manifest }
+
+  const applied: AppliedModuleMigrations[] = []
+  // Shallow-clone modules so we don't mutate the input — the new object is
+  // re-assigned below only if at least one migration ran.
+  const nextModules: Record<string, unknown> = { ...(manifest.modules as Record<string, unknown>) }
+  let manifestChanged = false
+
+  for (const [moduleName, moduleEntry] of Object.entries(nextModules)) {
+    if (!isVersionedModuleEntry(moduleEntry)) continue
+
+    const installer = moduleInstallers.find((i) => i.name === moduleName)
+    if (!installer) continue
+
+    const migrationsToRun = pendingMigrations(installer, moduleEntry.version)
+    if (migrationsToRun.length === 0) continue
+
+    const fromVersion = moduleEntry.version
+    let runningVersion = fromVersion
+    const ranNames: string[] = []
+
+    for (const migration of migrationsToRun) {
+      await migration.up(projectDir, manifest)
+      runningVersion = migration.to
+      ranNames.push(migration.name)
+    }
+
+    nextModules[moduleName] = { ...moduleEntry, version: runningVersion }
+    manifestChanged = true
+    applied.push({ module: moduleName, fromVersion, toVersion: runningVersion, migrations: ranNames })
+  }
+
+  const nextManifest = manifestChanged ? { ...manifest, modules: nextModules as SaaSFoundryManifest['modules'] } : manifest
+
+  return { applied, manifest: nextManifest }
+}
+
+/**
+ * Module entries with no `version` field (e.g. legacy boolean flags or string
+ * enums) have no migration chain — only versioned entries participate. This
+ * keeps the dispatcher backward-compatible with manifests where some modules
+ * haven't yet adopted the `{ provider, version }` envelope.
+ */
+function isVersionedModuleEntry(entry: unknown): entry is { version: number; [key: string]: unknown } {
+  return typeof entry === 'object' && entry !== null && typeof (entry as { version?: unknown }).version === 'number'
+}
+
+function pendingMigrations(installer: ModuleInstaller, currentVersion: number): ModuleMigration[] {
+  return installer.migrations.filter((m) => m.from >= currentVersion).sort((a, b) => a.from - b.from)
+}

--- a/src/migrations/module/types.ts
+++ b/src/migrations/module/types.ts
@@ -1,0 +1,42 @@
+import type { SaaSFoundryManifest } from '../../types'
+
+/**
+ * A module migration upgrades an installed module's on-disk shape from one
+ * version to the next inside an existing project (e.g. renaming a service file,
+ * adding a new env var to `.env`, restructuring a Prisma model).
+ *
+ * Contract — same shape as `ManifestMigration` but operates on the project
+ * directory instead of an in-memory manifest:
+ * - `from` and `to` are monotonic integers per module; `to === from + 1`.
+ * - `up` runs against the project root and the (already manifest-migrated)
+ *   manifest. It MUST be idempotent so a half-applied migration can be re-run
+ *   safely on the next `sf update`.
+ * - `up` is responsible for any file system changes the new version needs.
+ *   Bumping `modules.<name>.version` is owned by the dispatcher (#386), not the
+ *   migration itself — keeps the contract symmetric with manifest migrations
+ *   where the dispatcher records `appliedMigrations`.
+ */
+export interface ModuleMigration {
+  from: number
+  to: number
+  name: string
+  up(projectDir: string, manifest: SaaSFoundryManifest): Promise<void>
+}
+
+/**
+ * Metadata each module installer ships alongside its install function so the
+ * dispatcher (#386) can wire `currentVersion` into freshly installed modules
+ * and replay `migrations` against modules already installed at an older
+ * version.
+ *
+ * `name` matches the key used under `manifest.modules` (e.g. `email`,
+ * `storage`). `currentVersion` is what a fresh install stamps on
+ * `modules.<name>.version`. `migrations` is ordered: index n must have
+ * `from === n` and `to === n + 1`, contiguity-checked the same way as the
+ * manifest registry.
+ */
+export interface ModuleInstaller {
+  name: string
+  currentVersion: number
+  migrations: ModuleMigration[]
+}

--- a/src/prompts/update.prompts.ts
+++ b/src/prompts/update.prompts.ts
@@ -22,7 +22,7 @@ function isModuleAvailable(moduleName: string, manifest: SaaSFoundryManifest): b
   const modules = manifest.modules
   switch (moduleName) {
     case 'email':
-      return modules !== undefined && modules.emailService === 'none'
+      return modules !== undefined && modules.email.provider === 'none'
     case 'storage':
       return modules !== undefined && modules.s3Setup === 'manual'
     case 'analytics':

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,7 +221,14 @@ export interface SaaSFoundryManifest {
   structure: 'monorepo' | 'multirepo' | 'cli'
   projectName: string
   modules?: {
-    emailService: 'none' | 'mailersend'
+    // Email module — versioned shape introduced in manifestVersion 2.
+    // `provider` replaces the old flat `emailService` field; `version` is
+    // the per-module installed version, used by module-level migrations
+    // (Epic #310 — see installers' currentVersion + migrations array).
+    email: {
+      provider: 'none' | 'mailersend'
+      version: number
+    }
     s3Setup: 'docker' | 'credentials' | 'manual'
     dbSetup: 'docker' | 'credentials' | 'manual'
     includeAnalytics: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,9 @@ export interface ToolsConfig {
 
 export interface SaaSFoundryManifest {
   $schema?: string
+  // Schema-shape version, monotonic integer, bumped by registered manifest migrations.
+  // Treat absence as 0 (manifest predates the migration framework).
+  manifestVersion?: number
   version: string
   generatedAt: string
   structure: 'monorepo' | 'multirepo' | 'cli'

--- a/tests/docker/generate-and-build.ts
+++ b/tests/docker/generate-and-build.ts
@@ -9,7 +9,7 @@
 //   node --import tsx generate-and-build.ts  # runs all scenarios
 
 import { execSync } from 'child_process'
-import { mkdirSync, writeFileSync } from 'fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
 import {
@@ -31,7 +31,7 @@ import {
   reportResults,
   scanForUnreplacedPlaceholders
 } from './assertions'
-import { ALL_SCENARIOS, getScenario, getTopScenarios, GenerationScenario, UpdateScenario, AIScenario, TestScenario } from './scenarios'
+import { ALL_SCENARIOS, getScenario, getTopScenarios, GenerationScenario, UpdateScenario, AIScenario, MigrationScenario, TestScenario } from './scenarios'
 
 // ── Config ─────────────────────────────────────────────────────
 
@@ -428,6 +428,85 @@ async function runAIScenario(scenario: AIScenario): Promise<boolean> {
   return reportResults(scenario.name, results)
 }
 
+async function runMigrationScenario(scenario: MigrationScenario): Promise<boolean> {
+  console.log(`\nGenerating project for migration check: ${scenario.projectName}`)
+
+  // Reuse generateProject's minimal generation; we don't need a build for this scenario.
+  const projectDir = await generateProject({
+    projectName: scenario.projectName,
+    isMonorepo: scenario.isMonorepo,
+    dbSetup: 'manual',
+    s3Setup: 'manual',
+    emailService: 'none',
+    includeAnalytics: false
+  })
+
+  // Overwrite the manifest with a v0-shape (legacy) version: no $schema, no
+  // manifestVersion. This simulates a project scaffolded before Epic #310
+  // shipped, which is the input the migration framework must rescue.
+  const manifestPath = join(projectDir, '.saasfoundry.json')
+  const legacyManifest = {
+    version: '0.9.0',
+    generatedAt: '2026-01-15T00:00:00.000Z',
+    structure: scenario.isMonorepo ? 'monorepo' : 'multirepo',
+    projectName: scenario.projectName,
+    modules: {
+      emailService: 'none',
+      s3Setup: 'manual',
+      dbSetup: 'manual',
+      includeAnalytics: false,
+      advancedSkills: []
+    }
+  }
+  writeFileSync(manifestPath, JSON.stringify(legacyManifest, null, 2))
+
+  // Invoke the update command programmatically against the legacy manifest.
+  // Non-interactive + no module additions so the run hits the migration
+  // step then early-returns at the "no modules to install" branch — this is
+  // exactly the path that previously dropped the $schema stamp on the floor.
+  const originalCwd = process.cwd()
+  process.chdir(projectDir)
+  try {
+    const { updateCommand } = await import(join(CLI_PATH, 'dist', 'commands', 'update'))
+    // addModules='' → parseAddModules returns [] → prefill.selectedModules = []
+    // (an empty CSV is the contract for "non-interactive run that adds nothing")
+    await updateCommand({ nonInteractive: true, acceptTemplateUpdates: false, addModules: '' })
+  } finally {
+    process.chdir(originalCwd)
+  }
+
+  // Read back the manifest and check the dispatcher did its job.
+  const after = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>
+
+  const expectedSchema = 'https://raw.githubusercontent.com/DiamondForgeFr/SaaSFoundry/master/schemas/saasfoundry-manifest.schema.json'
+
+  const schemaOk = after.$schema === expectedSchema
+  const versionOk = typeof after.manifestVersion === 'number' && after.manifestVersion >= 1
+  const fieldsOk = after.projectName === scenario.projectName && after.version === '0.9.0'
+  const firstKeyOk = Object.keys(after)[0] === '$schema'
+
+  const results: AssertionResult[] = [
+    {
+      passed: schemaOk,
+      message: schemaOk ? `OK: $schema stamped (${expectedSchema})` : `FAIL: expected $schema=${expectedSchema}, got ${String(after.$schema)}`
+    },
+    {
+      passed: versionOk,
+      message: versionOk ? `OK: manifestVersion=${after.manifestVersion} (>= 1)` : `FAIL: expected manifestVersion >= 1, got ${String(after.manifestVersion)}`
+    },
+    {
+      passed: fieldsOk,
+      message: fieldsOk ? `OK: original fields preserved (projectName + version)` : `FAIL: projectName=${String(after.projectName)} version=${String(after.version)}`
+    },
+    {
+      passed: firstKeyOk,
+      message: firstKeyOk ? `OK: $schema is first key (sf new parity)` : `FAIL: first key=${Object.keys(after)[0]}`
+    }
+  ]
+
+  return reportResults(scenario.name, results)
+}
+
 // ── Scenario Dispatcher ────────────────────────────────────────
 
 async function runScenario(scenario: TestScenario): Promise<boolean> {
@@ -436,6 +515,8 @@ async function runScenario(scenario: TestScenario): Promise<boolean> {
       return runGenerationScenario(scenario)
     case 'update':
       return runUpdateScenario(scenario)
+    case 'migration':
+      return runMigrationScenario(scenario)
     case 'ai':
       return runAIScenario(scenario)
   }

--- a/tests/docker/generate-and-build.ts
+++ b/tests/docker/generate-and-build.ts
@@ -158,7 +158,7 @@ async function generateProject(scenario: GenerationScenario | (UpdateScenario['b
           structure: scenario.isMonorepo ? 'monorepo' : 'multirepo',
           projectName: scenario.projectName,
           modules: {
-            emailService: scenario.emailService,
+            email: { provider: scenario.emailService, version: 1 },
             s3Setup: scenario.s3Setup,
             dbSetup: scenario.dbSetup,
             includeAnalytics: scenario.includeAnalytics,
@@ -485,6 +485,13 @@ async function runMigrationScenario(scenario: MigrationScenario): Promise<boolea
   const fieldsOk = after.projectName === scenario.projectName && after.version === '0.9.0'
   const firstKeyOk = Object.keys(after)[0] === '$schema'
 
+  // Migration 002 must have lifted the legacy flat `emailService` enum into
+  // the nested `email.{provider, version}` object — this catches a chain
+  // that stops mid-way (e.g. registry not appended-to when adding migrations).
+  const modules = (after.modules ?? {}) as Record<string, unknown>
+  const emailShape = (modules.email ?? null) as { provider?: unknown; version?: unknown } | null
+  const emailMigrated = emailShape !== null && emailShape.provider === 'none' && typeof emailShape.version === 'number' && !('emailService' in modules)
+
   const results: AssertionResult[] = [
     {
       passed: schemaOk,
@@ -501,6 +508,12 @@ async function runMigrationScenario(scenario: MigrationScenario): Promise<boolea
     {
       passed: firstKeyOk,
       message: firstKeyOk ? `OK: $schema is first key (sf new parity)` : `FAIL: first key=${Object.keys(after)[0]}`
+    },
+    {
+      passed: emailMigrated,
+      message: emailMigrated
+        ? `OK: modules.email migrated to {provider, version} and legacy emailService dropped`
+        : `FAIL: expected modules.email={provider,version} and no emailService, got ${JSON.stringify(modules)}`
     }
   ]
 

--- a/tests/docker/scenarios.ts
+++ b/tests/docker/scenarios.ts
@@ -3,7 +3,7 @@
 // ALL_SCENARIOS is ordered by PRIORITY — first scenarios are the most critical.
 // This allows `--count N` to run the N most important scenarios.
 
-export type ScenarioType = 'generation' | 'update' | 'ai'
+export type ScenarioType = 'generation' | 'update' | 'ai' | 'migration'
 
 export interface GenerationScenario {
   type: 'generation'
@@ -38,7 +38,22 @@ export interface AIScenario {
   checks: ('skills' | 'claude-md' | 'workflow')[]
 }
 
-export type TestScenario = GenerationScenario | UpdateScenario | AIScenario
+/**
+ * Migration scenario — exercises the manifest migration framework end-to-end.
+ *
+ * Generates a project, hand-writes a legacy v0-shape manifest (no $schema, no
+ * manifestVersion), runs `sf update` and asserts the dispatcher upgrades the
+ * file in place. Catches integration bugs that pure unit tests can't see —
+ * e.g. early-return paths in update.ts that skip the persistence step.
+ */
+export interface MigrationScenario {
+  type: 'migration'
+  name: string
+  projectName: string
+  isMonorepo: boolean
+}
+
+export type TestScenario = GenerationScenario | UpdateScenario | AIScenario | MigrationScenario
 
 // ── ALL SCENARIOS — ordered by priority ────────────────────────
 // Priority rationale:
@@ -145,6 +160,14 @@ export const ALL_SCENARIOS: TestScenario[] = [
     projectName: 'ai-wf',
     isMonorepo: false,
     checks: ['workflow', 'claude-md']
+  },
+
+  // ── Migration framework E2E (Epic #310) ──────────────────────
+  {
+    type: 'migration',
+    name: 'migration-v0-to-current',
+    projectName: 'mig-v0',
+    isMonorepo: false
   },
 
   // ── Priority 10-12: Single module variations ──────────────────


### PR DESCRIPTION
## Summary

Closes Epic #310 — release-objective C4 (cross-version update path).

Ships a registry-driven migration framework that lets `sf update` walk projects forward through manifest-shape changes and per-module file-set changes:

- **Manifest dispatcher** (`src/migrations/manifest/`) — contiguous chain of numbered `ManifestMigration` (`from`/`to`/`name`/`up`) walked at `sf update`. Includes migration 001 (stamp `manifestVersion` + `\$schema`) and migration 002 (lift flat `modules.emailService` enum into versioned `modules.email = { provider, version }`).
- **Module dispatcher** (`src/migrations/module/`) — per-installer `migrations: ModuleMigration[]` array dispatched against `manifest.modules.<name>.version`. Conflict-aware writer (`writeMigratedFile`) falls back to a `.saasfoundry.new` sidecar on hash mismatch — same UX as the 3-way template merge.
- **Installer registry** (`src/installers/registry.ts`) — single source of truth listing all 8 installer metadatas (`<name>InstallerMeta: ModuleInstaller`).
- **Tests** — golden-fixture harness, contiguity-check unit tests, integration tests for both dispatchers, drift-guard test pairing the manifest interface shape with `targetManifestVersion()`, and a Docker E2E scenario (`migration-v0-to-current`).
- **Docs** — `.claude/docs/migration-framework.md` playbook (worked examples, when NOT to add a migration, registry layout). README + CLAUDE.md + sf-workflow SKILL.md cross-link the playbook so future contributors are routed through it on breaking changes.

Bundled-PR pattern: 9 child Subs across Stories #311 / #312 / #313 each shipped as one commit on this branch (`nature:bundled-pr`); single PR at the Epic level.

## Test plan

- [x] `npm run test:pre-commit` — 1368 passing, 1 flaky timeout in pr-existence-guard (passes in isolation)
- [x] `npm run test:docker -- --scenario migration-v0-to-current` — E2E verifies a v0 manifest is migrated to current target on `sf update`
- [x] `npm run test:docker -- --count 2` — pre-push validation (multirepo-minimal, monorepo-minimal)
- [ ] Manual integration check on freshly merged develop: scaffold a v0 project, run `sf update`, confirm `manifestVersion` bumped + `email` block restructured + chain re-run is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)