### PR TITLE
[#436] AI session visibility: stream progress of long-running commands + status-transition banner

### DIFF
--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -256,6 +256,8 @@ see its `## Conversational eval hook (SUB-10)` section. This skill only referenc
    installer's `migrations` array for module file-set changes). Inline manifest mutations and "let users fix it manually" shortcuts are forbidden by `CLAUDE.md`'s "Migration framework — NEVER bypass"
    section. Read `.claude/docs/migration-framework.md` before approving the transition.
 
+10. **ANNOUNCE + STREAM LONG COMMANDS** — before any command expected to take more than ~5 seconds (test suites, builds, commit/push hooks, Docker scenarios), announce in one sentence what runs and the expected duration. Over ~60 seconds, run it in the background and stream its progress markers to the user as they appear (e.g. `tail -f <log> | grep -E --line-buffered "PASS|FAIL|\[sf-progress\]"`) — never block silently. Report the outcome with numbers, and relay the ▶ AI / ⏳ Dev banner printed by `update-status` after every transition.
+
 ## Implementation
 
 The status descriptions are in the `statuses/` directory:

--- a/.claude/skills/sf-workflow/SKILL.md
+++ b/.claude/skills/sf-workflow/SKILL.md
@@ -256,7 +256,10 @@ see its `## Conversational eval hook (SUB-10)` section. This skill only referenc
    installer's `migrations` array for module file-set changes). Inline manifest mutations and "let users fix it manually" shortcuts are forbidden by `CLAUDE.md`'s "Migration framework — NEVER bypass"
    section. Read `.claude/docs/migration-framework.md` before approving the transition.
 
-10. **ANNOUNCE + STREAM LONG COMMANDS** — before any command expected to take more than ~5 seconds (test suites, builds, commit/push hooks, Docker scenarios), announce in one sentence what runs and the expected duration. Over ~60 seconds, run it in the background and stream its progress markers to the user as they appear (e.g. `tail -f <log> | grep -E --line-buffered "PASS|FAIL|\[sf-progress\]"`) — never block silently. Report the outcome with numbers, and relay the ▶ AI / ⏳ Dev banner printed by `update-status` after every transition.
+10. **ANNOUNCE + STREAM LONG COMMANDS** — before any command expected to take more than ~5 seconds (test suites, builds, commit/push hooks, Docker scenarios), announce in one sentence what runs and
+    the expected duration. Over ~60 seconds, run it in the background and stream its progress markers to the user as they appear (e.g.
+    `tail -f <log> | grep -E --line-buffered "PASS|FAIL|\[sf-progress\]"`) — never block silently. Report the outcome with numbers, and relay the ▶ AI / ⏳ Dev banner printed by `update-status` after
+    every transition.
 
 ## Implementation
 

--- a/.claude/skills/sf-workflow/statuses/1-backlog.md
+++ b/.claude/skills/sf-workflow/statuses/1-backlog.md
@@ -1,5 +1,7 @@
 ---
 status: Backlog
+banner_ai: Detect + persist the complexity label, analyze and plan per complexity, challenge the specs
+banner_human: Validate specs + plan (→ Ready), then confirm pickup priority (→ In progress)
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - Developer mentions a new idea / feature / bug

--- a/.claude/skills/sf-workflow/statuses/2-ready.md
+++ b/.claude/skills/sf-workflow/statuses/2-ready.md
@@ -1,5 +1,7 @@
 ---
 status: Ready
+banner_ai: Nothing — Ready is a waiting queue
+banner_human: Assign the ticket or confirm pickup to start development
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - Specs validated in Backlog

--- a/.claude/skills/sf-workflow/statuses/3-in-progress.md
+++ b/.claude/skills/sf-workflow/statuses/3-in-progress.md
@@ -1,5 +1,7 @@
 ---
 status: In Progress
+banner_ai: Branch from workingBranch, one commit per subtask, validate (build/lint/tests), push
+banner_human: Nothing yet — next involvement at Human Testing (or PR review for nature:internal)
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - Assignment or confirmation received in Ready

--- a/.claude/skills/sf-workflow/statuses/3a-ai-drafting.md
+++ b/.claude/skills/sf-workflow/statuses/3a-ai-drafting.md
@@ -1,5 +1,7 @@
 ---
 status: AI Drafting (drafting lifecycle — board column stays "In progress")
+banner_ai: Run the drafter against the configured SRS backend and post the draft page links on the ticket
+banner_human: Wait for the draft — your review comes next (human-review phase)
 complexity_profiles: [srs-drafting, srs-update, srs-new]
 entry_conditions:
   - Ticket board status is `In progress`

--- a/.claude/skills/sf-workflow/statuses/3b-human-review.md
+++ b/.claude/skills/sf-workflow/statuses/3b-human-review.md
@@ -1,5 +1,7 @@
 ---
 status: Human Review (drafting lifecycle — board column stays "In progress")
+banner_ai: Waiting — apply your review feedback to the draft pages
+banner_human: Review the SRS pages and approve, or request changes on the ticket
 complexity_profiles: [srs-drafting, srs-update, srs-new]
 entry_conditions:
   - `3a-ai-drafting.md` complete — `srs-cli.sh draft` exited 0

--- a/.claude/skills/sf-workflow/statuses/3c-spawning.md
+++ b/.claude/skills/sf-workflow/statuses/3c-spawning.md
@@ -1,5 +1,7 @@
 ---
 status: Spawning (drafting lifecycle — board column stays "In progress" → "Done" on transition-drafting done)
+banner_ai: Spawn child tickets from the approved FR pages, then close the drafting ticket
+banner_human: Nothing — children land in Backlog for later prioritization
 complexity_profiles: [srs-drafting, srs-update, srs-new]
 entry_conditions:
   - `3b-human-review.md` complete — owner approval signalled

--- a/.claude/skills/sf-workflow/statuses/4-ai-testing.md
+++ b/.claude/skills/sf-workflow/statuses/4-ai-testing.md
@@ -1,5 +1,7 @@
 ---
 status: AI Testing
+banner_ai: Post the test plan, run automated + manual tests, fix on red, post the report
+banner_human: Nothing yet — get ready to test manually (user-facing) or review the PR (internal)
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - All subtasks completed in In Progress

--- a/.claude/skills/sf-workflow/statuses/5-human-testing.md
+++ b/.claude/skills/sf-workflow/statuses/5-human-testing.md
@@ -1,5 +1,7 @@
 ---
 status: Human Testing
+banner_ai: Waiting — supporting reproduction and fixing whatever you report
+banner_human: Execute the manual test plan and report pass/fail on the ticket
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - All AI Testing steps passed

--- a/.claude/skills/sf-workflow/statuses/6-in-review.md
+++ b/.claude/skills/sf-workflow/statuses/6-in-review.md
@@ -1,5 +1,7 @@
 ---
 status: In Review
+banner_ai: Monitor CI until green, answer review comments, implement requested changes
+banner_human: Review + merge the PR — your merge is what triggers Done
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - One of:

--- a/.claude/skills/sf-workflow/statuses/7-done.md
+++ b/.claude/skills/sf-workflow/statuses/7-done.md
@@ -1,5 +1,7 @@
 ---
 status: Done
+banner_ai: Cleanup: checkout workingBranch, rebase-pull, delete the feature branch, rebase other in-progress branches
+banner_human: Nothing — cycle complete
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - One of:

--- a/.claude/skills/sf-workflow/workflow-cli.sh
+++ b/.claude/skills/sf-workflow/workflow-cli.sh
@@ -97,6 +97,41 @@ get_current_status() {
 }
 
 # Function to display status description
+# Post-transition expectations banner (#436): one line for the AI, one for the
+# developer, read from the target status file's `banner_ai:` / `banner_human:`
+# frontmatter fields. Lives here (not in the tool CLIs) so every board tool
+# (github-projects, jira, notion, linear) gets it for free. Never fails the
+# transition: missing file/fields just skip the banner.
+print_status_banner() {
+  local status=$1
+  local status_file=""
+
+  case "$status" in
+    "Backlog") status_file="1-backlog.md" ;;
+    "Ready") status_file="2-ready.md" ;;
+    "In Progress" | "In progress") status_file="3-in-progress.md" ;;
+    "AI Testing" | "AI testing") status_file="4-ai-testing.md" ;;
+    "Human Testing" | "Human testing") status_file="5-human-testing.md" ;;
+    "In Review" | "In review") status_file="6-in-review.md" ;;
+    "Done") status_file="7-done.md" ;;
+    "drafting:ai-draft") status_file="3a-ai-drafting.md" ;;
+    "drafting:human-review") status_file="3b-human-review.md" ;;
+    "drafting:spawning") status_file="3c-spawning.md" ;;
+    *) return 0 ;;
+  esac
+
+  local file_path="$SKILL_DIR/statuses/$status_file"
+  [[ -f "$file_path" ]] || return 0
+
+  local banner_ai banner_human
+  banner_ai=$(sed -n 's/^banner_ai: *//p' "$file_path" | head -n 1)
+  banner_human=$(sed -n 's/^banner_human: *//p' "$file_path" | head -n 1)
+
+  [[ -n "$banner_ai" ]] && echo -e "${BLUE}▶ AI:${NC} ${banner_ai}"
+  [[ -n "$banner_human" ]] && echo -e "${YELLOW}⏳ Dev:${NC} ${banner_human}"
+  return 0
+}
+
 show_status_description() {
   local status=$1
   local status_file=""
@@ -633,7 +668,8 @@ case "$COMMAND" in
     if ! check_pr_merged_guard "$TICKET" "$TARGET"; then
       exit 2
     fi
-    route_to_tool "$WORKFLOW_TOOL" update-status "$@"
+    route_to_tool "$WORKFLOW_TOOL" update-status "$@" || exit $?
+    print_status_banner "$TARGET"
     ;;
 
   create-subtask|create-pr|list|get-labels)
