### PR TITLE
[#424] Branch-choice propagation end-to-end: persist mainBranch, {{MAIN_BRANCH}} in CLAUDE.md, create working branch, align CI

### DIFF
--- a/.claude/docs/manifest-schema.md
+++ b/.claude/docs/manifest-schema.md
@@ -48,6 +48,7 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
   "version": "x.y.z",
   "projectName": "my-saas-app",
   "structure": "multirepo | monorepo | cli",
+  "mainBranch": "main | master", // git main branch chosen at sf new; absent on older manifests — fall back when reading
   "workflow": {
     "tool": "github-projects",
     "template": "SaaSFoundry AI",

--- a/scaffolds/blueprints/api/.github/workflows/deployment.yml
+++ b/scaffolds/blueprints/api/.github/workflows/deployment.yml
@@ -2,7 +2,7 @@ name: Deployment
 
 on:
   push:
-    branches: [master, main]
+    branches: [{{MAIN_BRANCH}}]
   workflow_dispatch:
     inputs:
       version:
@@ -34,7 +34,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             # Check if tests have passed for this specific commit
-            gh run list --workflow=test.yml --branch=master --status=success --limit=1 --commit=${{ github.sha }}
+            gh run list --workflow=test.yml --branch={{MAIN_BRANCH}} --status=success --limit=1 --commit=${{ github.sha }}
             if [ $? -ne 0 ]; then
               echo "Tests have not passed for commit ${{ github.sha }}. Deployment blocked."
               exit 1
@@ -122,12 +122,12 @@ jobs:
           git tag -a "v${{ steps.package-version.outputs.version }}" -m "Release version ${{ steps.package-version.outputs.version }}"
           echo "Created tag v${{ steps.package-version.outputs.version }}"
 
-      - name: Push current master to tag
+      - name: Push current {{MAIN_BRANCH}} to tag
         if: steps.check-is-version-bump.outputs.is_version_bump == 'true'
         run: |
           if [ "${{ steps.check-tag.outputs.tag_exists }}" == "true" ]; then
             git push origin HEAD:refs/tags/v${{ steps.package-version.outputs.version }} -f
-            echo "Updated existing tag v${{ steps.package-version.outputs.version }} with current master"
+            echo "Updated existing tag v${{ steps.package-version.outputs.version }} with current {{MAIN_BRANCH}}"
           else
             git push origin "v${{ steps.package-version.outputs.version }}"
             echo "Pushed new tag v${{ steps.package-version.outputs.version }}"

--- a/scaffolds/blueprints/api/.github/workflows/test.yml
+++ b/scaffolds/blueprints/api/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [master, main, develop]
+    branches: [{{CI_PR_BRANCHES}}]
 
 jobs:
   load-env:

--- a/scaffolds/blueprints/api/CLAUDE.md
+++ b/scaffolds/blueprints/api/CLAUDE.md
@@ -102,7 +102,7 @@ When in doubt, run `sf status --claude-friendly --no-network` to confirm topolog
 
 ## Git Workflow
 
-- Main branch: `master`
+- Main branch: `{{MAIN_BRANCH}}`
 - **ALWAYS** use conventional commits: `<type>(#<ticket>): <description>`
 - Types: feat, fix, docs, style, refactor, perf, test, chore
 - Scope (ticket number) is required
@@ -110,6 +110,8 @@ When in doubt, run `sf status --claude-friendly --no-network` to confirm topolog
 - Husky enforces commit format + pre-push checks
 
 ### Commit Examples
+
+_Ticket numbers below are illustrative — always use the number of the ticket you are working on._
 
 ```bash
 feat(#42): add user profile endpoint

--- a/scaffolds/blueprints/web/.github/workflows/deployment.yml
+++ b/scaffolds/blueprints/web/.github/workflows/deployment.yml
@@ -2,7 +2,7 @@ name: Deployment
 
 on:
   push:
-    branches: [master, develop, main]
+    branches: [{{MAIN_BRANCH}}]
   workflow_dispatch:
     inputs:
       version:
@@ -34,7 +34,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             # Check if tests have passed for this specific commit
-            gh run list --workflow=test.yml --branch=master --status=success --limit=1 --commit=${{ github.sha }}
+            gh run list --workflow=test.yml --branch={{MAIN_BRANCH}} --status=success --limit=1 --commit=${{ github.sha }}
             if [ $? -ne 0 ]; then
               echo "Tests have not passed for commit ${{ github.sha }}. Deployment blocked."
               exit 1
@@ -122,12 +122,12 @@ jobs:
           git tag -a "v${{ steps.package-version.outputs.version }}" -m "Release version ${{ steps.package-version.outputs.version }}"
           echo "Created tag v${{ steps.package-version.outputs.version }}"
 
-      - name: Push current master to tag
+      - name: Push current {{MAIN_BRANCH}} to tag
         if: steps.check-is-version-bump.outputs.is_version_bump == 'true'
         run: |
           if [ "${{ steps.check-tag.outputs.tag_exists }}" == "true" ]; then
             git push origin HEAD:refs/tags/v${{ steps.package-version.outputs.version }} -f
-            echo "Updated existing tag v${{ steps.package-version.outputs.version }} with current master"
+            echo "Updated existing tag v${{ steps.package-version.outputs.version }} with current {{MAIN_BRANCH}}"
           else
             git push origin "v${{ steps.package-version.outputs.version }}"
             echo "Pushed new tag v${{ steps.package-version.outputs.version }}"

--- a/scaffolds/blueprints/web/.github/workflows/test.yml
+++ b/scaffolds/blueprints/web/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [master, main]
+    branches: [{{CI_PR_BRANCHES}}]
 
 jobs:
   build:

--- a/scaffolds/blueprints/web/CLAUDE.md
+++ b/scaffolds/blueprints/web/CLAUDE.md
@@ -121,7 +121,7 @@ Run `sf status --claude-friendly --no-network` to confirm topology before changi
 
 ## Git Workflow
 
-- Main branch: `master`
+- Main branch: `{{MAIN_BRANCH}}`
 - **ALWAYS** use conventional commits: `<type>(#<ticket>): <description>`
 - Types: feat, fix, docs, style, refactor, perf, test, chore
 - Scope (ticket number) is required
@@ -129,6 +129,8 @@ Run `sf status --claude-friendly --no-network` to confirm topology before changi
 - Husky enforces commit format + pre-push checks
 
 ### Commit Examples
+
+_Ticket numbers below are illustrative — always use the number of the ticket you are working on._
 
 ```bash
 feat(#42): add user profile page

--- a/scaffolds/docs/manifest-schema.md
+++ b/scaffolds/docs/manifest-schema.md
@@ -48,6 +48,7 @@ jq -r '.tools.srs.scan.exclude[]'     .saasfoundry.json   # gitignore-style patt
   "version": "x.y.z",
   "projectName": "my-saas-app",
   "structure": "multirepo | monorepo | cli",
+  "mainBranch": "main | master", // git main branch chosen at sf new; absent on older manifests — fall back when reading
   "workflow": {
     "tool": "github-projects",
     "template": "SaaSFoundry AI",

--- a/scaffolds/overlays/monorepo/root/.github/workflows/deployment-api.yml
+++ b/scaffolds/overlays/monorepo/root/.github/workflows/deployment-api.yml
@@ -2,7 +2,7 @@ name: Deployment API
 
 on:
   push:
-    branches: [master, main]
+    branches: [{{MAIN_BRANCH}}]
     paths:
       - 'apps/api/**'
       - 'packages/**'
@@ -37,7 +37,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             # Check if tests have passed for this specific commit
-            gh run list --workflow=test.yml --branch=master --status=success --limit=1 --commit=${{ github.sha }}
+            gh run list --workflow=test.yml --branch={{MAIN_BRANCH}} --status=success --limit=1 --commit=${{ github.sha }}
             if [ $? -ne 0 ]; then
               echo "Tests have not passed for commit ${{ github.sha }}. Deployment blocked."
               exit 1
@@ -125,12 +125,12 @@ jobs:
           git tag -a "api-v${{ steps.package-version.outputs.version }}" -m "API release version ${{ steps.package-version.outputs.version }}"
           echo "Created tag api-v${{ steps.package-version.outputs.version }}"
 
-      - name: Push current master to tag
+      - name: Push current {{MAIN_BRANCH}} to tag
         if: steps.check-is-version-bump.outputs.is_version_bump == 'true'
         run: |
           if [ "${{ steps.check-tag.outputs.tag_exists }}" == "true" ]; then
             git push origin HEAD:refs/tags/api-v${{ steps.package-version.outputs.version }} -f
-            echo "Updated existing tag api-v${{ steps.package-version.outputs.version }} with current master"
+            echo "Updated existing tag api-v${{ steps.package-version.outputs.version }} with current {{MAIN_BRANCH}}"
           else
             git push origin "api-v${{ steps.package-version.outputs.version }}"
             echo "Pushed new tag api-v${{ steps.package-version.outputs.version }}"

--- a/scaffolds/overlays/monorepo/root/.github/workflows/deployment-web.yml
+++ b/scaffolds/overlays/monorepo/root/.github/workflows/deployment-web.yml
@@ -2,7 +2,7 @@ name: Deployment Web
 
 on:
   push:
-    branches: [master, main]
+    branches: [{{MAIN_BRANCH}}]
     paths:
       - 'apps/web/**'
       - 'packages/**'
@@ -37,7 +37,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             # Check if tests have passed for this specific commit
-            gh run list --workflow=test.yml --branch=master --status=success --limit=1 --commit=${{ github.sha }}
+            gh run list --workflow=test.yml --branch={{MAIN_BRANCH}} --status=success --limit=1 --commit=${{ github.sha }}
             if [ $? -ne 0 ]; then
               echo "Tests have not passed for commit ${{ github.sha }}. Deployment blocked."
               exit 1
@@ -125,12 +125,12 @@ jobs:
           git tag -a "web-v${{ steps.package-version.outputs.version }}" -m "Web release version ${{ steps.package-version.outputs.version }}"
           echo "Created tag web-v${{ steps.package-version.outputs.version }}"
 
-      - name: Push current master to tag
+      - name: Push current {{MAIN_BRANCH}} to tag
         if: steps.check-is-version-bump.outputs.is_version_bump == 'true'
         run: |
           if [ "${{ steps.check-tag.outputs.tag_exists }}" == "true" ]; then
             git push origin HEAD:refs/tags/web-v${{ steps.package-version.outputs.version }} -f
-            echo "Updated existing tag web-v${{ steps.package-version.outputs.version }} with current master"
+            echo "Updated existing tag web-v${{ steps.package-version.outputs.version }} with current {{MAIN_BRANCH}}"
           else
             git push origin "web-v${{ steps.package-version.outputs.version }}"
             echo "Pushed new tag web-v${{ steps.package-version.outputs.version }}"

--- a/scaffolds/overlays/monorepo/root/.github/workflows/test.yml
+++ b/scaffolds/overlays/monorepo/root/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [master, main, develop]
+    branches: [{{CI_PR_BRANCHES}}]
 
 jobs:
   install:

--- a/scaffolds/overlays/monorepo/root/CLAUDE.md
+++ b/scaffolds/overlays/monorepo/root/CLAUDE.md
@@ -164,7 +164,7 @@ npm run test:web          # Test Web only
 
 ## 📖 Git Workflow
 
-- Main branch: `master`
+- Main branch: `{{MAIN_BRANCH}}`
 - **ALWAYS** use conventional commits: `<type>(#<ticket>): <description>`
 - Types: feat, fix, docs, style, refactor, perf, test, chore
 - Scope (ticket number) is required
@@ -172,6 +172,8 @@ npm run test:web          # Test Web only
 - Husky enforces commit format + pre-push checks
 
 ### Commit Examples
+
+_Ticket numbers below are illustrative — always use the number of the ticket you are working on._
 ```bash
 feat(#42): add user profile endpoint
 fix(#43): resolve JWT token expiration

--- a/schemas/saasfoundry-manifest.schema.json
+++ b/schemas/saasfoundry-manifest.schema.json
@@ -34,6 +34,10 @@
       "type": "string",
       "minLength": 1
     },
+    "mainBranch": {
+      "type": "string",
+      "description": "Git main branch chosen at sf new (main/master). Absent on manifests written before this field existed — readers must fall back."
+    },
     "modules": {
       "type": "object",
       "required": ["email", "s3Setup", "dbSetup", "includeAnalytics", "advancedSkills"],

--- a/src/__tests__/integration/commands/new.non-interactive.spec.ts
+++ b/src/__tests__/integration/commands/new.non-interactive.spec.ts
@@ -178,6 +178,7 @@ describe('newCommand (non-interactive integration)', () => {
     expect(manifest).toMatchObject({
       projectName: 'acme',
       structure: 'monorepo',
+      mainBranch: 'main',
       modules: {
         email: { provider: 'none', version: 1 },
         s3Setup: 'manual',

--- a/src/__tests__/integration/installers/skills.installer.spec.ts
+++ b/src/__tests__/integration/installers/skills.installer.spec.ts
@@ -1,5 +1,5 @@
 import { copy } from 'fs-extra'
-import { mkdir, readFile, rm } from 'fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
 import { join, resolve } from 'path'
 import { tmpdir } from 'os'
 
@@ -93,23 +93,22 @@ describe('installSkills (integration)', () => {
       await expectFileExists(join(webPath, '.claude/skills/sf-tool-context7'))
     })
 
-    it('should replace CLAUDE.md placeholders with project name and version', async () => {
+    it('should replace CLAUDE.md placeholders with project name, version and main branch', async () => {
+      await writeFile(join(apiPath, 'CLAUDE.md'), '# {{PROJECT_NAME}} v{{VERSION}}\n- Main branch: `{{MAIN_BRANCH}}`\n')
+
       await installSkills({
         isMonorepo: false,
         apiPath,
         webPath,
         projectName: 'my-app',
-        version: '2.0.0'
+        version: '2.0.0',
+        mainBranch: 'master'
       })
 
-      // Read CLAUDE.md if it exists
-      try {
-        const apiClaudeMd = await readFile(join(apiPath, 'CLAUDE.md'), 'utf8')
-        expect(apiClaudeMd).not.toContain('{{PROJECT_NAME}}')
-        expect(apiClaudeMd).not.toContain('{{VERSION}}')
-      } catch {
-        // CLAUDE.md might not exist in the blueprint, which is fine
-      }
+      const apiClaudeMd = await readFile(join(apiPath, 'CLAUDE.md'), 'utf8')
+      expect(apiClaudeMd).toContain('# my-app v2.0.0')
+      expect(apiClaudeMd).toContain('- Main branch: `master`')
+      expect(apiClaudeMd).not.toContain('{{')
     })
 
     it('should not install optional skills when none selected', async () => {

--- a/src/__tests__/smoke/generated-project.spec.ts
+++ b/src/__tests__/smoke/generated-project.spec.ts
@@ -53,10 +53,15 @@ describe('generated project smoke tests', () => {
     await mkdir(join(projectDir, 'apps'), { recursive: true })
     process.chdir(projectDir)
 
+    // tool 'none' keeps installWorkflowSkill out of the way while still exercising
+    // the workingBranch-aware CI substitution
+    const workflow = { tool: 'none' as const, workingBranch: 'develop', prTargetBranch: 'develop' }
+
     await createApiApp(
       apiParams({
         isMonorepo: config.isMonorepo,
         projectName: config.projectName,
+        workflow,
         emailService: config.emailService,
         s3Setup: config.s3Setup,
         mailersendApiKey: config.emailService === 'mailersend' ? 'ms-key' : undefined,
@@ -82,12 +87,13 @@ describe('generated project smoke tests', () => {
         isMonorepo: config.isMonorepo,
         projectName: config.projectName,
         s3Setup: config.s3Setup,
-        includeAnalytics: config.includeAnalytics
+        includeAnalytics: config.includeAnalytics,
+        workflow
       })
     )
 
     if (config.isMonorepo) {
-      await createMonorepoRoot(monorepoRootParams({ projectName: config.projectName }))
+      await createMonorepoRoot(monorepoRootParams({ projectName: config.projectName, workflow }))
     }
 
     const skillsApiPath = config.isMonorepo ? 'apps/api' : `apps/${config.projectName}-api`
@@ -218,6 +224,18 @@ describe('generated project smoke tests', () => {
       await assertNoUnreplacedPlaceholders(join(paths.webPath, 'CLAUDE.md'))
     })
 
+    it('should substitute branch placeholders in CI workflows', async () => {
+      const testYml = await readFile(join(paths.apiPath, '.github/workflows/test.yml'), 'utf8')
+      const deployYml = await readFile(join(paths.apiPath, '.github/workflows/deployment.yml'), 'utf8')
+      expect(testYml).toContain('branches: [develop, main]')
+      expect(deployYml).toContain('branches: [main]')
+      expect(deployYml).toContain('--branch=main')
+      for (const content of [testYml, deployYml]) {
+        expect(content).not.toContain('{{MAIN_BRANCH}}')
+        expect(content).not.toContain('{{CI_PR_BRANCHES}}')
+      }
+    })
+
     it('should have activated email module (no mailer-service-active TODO markers)', async () => {
       await assertNoBrokenTodoMarkers(join(paths.apiPath, 'src/modules/auth/services/auth.service.ts'))
       await assertNoBrokenTodoMarkers(join(paths.apiPath, 'src/modules/email/services/email.service.ts'))
@@ -266,6 +284,18 @@ describe('generated project smoke tests', () => {
 
     it('should have all critical API files in apps/api', async () => {
       await assertApiCriticalFiles(paths.apiPath)
+    })
+
+    it('should substitute branch placeholders in root CI workflows', async () => {
+      const testYml = await readFile(join(paths.projectDir, '.github/workflows/test.yml'), 'utf8')
+      const deployApiYml = await readFile(join(paths.projectDir, '.github/workflows/deployment-api.yml'), 'utf8')
+      expect(testYml).toContain('branches: [develop, main]')
+      expect(deployApiYml).toContain('branches: [main]')
+      expect(deployApiYml).toContain('--branch=main')
+      for (const content of [testYml, deployApiYml]) {
+        expect(content).not.toContain('{{MAIN_BRANCH}}')
+        expect(content).not.toContain('{{CI_PR_BRANCHES}}')
+      }
     })
 
     it('should have all critical Web files in apps/web', async () => {

--- a/src/__tests__/unit/migrations/drift-guard.spec.ts
+++ b/src/__tests__/unit/migrations/drift-guard.spec.ts
@@ -44,7 +44,9 @@ describe('SaaSFoundryManifest drift-guard', () => {
     }
     expect(snapshot).toEqual({
       targetVersion: 2,
-      keys: ['$schema', 'manifestVersion', 'version', 'generatedAt', 'structure', 'projectName', 'modules', 'skillsAccounts', 'fileHashes', 'workflow', 'aiRules', 'tools']
+      // mainBranch added without a version bump: new OPTIONAL field with read-site
+      // fallback — the "no migration needed" case of migration-framework.md.
+      keys: ['$schema', 'manifestVersion', 'version', 'generatedAt', 'structure', 'projectName', 'mainBranch', 'modules', 'skillsAccounts', 'fileHashes', 'workflow', 'aiRules', 'tools']
     })
   })
 })

--- a/src/builders/api.builder.ts
+++ b/src/builders/api.builder.ts
@@ -183,6 +183,9 @@ export async function createApiApp({
     if (backendRepoUrl) await exec(`git -C ${apiPath} remote add origin ${backendRepoUrl} > /dev/null 2>&1`)
     await exec(`git -C ${apiPath} add . > /dev/null 2>&1`)
     await exec(`git -C ${apiPath} commit -m "Initial commit" > /dev/null 2>&1`)
+    // Develop-first: create the declared working branch so the repo matches its docs.
+    const workingBranch = workflow?.workingBranch
+    if (workingBranch && workingBranch !== mainBranch) await exec(`git -C ${apiPath} checkout -b ${workingBranch} > /dev/null 2>&1`)
   }
 
   return true

--- a/src/builders/api.builder.ts
+++ b/src/builders/api.builder.ts
@@ -176,6 +176,10 @@ export async function createApiApp({
     await writeFile(deploymentYmlPath, deploymentYmlContent)
   }
 
+  // Branch placeholders in CI workflows: PRs target the working branch + main, deploys push from main
+  const ciPrBranches = [...new Set([workflow?.workingBranch || mainBranch, mainBranch])].join(', ')
+  await substitutePlaceholdersInFiles([`${apiPath}/.github/workflows/test.yml`, deploymentYmlPath], { MAIN_BRANCH: mainBranch, CI_PR_BRANCHES: ciPrBranches })
+
   // Initialize Git repository
   if (!isMonorepo) {
     await exec(`git init ${apiPath} > /dev/null 2>&1`)

--- a/src/builders/monorepo.builder.ts
+++ b/src/builders/monorepo.builder.ts
@@ -71,6 +71,10 @@ export async function createMonorepoRoot({ projectName, projectDescription, mono
     await writeFile(deployWebPath, content)
   }
 
+  // Branch placeholders in CI workflows: PRs target the working branch + main, deploys push from main
+  const ciPrBranches = [...new Set([workflow?.workingBranch || mainBranch, mainBranch])].join(', ')
+  await substitutePlaceholdersInFiles(['.github/workflows/test.yml', deployApiPath, deployWebPath], { MAIN_BRANCH: mainBranch, CI_PR_BRANCHES: ciPrBranches })
+
   // Replay shared-config / shared-types deposits for any module the API
   // installer activated before the workspace existed. `installStorageModule`
   // and `installEmailModule` run during `createApiApp` (i.e. before this

--- a/src/builders/monorepo.builder.ts
+++ b/src/builders/monorepo.builder.ts
@@ -108,6 +108,10 @@ export async function createMonorepoRoot({ projectName, projectDescription, mono
   if (monorepoUrl) await exec(`git remote add origin ${monorepoUrl} > /dev/null 2>&1`)
   await exec(`git add . > /dev/null 2>&1`)
   await exec(`git commit -m "Initial commit" > /dev/null 2>&1`)
+  // Develop-first: the manifest declares workflow.workingBranch as the AI's work
+  // branch — create it and stay on it so the repo matches its own documentation.
+  const workingBranch = workflow?.workingBranch
+  if (workingBranch && workingBranch !== mainBranch) await exec(`git checkout -b ${workingBranch} > /dev/null 2>&1`)
 
   return true
 }

--- a/src/builders/web.builder.ts
+++ b/src/builders/web.builder.ts
@@ -132,6 +132,9 @@ export async function createWebApp({ isMonorepo, projectName, projectDescription
     if (frontendRepoUrl) await exec(`git -C ${webPath} remote add origin ${frontendRepoUrl} > /dev/null 2>&1`)
     await exec(`git -C ${webPath} add . > /dev/null 2>&1`)
     await exec(`git -C ${webPath} commit -m "Initial commit" > /dev/null 2>&1`)
+    // Develop-first: create the declared working branch so the repo matches its docs.
+    const workingBranch = workflow?.workingBranch
+    if (workingBranch && workingBranch !== mainBranch) await exec(`git -C ${webPath} checkout -b ${workingBranch} > /dev/null 2>&1`)
   }
 
   return true

--- a/src/builders/web.builder.ts
+++ b/src/builders/web.builder.ts
@@ -95,6 +95,10 @@ export async function createWebApp({ isMonorepo, projectName, projectDescription
     await writeFile(deploymentYmlPath, deploymentYmlContent)
   }
 
+  // Branch placeholders in CI workflows: PRs target the working branch + main, deploys push from main
+  const ciPrBranches = [...new Set([workflow?.workingBranch || mainBranch, mainBranch])].join(', ')
+  await substitutePlaceholdersInFiles([`${webPath}/.github/workflows/test.yml`, deploymentYmlPath], { MAIN_BRANCH: mainBranch, CI_PR_BRANCHES: ciPrBranches })
+
   // Update storage enabled flag in .env
   if (s3Setup !== 'manual') {
     const webEnvPath = `${webPath}/.env`

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -182,6 +182,7 @@ export async function newCommand(opts: NewCommandOptions = {}) {
       webPath,
       projectName: startProjectAnswers.projectName,
       version: cliVersion,
+      mainBranch: startProjectAnswers.mainBranch,
       advancedSkills: startProjectAnswers.advancedSkills,
       context7ApiKey: startProjectAnswers.context7ApiKey,
       atlassianEmail: startProjectAnswers.atlassianEmail,

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -251,6 +251,7 @@ export async function newCommand(opts: NewCommandOptions = {}) {
       generatedAt: new Date().toISOString(),
       structure: startProjectAnswers.isMonorepo ? 'monorepo' : 'multirepo',
       projectName: startProjectAnswers.projectName,
+      mainBranch: startProjectAnswers.mainBranch,
       modules: {
         email: { provider: startProjectAnswers.emailService, version: 1 },
         s3Setup: startProjectAnswers.s3Setup,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -70,7 +70,7 @@ async function regenerateInTempDir(manifest: SaaSFoundryManifest): Promise<{ tem
       projectDescription: '',
       backendRepoUrl: '',
       dbCredentials: { host: 'localhost', port: '5435', user: 'user', password: 'pass', database: 'db', dbType: 'postgresql' },
-      mainBranch: 'main',
+      mainBranch: manifest.mainBranch ?? 'main', // pre-mainBranch manifests: backfill deferred (#424 step 6)
       emailService: manifest.modules.email.provider,
       mailersendApiKey: manifest.modules.email.provider === 'mailersend' ? 'dummy-key' : undefined,
       mailersendSenderEmail: manifest.modules.email.provider === 'mailersend' ? 'noreply@example.com' : undefined,
@@ -98,7 +98,7 @@ async function regenerateInTempDir(manifest: SaaSFoundryManifest): Promise<{ tem
       projectName: manifest.projectName,
       projectDescription: '',
       frontendRepoUrl: '',
-      mainBranch: 'main',
+      mainBranch: manifest.mainBranch ?? 'main',
       s3Setup: manifest.modules.s3Setup,
       includeAnalytics: manifest.modules.includeAnalytics,
       advancedSkills: manifest.modules.advancedSkills || []
@@ -109,7 +109,7 @@ async function regenerateInTempDir(manifest: SaaSFoundryManifest): Promise<{ tem
       await createMonorepoRoot({
         projectName: manifest.projectName,
         projectDescription: '',
-        mainBranch: 'main'
+        mainBranch: manifest.mainBranch ?? 'main'
       })
     }
 
@@ -122,6 +122,7 @@ async function regenerateInTempDir(manifest: SaaSFoundryManifest): Promise<{ tem
       webPath,
       projectName: manifest.projectName,
       version: cliVersion,
+      mainBranch: manifest.mainBranch,
       advancedSkills: manifest.modules.advancedSkills || []
     })
 
@@ -691,6 +692,7 @@ export async function updateCommand(opts: UpdateCommandOptions = {}) {
         webPath,
         projectName: manifest.projectName,
         version: cliVersion,
+        mainBranch: manifest.mainBranch,
         advancedSkills: [...(manifest.modules!.advancedSkills || []), ...skillsToAdd],
         ...skillsCredentials
       })

--- a/src/installers/skills.installer.ts
+++ b/src/installers/skills.installer.ts
@@ -18,6 +18,7 @@ interface InstallSkillsParams {
   webPath: string
   projectName: string
   version: string
+  mainBranch?: string
   advancedSkills?: string[]
   context7ApiKey?: string
   atlassianEmail?: string
@@ -42,7 +43,7 @@ interface InstallSkillsParams {
  *
  * Used by both `sf new` (during initial project generation) and `sf update` (when adding skills later).
  */
-export async function installSkills({ isMonorepo, apiPath, webPath, projectName, version, advancedSkills = [] }: InstallSkillsParams) {
+export async function installSkills({ isMonorepo, apiPath, webPath, projectName, version, mainBranch = 'main', advancedSkills = [] }: InstallSkillsParams) {
   if (isMonorepo) {
     // Monorepo: Install skills at root (centralized)
     await installCoreSkills({ targetPath: '.' })
@@ -56,9 +57,9 @@ export async function installSkills({ isMonorepo, apiPath, webPath, projectName,
     }
 
     // Update CLAUDE.md placeholders at root + per-app (blueprints copy CLAUDE.md with placeholders)
-    await updateClaudeMdPlaceholders({ targetPath: '.', projectName, version })
-    await updateClaudeMdPlaceholders({ targetPath: apiPath, projectName, version })
-    await updateClaudeMdPlaceholders({ targetPath: webPath, projectName, version })
+    await updateClaudeMdPlaceholders({ targetPath: '.', projectName, version, mainBranch })
+    await updateClaudeMdPlaceholders({ targetPath: apiPath, projectName, version, mainBranch })
+    await updateClaudeMdPlaceholders({ targetPath: webPath, projectName, version, mainBranch })
 
     // Copy README.md to .claude/
     await copyClaudeReadme({ targetPath: '.' })
@@ -82,8 +83,8 @@ export async function installSkills({ isMonorepo, apiPath, webPath, projectName,
     }
 
     // Update CLAUDE.md placeholders
-    await updateClaudeMdPlaceholders({ targetPath: apiPath, projectName, version })
-    await updateClaudeMdPlaceholders({ targetPath: webPath, projectName, version })
+    await updateClaudeMdPlaceholders({ targetPath: apiPath, projectName, version, mainBranch })
+    await updateClaudeMdPlaceholders({ targetPath: webPath, projectName, version, mainBranch })
 
     // Copy README.md
     await copyClaudeReadme({ targetPath: apiPath })
@@ -92,14 +93,17 @@ export async function installSkills({ isMonorepo, apiPath, webPath, projectName,
 }
 
 /**
- * Update CLAUDE.md placeholders ({{PROJECT_NAME}}, {{VERSION}})
+ * Update CLAUDE.md placeholders ({{PROJECT_NAME}}, {{VERSION}}, {{MAIN_BRANCH}})
  */
-async function updateClaudeMdPlaceholders({ targetPath, projectName, version }: { targetPath: string; projectName: string; version: string }) {
+async function updateClaudeMdPlaceholders({ targetPath, projectName, version, mainBranch }: { targetPath: string; projectName: string; version: string; mainBranch: string }) {
   const claudeMdPath = targetPath === '.' ? 'CLAUDE.md' : `${targetPath}/CLAUDE.md`
 
   if (await fileExists(claudeMdPath)) {
     let claudeMdContent = await readFile(claudeMdPath, 'utf8')
-    claudeMdContent = claudeMdContent.replace(/\{\{PROJECT_NAME\}\}/g, projectName).replace(/\{\{VERSION\}\}/g, version)
+    claudeMdContent = claudeMdContent
+      .replace(/\{\{PROJECT_NAME\}\}/g, projectName)
+      .replace(/\{\{VERSION\}\}/g, version)
+      .replace(/\{\{MAIN_BRANCH\}\}/g, mainBranch)
     await writeFile(claudeMdPath, claudeMdContent)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,6 +220,10 @@ export interface SaaSFoundryManifest {
   generatedAt: string
   structure: 'monorepo' | 'multirepo' | 'cli'
   projectName: string
+  // Git main branch chosen at `sf new` (main/master). Optional: manifests
+  // written before this field exists omit it — read sites must fall back
+  // (no migration; see .claude/docs/migration-framework.md "When NOT to add").
+  mainBranch?: string
   modules?: {
     // Email module — versioned shape introduced in manifestVersion 2.
     // `provider` replaces the old flat `emailService` field; `version` is


### PR DESCRIPTION
Resolves #424

## Summary
The `sf new` main-branch choice (main/master) was used for `git init` then lost, while 3 scaffold CLAUDE.md hardcoded `Main branch: \`master\``, CI workflows hardcoded `branches: [master, main, develop]` (and a deploy gate on `--branch=master` that could never fire on `main` projects), and the declared `workflow.workingBranch` was never created. Generated projects shipped self-contradicting branch docs — reported by an AI session on a freshly generated project.

- **Manifest**: top-level `mainBranch` persisted (type + JSON schema + writer + canonical docs). Optional field with read-site fallback — no migration needed per `.claude/docs/migration-framework.md`; `sf update` backfill stays a backlog note (#424 step 6). Drift-guard snapshot updated consciously (no version bump).
- **CLAUDE.md ×3**: `Main branch: \`{{MAIN_BRANCH}}\`` substituted by `installSkills`; commit examples annotated as illustrative (the `feat(#42)` confusion).
- **Develop-first**: builders create and stay on `workflow.workingBranch` after the initial commit (monorepo + both multirepo repos) when it differs from `mainBranch`.
- **CI ×7 workflows**: `{{CI_PR_BRANCHES}}` (PR triggers, deduped `[workingBranch, mainBranch]`) and `{{MAIN_BRANCH}}` (deploy push + `--branch=` gate + tag steps), substituted by builders.
- **update.ts**: 3 hardcoded `mainBranch: 'main'` sites now read `manifest.mainBranch ?? 'main'`.
- **Dogfood**: witness `rework-ui-mono-check` aligned (CLAUDE.md, manifest, `develop` created).

## Tests
- New/updated: manifest assertion (non-interactive spec) · `MAIN_BRANCH` placeholder substitution with deterministic fixture (skills installer spec) · CI branch substitution smoke ×2 topologies · drift-guard snapshot.
- Full suite green: 1399 jest tests + top-2 docker scenarios (pre-push).
- Manual: 4 scenarios on the compiled CLI (mono/main, mono/master, multirepo, real-git workingBranch creation) — full report on #424.

## Known limitation
`sf update` re-runs builders without the workflow block: CI re-substitution on template refresh falls back to `[mainBranch]`. Rides with the manifest backfill (backlog note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)