### PR TITLE
[#435] github-projects CLI: create-pr reports success when gh pr create failed (grep 'http' false positive)

### DIFF
--- a/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
+++ b/.claude/skills/sf-tool-github-projects/github-projects-cli.sh
@@ -777,17 +777,24 @@ cmd_create_pr() {
 
   git push -u origin "$CURRENT_BRANCH"
 
-  PR_URL=$(gh pr create \
+  # `|| status=$?` keeps `set -e` from killing the script mid-assignment — that
+  # silently swallowed gh's error message (captured in the substitution, never
+  # printed). Success requires exit 0 AND a real PR URL: gh error output often
+  # contains URLs (compare/doc links), so a bare `grep http` false-positives (#435).
+  PR_CREATE_STATUS=0
+  PR_OUTPUT=$(gh pr create \
     --title "[#${TICKET_NUMBER}] $ISSUE_TITLE" \
     --body "Resolves #${TICKET_NUMBER}" \
-    --base "$WORKING_BRANCH" 2>&1)
+    --base "$WORKING_BRANCH" 2>&1) || PR_CREATE_STATUS=$?
 
-  if echo "$PR_URL" | grep -q "http"; then
+  PR_URL=$(echo "$PR_OUTPUT" | grep -oE 'https://[^[:space:]]+/pull/[0-9]+' | head -n 1 || true)
+
+  if [ "$PR_CREATE_STATUS" -eq 0 ] && [ -n "$PR_URL" ]; then
     echo -e "${GREEN}✓ Pull request created${NC}"
     echo "$PR_URL"
   else
-    echo -e "${RED}Error creating PR:${NC}"
-    echo "$PR_URL"
+    echo -e "${RED}Error creating PR (gh exit ${PR_CREATE_STATUS}):${NC}"
+    echo "$PR_OUTPUT"
     exit 1
   fi
 }

--- a/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
+++ b/scaffolds/skills-templates/tools/github-projects/github-projects-cli.sh
@@ -777,17 +777,24 @@ cmd_create_pr() {
 
   git push -u origin "$CURRENT_BRANCH"
 
-  PR_URL=$(gh pr create \
+  # `|| status=$?` keeps `set -e` from killing the script mid-assignment — that
+  # silently swallowed gh's error message (captured in the substitution, never
+  # printed). Success requires exit 0 AND a real PR URL: gh error output often
+  # contains URLs (compare/doc links), so a bare `grep http` false-positives (#435).
+  PR_CREATE_STATUS=0
+  PR_OUTPUT=$(gh pr create \
     --title "[#${TICKET_NUMBER}] $ISSUE_TITLE" \
     --body "Resolves #${TICKET_NUMBER}" \
-    --base "$WORKING_BRANCH" 2>&1)
+    --base "$WORKING_BRANCH" 2>&1) || PR_CREATE_STATUS=$?
 
-  if echo "$PR_URL" | grep -q "http"; then
+  PR_URL=$(echo "$PR_OUTPUT" | grep -oE 'https://[^[:space:]]+/pull/[0-9]+' | head -n 1 || true)
+
+  if [ "$PR_CREATE_STATUS" -eq 0 ] && [ -n "$PR_URL" ]; then
     echo -e "${GREEN}✓ Pull request created${NC}"
     echo "$PR_URL"
   else
-    echo -e "${RED}Error creating PR:${NC}"
-    echo "$PR_URL"
+    echo -e "${RED}Error creating PR (gh exit ${PR_CREATE_STATUS}):${NC}"
+    echo "$PR_OUTPUT"
     exit 1
   fi
 }

--- a/src/__tests__/unit/skill/github-projects-cli.create-pr.spec.ts
+++ b/src/__tests__/unit/skill/github-projects-cli.create-pr.spec.ts
@@ -1,0 +1,122 @@
+import { execFile } from 'node:child_process'
+import { chmodSync, mkdtempSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileP = promisify(execFile)
+
+// Regression guard for #435: `cmd_create_pr` detected success by grepping the
+// captured `gh pr create` output for "http" — but gh error messages routinely
+// contain URLs (compare links, doc links), and under `set -e` a failing
+// command substitution killed the script before the check, swallowing the
+// error entirely (observed live on #424: exit masked, no PR, no message).
+// The contract pinned here: success = gh exit 0 AND a real `/pull/<n>` URL;
+// anything else must exit non-zero AND surface gh's output.
+const CLI = path.resolve(__dirname, '../../../../.claude/skills/sf-tool-github-projects/github-projects-cli.sh')
+const BASH = '/bin/bash'
+
+async function buildSandbox(): Promise<{ dir: string; env: NodeJS.ProcessEnv; cleanup: () => Promise<void> }> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sf-gh-create-pr-'))
+  const binDir = path.join(dir, 'bin')
+  await mkdir(binDir, { recursive: true })
+
+  await writeFile(
+    path.join(dir, '.saasfoundry.json'),
+    JSON.stringify({
+      workflow: { projectUrl: 'https://github.com/orgs/FakeOrg/projects/42', workingBranch: 'develop' }
+    })
+  )
+
+  // gh shim — `issue view` returns a title; `pr create` behavior is driven by
+  // GH_PR_CREATE_MODE (ok | ok-no-url | fail-with-url).
+  const ghShim = `#!/bin/bash
+case "$1" in
+  issue)
+    echo "Sample ticket title"
+    ;;
+  pr)
+    case "$GH_PR_CREATE_MODE" in
+      ok)
+        echo "https://github.com/FakeOrg/FakeRepo/pull/123"
+        exit 0
+        ;;
+      ok-no-url)
+        echo "warning: something unexpected, no PR url printed"
+        exit 0
+        ;;
+      *)
+        echo "pull request create failed: GraphQL: was submitted too quickly"
+        echo "see https://docs.github.com/en/rest/pulls for more information"
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected gh call: $*" >&2
+    exit 1
+    ;;
+esac
+`
+  const gitShim = `#!/bin/bash
+case "$1" in
+  rev-parse) echo "fix/999-sandbox" ;;
+  *) exit 0 ;;
+esac
+`
+  await writeFile(path.join(binDir, 'gh'), ghShim)
+  await writeFile(path.join(binDir, 'git'), gitShim)
+  chmodSync(path.join(binDir, 'gh'), 0o755)
+  chmodSync(path.join(binDir, 'git'), 0o755)
+
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` }
+  return { dir, env, cleanup: () => rm(dir, { recursive: true, force: true }) }
+}
+
+async function runCreatePr(env: NodeJS.ProcessEnv, cwd: string): Promise<{ code: number; output: string }> {
+  try {
+    const { stdout, stderr } = await execFileP(BASH, [CLI, 'create-pr', '999'], { env, cwd })
+    return { code: 0, output: `${stdout}\n${stderr}` }
+  } catch (error) {
+    const e = error as { code?: number; stdout?: string; stderr?: string }
+    return { code: e.code ?? 1, output: `${e.stdout ?? ''}\n${e.stderr ?? ''}` }
+  }
+}
+
+describe('github-projects-cli create-pr (regression #435)', () => {
+  let sandbox: Awaited<ReturnType<typeof buildSandbox>>
+
+  beforeEach(async () => {
+    sandbox = await buildSandbox()
+  })
+
+  afterEach(async () => {
+    await sandbox.cleanup()
+  })
+
+  it('fails loudly when gh pr create exits non-zero, even if its error output contains a URL', async () => {
+    const { code, output } = await runCreatePr({ ...sandbox.env, GH_PR_CREATE_MODE: 'fail-with-url' }, sandbox.dir)
+
+    expect(code).not.toBe(0)
+    expect(output).not.toContain('Pull request created')
+    expect(output).toContain('Error creating PR')
+    // gh's actual error must surface (it was silently swallowed by set -e before the fix)
+    expect(output).toContain('was submitted too quickly')
+  })
+
+  it('fails when gh exits 0 but prints no PR URL', async () => {
+    const { code, output } = await runCreatePr({ ...sandbox.env, GH_PR_CREATE_MODE: 'ok-no-url' }, sandbox.dir)
+
+    expect(code).not.toBe(0)
+    expect(output).toContain('Error creating PR')
+  })
+
+  it('succeeds and prints the PR URL when gh exits 0 with a real /pull/<n> URL', async () => {
+    const { code, output } = await runCreatePr({ ...sandbox.env, GH_PR_CREATE_MODE: 'ok' }, sandbox.dir)
+
+    expect(code).toBe(0)
+    expect(output).toContain('Pull request created')
+    expect(output).toContain('https://github.com/FakeOrg/FakeRepo/pull/123')
+  })
+})


### PR DESCRIPTION
Resolves #435

## Summary
`cmd_create_pr` had two stacked failure modes (observed live on #424): under `set -e`, a transient `gh pr create` failure killed the script mid-command-substitution — gh's error was captured into the dying assignment and never printed (silent no-PR outcome); and the `grep -q "http"` success check was a latent false positive since gh error output routinely contains URLs.

- set-e-safe capture (`|| PR_CREATE_STATUS=$?`)
- success = gh exit 0 **AND** a `/pull/<n>` URL extracted by shape
- failure path prints gh's full output + exit code
- `scaffolds/skills-templates/tools/github-projects/` mirror synced byte-identical (drift-guard)

## Tests
- New regression spec `github-projects-cli.create-pr.spec.ts` (sandboxed gh/git shims): fail-with-URL → loud non-zero + gh message surfaced · exit 0 without URL → failure · nominal → URL printed
- Full jest 1402 green, docker pre-push 2/2
- Manual sandbox demo of the silent-failure scenario + **this very PR was opened by the fixed CLI** (nominal path dogfooded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)