@@ -694,13 +730,15 @@ case "$COMMAND" in
           echo -e "${RED}✗ Expected ${SRS_CLI} to be executable. Run the SRS skill install first.${NC}" >&2
           exit 2
         fi
-        "$SRS_CLI" draft --ticket "$TICKET"
+        "$SRS_CLI" draft --ticket "$TICKET" || exit $?
+        print_status_banner "drafting:ai-draft"
         ;;
       human-review)
         echo -e "${BLUE}→ Human review phase for #${TICKET}${NC}"
         echo "  Post a review checklist comment on the ticket and wait for the owner's approval."
         echo "  The Notion page URL should already be in the ticket (posted by the AI draft phase)."
         echo "  No automated action — this phase is driven by the human reviewer."
+        print_status_banner "drafting:human-review"
         ;;
       spawning)
         echo -e "${BLUE}→ Spawning phase for #${TICKET}${NC}"
@@ -708,11 +746,13 @@ case "$COMMAND" in
           echo -e "${RED}✗ Expected ${SRS_CLI} to be executable. Run the SRS skill install first.${NC}" >&2
           exit 2
         fi
-        "$SRS_CLI" spawn --ticket "$TICKET"
+        "$SRS_CLI" spawn --ticket "$TICKET" || exit $?
+        print_status_banner "drafting:spawning"
         ;;
       done)
         echo -e "${BLUE}→ Closing drafting ticket #${TICKET}${NC}"
