### PR TITLE
feat(#314): install tool-saasfoundry skill via symlink for contributor dogfooding

### DIFF
--- a/.claude/skills/tool-saasfoundry
+++ b/.claude/skills/tool-saasfoundry
@@ -1,0 +1,1 @@
+../../scaffolds/skills-templates/tool-saasfoundry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ shortcuts reintroduce exactly the cross-version drift the framework was built to
 ### Reading before acting
 
 - Workflow: `.claude/skills/sf-workflow/SKILL.md` and the `statuses/` files
+- SRS drafting / spawning: `.claude/skills/sf-srs/SKILL.md`
+- Integration grammar (adding modules / pages / endpoints): `.claude/skills/sf-integration-rules/SKILL.md`
+- CLI orchestration (`sf new`, `sf update`, `sf workflow`, feedback flows): `.claude/skills/tool-saasfoundry/SKILL.md` — symlinked to `scaffolds/skills-templates/tool-saasfoundry/` so contributor edits land in the source of truth
 - Module architecture (adding/modifying modules): `.claude/docs/architecture-modules.md`
 - Skills architecture (adding/modifying skills): `.claude/docs/architecture-skills.md`
 - Migration framework (any breaking manifest/module change): `.claude/docs/migration-framework.md`

--- a/src/__tests__/unit/status/installed-skills.spec.ts
+++ b/src/__tests__/unit/status/installed-skills.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from 'fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -62,5 +62,25 @@ describe('collectStatus.installedSkills', () => {
 
     const report = await collectStatus(tempDir, { checkNetwork: false })
     expect(report.installedSkills).toEqual(['sf-git-commit', 'sf-integration-rules'])
+  })
+
+  it('follows symlinks so contributors can dogfood a scaffold-templated skill in-place', async () => {
+    await writeFile(
+      join(tempDir, '.saasfoundry.json'),
+      JSON.stringify({
+        version: '1.0.0-beta',
+        generatedAt: '2026-04-30T00:00:00Z',
+        structure: 'monorepo',
+        projectName: 'demo'
+      })
+    )
+    const sourceDir = join(tempDir, 'scaffolds', 'tool-saasfoundry')
+    await makeSkill(join(tempDir, 'scaffolds'), 'tool-saasfoundry')
+    const skillsRoot = join(tempDir, '.claude', 'skills')
+    await mkdir(skillsRoot, { recursive: true })
+    await symlink(sourceDir, join(skillsRoot, 'tool-saasfoundry'))
+
+    const report = await collectStatus(tempDir, { checkNetwork: false })
+    expect(report.installedSkills).toEqual(['tool-saasfoundry'])
   })
 })

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -81,7 +81,20 @@ function listSkillsIn(skillsDir: string): string[] {
   if (!fs.existsSync(skillsDir)) return []
   return fs
     .readdirSync(skillsDir, { withFileTypes: true })
-    .filter((d) => d.isDirectory() && fs.existsSync(path.join(skillsDir, d.name, 'SKILL.md')))
+    .filter((d) => {
+      const entry = path.join(skillsDir, d.name)
+      // fs.statSync follows symlinks — needed so contributors can symlink a
+      // skill from scaffolds/skills-templates/ into .claude/skills/ without
+      // it dropping out of `sf status`. d.isDirectory() alone returns false
+      // for symlinks even when they point at a directory.
+      let isDir: boolean
+      try {
+        isDir = fs.statSync(entry).isDirectory()
+      } catch {
+        return false
+      }
+      return isDir && fs.existsSync(path.join(entry, 'SKILL.md'))
+    })
     .map((d) => d.name)
 }
 


### PR DESCRIPTION
## Summary

Closes Story #314 — closes a dogfooding gap: SaaSFoundry contributors now have the same `tool-saasfoundry` skill installed at the project level that generated-project users get.

- **Symlink** `.claude/skills/tool-saasfoundry → scaffolds/skills-templates/tool-saasfoundry/` — contributor edits to the skill land directly in the source of truth, zero drift.
- **`listSkillsIn` follows symlinks** — `Dirent.isDirectory()` returns `false` for symlinks even when the target is a directory; switched to `fs.statSync` so the symlinked skill is reported by `sf status`.
- **Unit test** covering the symlinked-skill path.
- **CLAUDE.md** "Reading before acting" lists the new skill alongside `sf-workflow`, `sf-srs`, `sf-integration-rules`.

## Test plan

- [x] `npm run test:pre-commit` — 1370 passing
- [x] Manual: `node bin/sf.js status --claude-friendly --no-network` lists `tool-saasfoundry` in skills
- [x] Manual: symlink resolves correctly to scaffolds path
- [ ] Reviewer: confirm a fresh Claude session in this repo activates the `tool-saasfoundry` skill on the next `sf new` / `sf update` request

🤖 Generated with [Claude Code](https://claude.com/claude-code)