-        SF_WORKFLOW_BYPASS_SRS_GUARD=1 route_to_tool "$WORKFLOW_TOOL" update-status "$TICKET" "Done"
+        SF_WORKFLOW_BYPASS_SRS_GUARD=1 route_to_tool "$WORKFLOW_TOOL" update-status "$TICKET" "Done" || exit $?
+        print_status_banner "Done"
         ;;
       *)
         echo -e "${RED}✗ Unknown phase '${PHASE}'${NC}" >&2

--- a/scaffolds/blueprints/api/CLAUDE.md
+++ b/scaffolds/blueprints/api/CLAUDE.md
@@ -149,6 +149,14 @@ docker compose -f docker-compose.dev-services.yml down   # Stop services
 
 This project is pre-configured for AI development with Claude Code.
 
+### 📣 Long-running commands (announce + stream)
+
+The screen must never freeze silently. For any command expected to take more than ~5 seconds (test suites, builds, commit/push hooks, Docker scenarios):
+
+1. **Announce before running** — one sentence: what runs and the expected duration (e.g. "pre-commit hook ~40s: format + lint + build + tests").
+2. **Over ~60 seconds: stream progress** — run the command in the background and surface its progress markers to the user as they appear (e.g. `tail -f <log> | grep -E --line-buffered "PASS|FAIL|\[sf-progress\]"`). Never block silently.
+3. **Report the outcome with numbers** — suites passed/failed, duration — not just "done".
+
 ### 🛠️ Available Skills
 
 Located in `.claude/skills/`:

--- a/scaffolds/blueprints/web/CLAUDE.md
+++ b/scaffolds/blueprints/web/CLAUDE.md
@@ -162,6 +162,14 @@ npm run preview             # Preview production build
 
 This project is pre-configured for AI development with Claude Code.
 
+### 📣 Long-running commands (announce + stream)
+
+The screen must never freeze silently. For any command expected to take more than ~5 seconds (test suites, builds, commit/push hooks, Docker scenarios):
+
+1. **Announce before running** — one sentence: what runs and the expected duration (e.g. "pre-commit hook ~40s: format + lint + build + tests").
+2. **Over ~60 seconds: stream progress** — run the command in the background and surface its progress markers to the user as they appear (e.g. `tail -f <log> | grep -E --line-buffered "PASS|FAIL|\[sf-progress\]"`). Never block silently.
+3. **Report the outcome with numbers** — suites passed/failed, duration — not just "done".
+
 ### 🛠️ Available Skills
 
 Located in `.claude/skills/`:

--- a/scaffolds/overlays/monorepo/root/CLAUDE.md
+++ b/scaffolds/overlays/monorepo/root/CLAUDE.md
@@ -85,6 +85,14 @@ Edit these files like any other shared file once they exist — they're just can
 
 SaaSFoundry skills are located in `.claude/` at the repository root and are optimized for this monorepo structure.
 
+## 📣 Long-running commands (announce + stream)
+
+The screen must never freeze silently. For any command expected to take more than ~5 seconds (test suites, builds, commit/push hooks, Docker scenarios):
+
+1. **Announce before running** — one sentence: what runs and the expected duration (e.g. "pre-commit hook ~40s: format + lint + build + tests").
+2. **Over ~60 seconds: stream progress** — run the command in the background and surface its progress markers to the user as they appear (e.g. `tail -f <log> | grep -E --line-buffered "PASS|FAIL|\[sf-progress\]"`). Never block silently.
+3. **Report the outcome with numbers** — suites passed/failed, duration — not just "done".
+
 ## 📦 Tech Stack
 
 ### Backend (apps/api/)

--- a/scaffolds/skills-templates/workflow/SKILL.md
+++ b/scaffolds/skills-templates/workflow/SKILL.md
@@ -203,6 +203,8 @@ When `tools.srs.enabled = true`, Claude must interject during conversation turns
 7. **FINISH THE CURRENT TICKET BEFORE STARTING ANOTHER** — if a ticket is `In Progress` / `AI Testing` / `Human Testing` / `In Review`, drive it to `Done` before claiming or starting another. The only override is an explicit developer request to pause.
 8. **TICKETS FROM SRS** — when `tools.srs.backend` is set in `.saasfoundry.json`, Story sub-tickets under an SRS Epic must be spawned from the canonical FR pages, not hand-written. Use `.claude/skills/sf-srs/scripts/srs-cli.sh spawn --ticket <parent> --epic <page-url-or-id>` to create one child issue per FR page, each body rendered from `renderStoryTicketBody`. The `create-subtask` command rejects any call without `--bypass-srs <reason>` on SRS-enabled projects — see the "SRS Handoff" section above. The escape hatch exists for meta tickets (SRS refactors, tooling) but must never be used to duplicate an FR that already has a page.
 
+9. **ANNOUNCE + STREAM LONG COMMANDS** — before any command expected to take more than ~5 seconds (test suites, builds, commit/push hooks, Docker scenarios), announce in one sentence what runs and the expected duration. Over ~60 seconds, run it in the background and stream its progress markers to the user as they appear (e.g. `tail -f <log> | grep -E --line-buffered "PASS|FAIL|\[sf-progress\]"`) — never block silently. Report the outcome with numbers, and relay the ▶ AI / ⏳ Dev banner printed by `update-status` after every transition.
+
 ## Implementation
 
 The status descriptions are in the `statuses/` directory:

--- a/scaffolds/skills-templates/workflow/statuses/1-backlog.md
+++ b/scaffolds/skills-templates/workflow/statuses/1-backlog.md
@@ -1,5 +1,7 @@
 ---
 status: Backlog
+banner_ai: Detect + persist the complexity label, analyze and plan per complexity, challenge the specs
+banner_human: Validate specs + plan (→ Ready), then confirm pickup priority (→ In progress)
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - Developer mentions a new idea / feature / bug

--- a/scaffolds/skills-templates/workflow/statuses/2-ready.md
+++ b/scaffolds/skills-templates/workflow/statuses/2-ready.md
@@ -1,5 +1,7 @@
 ---
 status: Ready
+banner_ai: Nothing — Ready is a waiting queue
+banner_human: Assign the ticket or confirm pickup to start development
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - Specs validated in Backlog

--- a/scaffolds/skills-templates/workflow/statuses/3-in-progress.md
+++ b/scaffolds/skills-templates/workflow/statuses/3-in-progress.md
@@ -1,5 +1,7 @@
 ---
 status: In Progress
+banner_ai: Branch from workingBranch, one commit per subtask, validate (build/lint/tests), push
+banner_human: Nothing yet — next involvement at Human Testing (or PR review for nature:internal)
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - Assignment or confirmation received in Ready

--- a/scaffolds/skills-templates/workflow/statuses/3a-ai-drafting.md
+++ b/scaffolds/skills-templates/workflow/statuses/3a-ai-drafting.md
@@ -1,5 +1,7 @@
 ---
 status: AI Drafting (drafting lifecycle — board column stays "In progress")
+banner_ai: Run the drafter against the configured SRS backend and post the draft page links on the ticket
+banner_human: Wait for the draft — your review comes next (human-review phase)
 complexity_profiles: [srs-drafting, srs-update, srs-new]
 entry_conditions:
   - Ticket board status is `In progress`

--- a/scaffolds/skills-templates/workflow/statuses/3b-human-review.md
+++ b/scaffolds/skills-templates/workflow/statuses/3b-human-review.md
@@ -1,5 +1,7 @@
 ---
 status: Human Review (drafting lifecycle — board column stays "In progress")
+banner_ai: Waiting — apply your review feedback to the draft pages
+banner_human: Review the SRS pages and approve, or request changes on the ticket
 complexity_profiles: [srs-drafting, srs-update, srs-new]
 entry_conditions:
   - `3a-ai-drafting.md` complete — `srs-cli.sh draft` exited 0

--- a/scaffolds/skills-templates/workflow/statuses/3c-spawning.md
+++ b/scaffolds/skills-templates/workflow/statuses/3c-spawning.md
@@ -1,5 +1,7 @@
 ---
 status: Spawning (drafting lifecycle — board column stays "In progress" → "Done" on transition-drafting done)
+banner_ai: Spawn child tickets from the approved FR pages, then close the drafting ticket
+banner_human: Nothing — children land in Backlog for later prioritization
 complexity_profiles: [srs-drafting, srs-update, srs-new]
 entry_conditions:
   - `3b-human-review.md` complete — owner approval signalled

--- a/scaffolds/skills-templates/workflow/statuses/4-ai-testing.md
+++ b/scaffolds/skills-templates/workflow/statuses/4-ai-testing.md
@@ -1,5 +1,7 @@
 ---
 status: AI Testing
+banner_ai: Post the test plan, run automated + manual tests, fix on red, post the report
+banner_human: Nothing yet — get ready to test manually (user-facing) or review the PR (internal)
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - All subtasks completed in In Progress

--- a/scaffolds/skills-templates/workflow/statuses/5-human-testing.md
+++ b/scaffolds/skills-templates/workflow/statuses/5-human-testing.md
@@ -1,5 +1,7 @@
 ---
 status: Human Testing
+banner_ai: Waiting — supporting reproduction and fixing whatever you report
+banner_human: Execute the manual test plan and report pass/fail on the ticket
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - All AI Testing steps passed

--- a/scaffolds/skills-templates/workflow/statuses/6-in-review.md
+++ b/scaffolds/skills-templates/workflow/statuses/6-in-review.md
@@ -1,5 +1,7 @@
 ---
 status: In Review
+banner_ai: Monitor CI until green, answer review comments, implement requested changes
+banner_human: Review + merge the PR — your merge is what triggers Done
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - One of:

--- a/scaffolds/skills-templates/workflow/statuses/7-done.md
+++ b/scaffolds/skills-templates/workflow/statuses/7-done.md
@@ -1,5 +1,7 @@
 ---
 status: Done
+banner_ai: Cleanup: checkout workingBranch, rebase-pull, delete the feature branch, rebase other in-progress branches
+banner_human: Nothing — cycle complete
 complexity_profiles: [bug, low, medium, complex]
 entry_conditions:
   - One of:

--- a/scaffolds/skills-templates/workflow/workflow-cli.sh
+++ b/scaffolds/skills-templates/workflow/workflow-cli.sh
@@ -97,6 +97,41 @@ get_current_status() {
 }
 
 # Function to display status description
+# Post-transition expectations banner (#436): one line for the AI, one for the
+# developer, read from the target status file's `banner_ai:` / `banner_human:`
+# frontmatter fields. Lives here (not in the tool CLIs) so every board tool
+# (github-projects, jira, notion, linear) gets it for free. Never fails the
+# transition: missing file/fields just skip the banner.
+print_status_banner() {
+  local status=$1
+  local status_file=""
+
+  case "$status" in
+    "Backlog") status_file="1-backlog.md" ;;
+    "Ready") status_file="2-ready.md" ;;
+    "In Progress" | "In progress") status_file="3-in-progress.md" ;;
+    "AI Testing" | "AI testing") status_file="4-ai-testing.md" ;;
+    "Human Testing" | "Human testing") status_file="5-human-testing.md" ;;
+    "In Review" | "In review") status_file="6-in-review.md" ;;
+    "Done") status_file="7-done.md" ;;
+    "drafting:ai-draft") status_file="3a-ai-drafting.md" ;;
+    "drafting:human-review") status_file="3b-human-review.md" ;;
+    "drafting:spawning") status_file="3c-spawning.md" ;;
+    *) return 0 ;;
+  esac
+
+  local file_path="$SKILL_DIR/statuses/$status_file"
+  [[ -f "$file_path" ]] || return 0
+
+  local banner_ai banner_human
+  banner_ai=$(sed -n 's/^banner_ai: *//p' "$file_path" | head -n 1)
+  banner_human=$(sed -n 's/^banner_human: *//p' "$file_path" | head -n 1)
+
+  [[ -n "$banner_ai" ]] && echo -e "${BLUE}▶ AI:${NC} ${banner_ai}"
+  [[ -n "$banner_human" ]] && echo -e "${YELLOW}⏳ Dev:${NC} ${banner_human}"
+  return 0
+}
+
 show_status_description() {
   local status=$1
   local status_file=""
@@ -633,7 +668,8 @@ case "$COMMAND" in
     if ! check_pr_merged_guard "$TICKET" "$TARGET"; then
       exit 2
     fi
-    route_to_tool "$WORKFLOW_TOOL" update-status "$@"
+    route_to_tool "$WORKFLOW_TOOL" update-status "$@" || exit $?
+    print_status_banner "$TARGET"
     ;;
 
   create-subtask|create-pr|list|get-labels)
@@ -694,13 +730,15 @@ case "$COMMAND" in
           echo -e "${RED}✗ Expected ${SRS_CLI} to be executable. Run the SRS skill install first.${NC}" >&2
           exit 2
         fi
-        "$SRS_CLI" draft --ticket "$TICKET"
+        "$SRS_CLI" draft --ticket "$TICKET" || exit $?
+        print_status_banner "drafting:ai-draft"
         ;;
       human-review)
         echo -e "${BLUE}→ Human review phase for #${TICKET}${NC}"
         echo "  Post a review checklist comment on the ticket and wait for the owner's approval."
         echo "  The Notion page URL should already be in the ticket (posted by the AI draft phase)."
         echo "  No automated action — this phase is driven by the human reviewer."
+        print_status_banner "drafting:human-review"
         ;;
       spawning)
         echo -e "${BLUE}→ Spawning phase for #${TICKET}${NC}"
@@ -708,11 +746,13 @@ case "$COMMAND" in
           echo -e "${RED}✗ Expected ${SRS_CLI} to be executable. Run the SRS skill install first.${NC}" >&2
           exit 2
         fi
-        "$SRS_CLI" spawn --ticket "$TICKET"
+        "$SRS_CLI" spawn --ticket "$TICKET" || exit $?
+        print_status_banner "drafting:spawning"
         ;;
       done)
         echo -e "${BLUE}→ Closing drafting ticket #${TICKET}${NC}"
-        SF_WORKFLOW_BYPASS_SRS_GUARD=1 route_to_tool "$WORKFLOW_TOOL" update-status "$TICKET" "Done"
+        SF_WORKFLOW_BYPASS_SRS_GUARD=1 route_to_tool "$WORKFLOW_TOOL" update-status "$TICKET" "Done" || exit $?
+        print_status_banner "Done"
         ;;
       *)
         echo -e "${RED}✗ Unknown phase '${PHASE}'${NC}" >&2

--- a/src/__tests__/unit/skill/workflow-cli.banner.spec.ts
+++ b/src/__tests__/unit/skill/workflow-cli.banner.spec.ts
@@ -1,0 +1,130 @@
+import { execFile } from 'child_process'
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { readdirSync } from 'fs'
+import { mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { promisify } from 'util'
+
+const execFileP = promisify(execFile)
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const CLI = path.resolve(REPO_ROOT, '.claude/skills/sf-workflow/workflow-cli.sh')
+const STATUSES_DIR = path.resolve(REPO_ROOT, '.claude/skills/sf-workflow/statuses')
+const BASH = '/bin/bash'
+
+// #436: after a successful transition, update-status prints an expectations
+// banner (▶ AI / ⏳ Dev) read from the target status file's banner_ai /
+// banner_human frontmatter. The banner is what tells the developer whose turn
+// it is — silence after "✓ Ticket #N → In review" is how merges got forgotten.
+// Contract pinned here: banner on success, no banner on tool failure, and
+// every status file carries both fields.
+
+async function buildSandbox(options: { toolExitCode?: number } = {}): Promise<{
+  dir: string
+  env: NodeJS.ProcessEnv
+  cleanup: () => Promise<void>
+}> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sf-wfcli-banner-'))
+  const toolDir = path.join(dir, '.claude/skills/sf-tool-github-projects')
+  await mkdir(toolDir, { recursive: true })
+
+  await writeFile(
+    path.join(dir, '.saasfoundry.json'),
+    JSON.stringify({
+      workflow: {
+        tool: 'github-projects',
+        projectUrl: 'https://github.com/orgs/FakeOrg/projects/42',
+        workingBranch: 'develop'
+      }
+    })
+  )
+
+  // Tool CLI shim: `complexity: low` keeps the complexity guard quiet so the
+  // banner logic is isolated; update-status succeeds or fails per the option.
+  const toolExit = options.toolExitCode ?? 0
+  const toolShim = `#!/bin/bash
+case "$1" in
+  get-labels)
+    printf '%s\\n' "complexity: low"
+    ;;
+  update-status)
+    if [ "${toolExit}" -ne 0 ]; then
+      echo "fake-tool-cli: simulated update failure" >&2
+      exit ${toolExit}
+    fi
+    echo "✓ Ticket #$2 → $3"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+  const toolPath = path.join(toolDir, 'github-projects-cli.sh')
+  writeFileSync(toolPath, toolShim)
+  chmodSync(toolPath, 0o755)
+
+  const env: NodeJS.ProcessEnv = { ...process.env, PWD: dir }
+  return { dir, env, cleanup: () => rm(dir, { recursive: true, force: true }) }
+}
+
+describe('workflow-cli update-status expectations banner (#436)', () => {
+  it('prints the ▶ AI / ⏳ Dev banner of the target status after a successful transition', async () => {
+    const sandbox = await buildSandbox()
+    try {
+      const { stdout } = await execFileP(BASH, [CLI, 'update-status', '277', 'In progress'], {
+        env: sandbox.env,
+        cwd: sandbox.dir
+      })
+
+      expect(stdout).toContain('✓ Ticket #277 → In progress')
+      expect(stdout).toContain('▶ AI:')
+      expect(stdout).toContain('Branch from workingBranch')
+      expect(stdout).toContain('⏳ Dev:')
+      expect(stdout).toContain('next involvement at Human Testing')
+    } finally {
+      await sandbox.cleanup()
+    }
+  })
+
+  it('prints the In-review banner that hands the ball to the developer', async () => {
+    // "In progress" → banner is AI-centric; the In-review banner is the one
+    // that prevented forgotten merges, so pin its wording too. Read straight
+    // from the status file to avoid duplicating prose in the test.
+    const file = readFileSync(path.join(STATUSES_DIR, '6-in-review.md'), 'utf8')
+    expect(file).toMatch(/^banner_human: .*merge.*triggers Done/m)
+  })
+
+  it('prints no banner when the tool CLI fails the transition', async () => {
+    const sandbox = await buildSandbox({ toolExitCode: 1 })
+    try {
+      await expect(
+        execFileP(BASH, [CLI, 'update-status', '277', 'In progress'], { env: sandbox.env, cwd: sandbox.dir })
+      ).rejects.toMatchObject({
+        stdout: expect.not.stringContaining('▶ AI:')
+      })
+    } finally {
+      await sandbox.cleanup()
+    }
+  })
+
+  it('every status file carries both banner_ai and banner_human fields', () => {
+    const files = readdirSync(STATUSES_DIR).filter(f => f.endsWith('.md'))
+    expect(files.length).toBeGreaterThanOrEqual(10)
+    for (const f of files) {
+      const content = readFileSync(path.join(STATUSES_DIR, f), 'utf8')
+      expect(content).toMatch(/^banner_ai: .+/m)
+      expect(content).toMatch(/^banner_human: .+/m)
+    }
+  })
+
+  it('status files are byte-identical between the live skill and the scaffolded template', () => {
+    const templateDir = path.resolve(REPO_ROOT, 'scaffolds/skills-templates/workflow/statuses')
+    for (const f of readdirSync(STATUSES_DIR).filter(f => f.endsWith('.md'))) {
+      expect(readFileSync(path.join(STATUSES_DIR, f), 'utf8')).toBe(readFileSync(path.join(templateDir, f), 'utf8'))
+    }
+    expect(readFileSync(CLI, 'utf8')).toBe(
+      readFileSync(path.resolve(REPO_ROOT, 'scaffolds/skills-templates/workflow/workflow-cli.sh'), 'utf8')
+    )
+  })
+})

--- a/src/__tests__/unit/skill/workflow-cli.banner.spec.ts
+++ b/src/__tests__/unit/skill/workflow-cli.banner.spec.ts
@@ -98,9 +98,7 @@ describe('workflow-cli update-status expectations banner (#436)', () => {
   it('prints no banner when the tool CLI fails the transition', async () => {
     const sandbox = await buildSandbox({ toolExitCode: 1 })
     try {
-      await expect(
-        execFileP(BASH, [CLI, 'update-status', '277', 'In progress'], { env: sandbox.env, cwd: sandbox.dir })
-      ).rejects.toMatchObject({
+      await expect(execFileP(BASH, [CLI, 'update-status', '277', 'In progress'], { env: sandbox.env, cwd: sandbox.dir })).rejects.toMatchObject({
         stdout: expect.not.stringContaining('▶ AI:')
       })
     } finally {
@@ -109,7 +107,7 @@ describe('workflow-cli update-status expectations banner (#436)', () => {
   })
 
   it('every status file carries both banner_ai and banner_human fields', () => {
-    const files = readdirSync(STATUSES_DIR).filter(f => f.endsWith('.md'))
+    const files = readdirSync(STATUSES_DIR).filter((f) => f.endsWith('.md'))
     expect(files.length).toBeGreaterThanOrEqual(10)
     for (const f of files) {
       const content = readFileSync(path.join(STATUSES_DIR, f), 'utf8')
@@ -120,11 +118,9 @@ describe('workflow-cli update-status expectations banner (#436)', () => {
 
   it('status files are byte-identical between the live skill and the scaffolded template', () => {
     const templateDir = path.resolve(REPO_ROOT, 'scaffolds/skills-templates/workflow/statuses')
-    for (const f of readdirSync(STATUSES_DIR).filter(f => f.endsWith('.md'))) {
+    for (const f of readdirSync(STATUSES_DIR).filter((f) => f.endsWith('.md'))) {
       expect(readFileSync(path.join(STATUSES_DIR, f), 'utf8')).toBe(readFileSync(path.join(templateDir, f), 'utf8'))
     }
-    expect(readFileSync(CLI, 'utf8')).toBe(
-      readFileSync(path.resolve(REPO_ROOT, 'scaffolds/skills-templates/workflow/workflow-cli.sh'), 'utf8')
-    )
+    expect(readFileSync(CLI, 'utf8')).toBe(readFileSync(path.resolve(REPO_ROOT, 'scaffolds/skills-templates/workflow/workflow-cli.sh'), 'utf8'))
   })
 })

--- a/tests/docker/generate-and-build.ts
+++ b/tests/docker/generate-and-build.ts
@@ -566,13 +566,19 @@ async function main() {
 
   const results: { name: string; passed: boolean }[] = []
 
-  for (const scenario of scenarios) {
+  for (const [index, scenario] of scenarios.entries()) {
+    // [sf-progress] markers are the greppable progress contract for agent
+    // harnesses streaming this run (tail -f | grep) — see workflow SKILL.md
+    // "ANNOUNCE + STREAM LONG COMMANDS" (#436). Keep the format stable.
+    console.log(`[sf-progress] scenario ${index + 1}/${scenarios.length} ${scenario.name} — started`)
     try {
       const passed = await runScenario(scenario)
       results.push({ name: scenario.name, passed })
+      console.log(`[sf-progress] scenario ${index + 1}/${scenarios.length} ${scenario.name} — ${passed ? 'passed' : 'failed'}`)
     } catch (error) {
       console.error(`\nScenario "${scenario.name}" crashed:`, error instanceof Error ? error.message : error)
       results.push({ name: scenario.name, passed: false })
+      console.log(`[sf-progress] scenario ${index + 1}/${scenarios.length} ${scenario.name} — crashed`)
     }
   }
 


### PR DESCRIPTION
Resolves #436

## Summary
During AI sessions the screen could freeze for minutes (test batteries, docker scenarios, push hooks) with zero feedback, and workflow transitions never said whose turn it was. Dev-requested visibility, two layers:

- **Expectations banner** — `workflow-cli.sh update-status` (and `transition-drafting` phases) now print a `▶ AI / ⏳ Dev` banner after every successful transition, read from new `banner_ai:`/`banner_human:` frontmatter in all 10 `statuses/*.md`. Implemented in workflow-cli (not the tool CLIs) so every board tool gets it. Tool failure still propagates (`|| exit $?` — the spec caught the masking bug).
- **Announce + stream convention** — '📣 Long-running commands' rule shipped in the 3 generated CLAUDE.md + workflow SKILL.md (both copies): announce >5s with duration, background + stream progress >60s, report with numbers.
- **Greppable progress contract** — `[sf-progress] scenario i/N <name> — started|passed|failed|crashed` markers in `tests/docker/generate-and-build.ts`.
- In-repo skill ↔ `skills-templates` mirrors byte-identical (pinned by the new spec).

## Tests
- `workflow-cli.banner.spec.ts` — 5 cases (success banner, In-review wording pinned, no-banner-on-failure + exit propagation, field presence ×10 files, mirror byte-identity)
- Live validation: the AI-testing transition of this very ticket printed its banner; `[sf-progress]` markers streamed during this branch's pre-push; fresh `sf new` carries the CLAUDE.md rule
- Full jest 1407 + docker 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)