### PR TITLE
feat(#474): auto-provision working branch + workflow labels on harness install

### DIFF
--- a/.claude/docs/github-labels.md
+++ b/.claude/docs/github-labels.md
@@ -3,6 +3,10 @@
 The SaaSFoundry upstream repository (`DiamondForgeFr/SaaSFoundry`) and every generated project expects the labels below to exist. They're used for issue classification, dedup search, voting filters,
 and to let `sf-srs` detect drafting / update / creation events on the board.
 
+> **Auto-provisioning** — `sf new --profile harness` creates the workflow guard labels (`complexity:*`, `nature:*`, and `srs:*` when an SRS backend is configured) on the target repo automatically and
+> idempotently, right after writing the manifest. The canonical catalogue lives in `src/installers/harness-provisioning.ts` (`buildWorkflowLabels`); the tables below mirror it. The manual
+> `gh label create` snippets remain useful for the upstream repo and for the feedback labels, which are **not** auto-provisioned on consumer projects.
+
 ## Labels used by `sf feedback`
 
 | Label            | Color     | Purpose                                                                                                |

--- a/scaffolds/docs/github-labels.md
+++ b/scaffolds/docs/github-labels.md
@@ -3,6 +3,10 @@
 The SaaSFoundry upstream repository (`DiamondForgeFr/SaaSFoundry`) and every generated project expects the labels below to exist. They're used for issue classification, dedup search, voting filters,
 and to let `sf-srs` detect drafting / update / creation events on the board.
 
+> **Auto-provisioning** — `sf new --profile harness` creates the workflow guard labels (`complexity:*`, `nature:*`, and `srs:*` when an SRS backend is configured) on the target repo automatically and
+> idempotently, right after writing the manifest. The canonical catalogue lives in `src/installers/harness-provisioning.ts` (`buildWorkflowLabels`); the tables below mirror it. The manual
+> `gh label create` snippets remain useful for the upstream repo and for the feedback labels, which are **not** auto-provisioned on consumer projects.
+
 ## Labels used by `sf feedback`
 
 | Label            | Color     | Purpose                                                                                                |

--- a/src/__tests__/unit/installers/harness-provisioning.spec.ts
+++ b/src/__tests__/unit/installers/harness-provisioning.spec.ts
@@ -1,0 +1,182 @@
+import { execSync } from 'node:child_process'
+import { mkdir, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { buildWorkflowLabels, ensureWorkflowLabels, ensureWorkingBranch, resolveRepoSlug, type CommandRunner } from '../../../installers/harness-provisioning'
+
+const sh = (cmd: string, cwd: string) => execSync(cmd, { cwd, stdio: ['pipe', 'pipe', 'pipe'] })
+
+describe('harness-provisioning', () => {
+  describe('ensureWorkingBranch', () => {
+    let dir: string
+
+    beforeEach(async () => {
+      dir = join(tmpdir(), `sf-prov-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+      await mkdir(dir, { recursive: true })
+    })
+
+    afterEach(async () => {
+      await rm(dir, { recursive: true, force: true }).catch(() => {})
+    })
+
+    const initRepo = (branch = 'main') => {
+      sh(`git init -b ${branch}`, dir)
+      sh('git -c user.email=t@t -c user.name=t commit --allow-empty -m init', dir)
+    }
+
+    const branchExists = (branch: string) => {
+      try {
+        sh(`git rev-parse --verify --quiet refs/heads/${branch}`, dir)
+        return true
+      } catch {
+        return false
+      }
+    }
+
+    it('creates the working branch from main without switching the current branch', () => {
+      initRepo('main')
+      sh('git checkout -b feature/wip', dir)
+
+      const result = ensureWorkingBranch({ cwd: dir, workingBranch: 'develop', mainBranch: 'main' })
+
+      expect(result.action).toBe('created')
+      expect(result.branch).toBe('develop')
+      expect(result.pushed).toBe(false)
+      expect(result.reason).toBe('no-remote')
+      expect(branchExists('develop')).toBe(true)
+      // user stays on their branch — harness must not move them
+      expect(sh('git branch --show-current', dir).toString().trim()).toBe('feature/wip')
+    })
+
+    it('is a no-op when the branch already exists', () => {
+      initRepo('main')
+      sh('git branch develop', dir)
+
+      const result = ensureWorkingBranch({ cwd: dir, workingBranch: 'develop', mainBranch: 'main' })
+
+      expect(result.action).toBe('exists')
+      expect(result.branch).toBe('develop')
+    })
+
+    it('is a no-op when the working branch is already the current branch', () => {
+      initRepo('develop')
+
+      const result = ensureWorkingBranch({ cwd: dir, workingBranch: 'develop', mainBranch: 'main' })
+
+      expect(result).toEqual({ action: 'skipped', reason: 'already-current', branch: 'develop' })
+    })
+
+    it('falls back to the default branch when mainBranch does not exist locally', () => {
+      initRepo('master')
+      sh('git checkout -b feature/wip', dir)
+
+      const result = ensureWorkingBranch({ cwd: dir, workingBranch: 'develop', mainBranch: 'main' })
+
+      expect(result.action).toBe('created')
+      expect(branchExists('develop')).toBe(true)
+    })
+
+    it('skips gracefully outside a git repository', () => {
+      const result = ensureWorkingBranch({ cwd: dir, workingBranch: 'develop', mainBranch: 'main' })
+      expect(result).toEqual({ action: 'skipped', reason: 'not-a-git-repo', branch: 'develop' })
+    })
+
+    it('skips when no working branch is configured', () => {
+      initRepo('main')
+      expect(ensureWorkingBranch({ cwd: dir, workingBranch: undefined })).toEqual({ action: 'skipped', reason: 'no-working-branch' })
+      expect(ensureWorkingBranch({ cwd: dir, workingBranch: '   ' })).toEqual({ action: 'skipped', reason: 'no-working-branch' })
+    })
+
+    it('pushes to origin when a remote is configured', () => {
+      // Bare "remote" + working clone so push actually succeeds locally.
+      const remote = `${dir}-remote.git`
+      sh(`git init --bare -b main ${remote}`, dir)
+      initRepo('main')
+      sh(`git remote add origin ${remote}`, dir)
+      sh('git push -u origin main', dir)
+      sh('git checkout -b feature/wip', dir)
+
+      const result = ensureWorkingBranch({ cwd: dir, workingBranch: 'develop', mainBranch: 'main' })
+
+      expect(result).toMatchObject({ action: 'created', branch: 'develop', pushed: true })
+      // remote now has the branch
+      const remoteBranches = execSync(`git ls-remote --heads ${remote}`, { encoding: 'utf-8' })
+      expect(remoteBranches).toContain('refs/heads/develop')
+
+      execSync(`rm -rf ${remote}`)
+    })
+  })
+
+  describe('buildWorkflowLabels', () => {
+    it('includes complexity + nature labels and excludes feedback labels', () => {
+      const names = buildWorkflowLabels({ srs: false }).map((l) => l.name)
+      expect(names).toEqual(expect.arrayContaining(['complexity: bug', 'complexity: low', 'complexity: medium', 'complexity: complex', 'nature:user-facing', 'nature:internal', 'nature:bundled-pr']))
+      expect(names).not.toContain('module-request')
+      expect(names).not.toContain('cli-bug')
+      expect(names).not.toContain('scaffold-bug')
+      expect(names.some((n) => n.startsWith('srs:'))).toBe(false)
+    })
+
+    it('adds the srs labels only when srs is enabled', () => {
+      const names = buildWorkflowLabels({ srs: true }).map((l) => l.name)
+      expect(names).toEqual(expect.arrayContaining(['srs:drafting', 'srs:update', 'srs:new']))
+    })
+  })
+
+  describe('ensureWorkflowLabels', () => {
+    it('creates every label and reports them', () => {
+      const calls: string[] = []
+      const run: CommandRunner = (cmd) => {
+        calls.push(cmd)
+        return ''
+      }
+
+      const result = ensureWorkflowLabels('acme/notulias', { srs: true }, run)
+
+      expect(result.created).toHaveLength(10)
+      expect(result.existing).toHaveLength(0)
+      expect(result.failed).toHaveLength(0)
+      expect(calls).toHaveLength(10)
+      expect(calls[0]).toContain('gh label create')
+      expect(calls[0]).toContain("--repo 'acme/notulias'")
+    })
+
+    it('treats "already exists" as idempotent success, not a failure', () => {
+      const run: CommandRunner = () => {
+        throw Object.assign(new Error('failed to run git: GraphQL: Label "complexity: bug" already exists'), { stderr: 'already exists' })
+      }
+
+      const result = ensureWorkflowLabels('acme/notulias', { srs: false }, run)
+
+      expect(result.created).toHaveLength(0)
+      expect(result.existing).toHaveLength(7)
+      expect(result.failed).toHaveLength(0)
+    })
+
+    it('records real failures separately', () => {
+      const run: CommandRunner = () => {
+        throw Object.assign(new Error('HTTP 403'), { stderr: 'must have admin rights' })
+      }
+
+      const result = ensureWorkflowLabels('acme/notulias', { srs: false }, run)
+
+      expect(result.failed).toHaveLength(7)
+      expect(result.existing).toHaveLength(0)
+    })
+  })
+
+  describe('resolveRepoSlug', () => {
+    it('returns the slug from gh', () => {
+      expect(resolveRepoSlug(() => 'acme/notulias\n')).toBe('acme/notulias')
+    })
+
+    it('returns null when gh fails', () => {
+      expect(
+        resolveRepoSlug(() => {
+          throw new Error('not authenticated')
+        })
+      ).toBeNull()
+    })
+  })
+})

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -12,6 +12,7 @@ import { createWebApp } from '../builders/web.builder'
 import { inquirerRenderer } from '../config-engine/renderers/inquirer.renderer'
 import { runConfigSession } from '../config-engine/session'
 import { computeHarnessFileHashes, harnessInstallerMeta, installHarness } from '../installers/harness.installer'
+import { ensureWorkflowLabels, ensureWorkingBranch, resolveRepoSlug } from '../installers/harness-provisioning'
 import { installSkills } from '../installers/skills.installer'
 import { installSrsSkill } from '../installers/srs-skill.installer'
 import { initAndStartDb } from '../runners/database.runner'
@@ -554,6 +555,9 @@ async function runHarnessInstall(config: Answers): Promise<void> {
 
   const spinner = ora({ text: 'Installing the AI harness...', spinner: 'dots' }).start()
 
+  // Best-effort provisioning notes, surfaced after the spinner stops.
+  const provisioning: string[] = []
+
   try {
     spinner.text = 'Installing skills and workflow artefacts...'
     await installHarness({
@@ -588,11 +592,45 @@ async function runHarnessInstall(config: Answers): Promise<void> {
     }
     await writeFile('.saasfoundry.json', JSON.stringify(manifest, null, 2))
 
+    // Provision the workflow's prerequisites on the existing repo so it's
+    // immediately runnable: the declared working branch and the guard labels
+    // (#474). Both are best-effort — a git/gh hiccup must not fail the install.
+    if (manifest.workflow && manifest.workflow.tool !== 'none') {
+      spinner.text = 'Provisioning workflow branch + labels...'
+
+      const branch = ensureWorkingBranch({ workingBranch: manifest.workflow.workingBranch, mainBranch: manifest.mainBranch })
+      if (branch.action === 'created') {
+        provisioning.push(
+          branch.pushed
+            ? chalk.green(`✓ Created and pushed working branch "${branch.branch}"`)
+            : chalk.yellow(`⚠️  Created working branch "${branch.branch}" locally — push it manually (${branch.reason === 'no-remote' ? 'no remote configured' : 'push failed'})`)
+        )
+      } else if (branch.action === 'skipped' && branch.reason === 'not-a-git-repo') {
+        provisioning.push(chalk.yellow('⚠️  Not a git repository — skipped working-branch creation'))
+      }
+
+      if (manifest.workflow.tool === 'github-projects') {
+        const slug = resolveRepoSlug()
+        if (slug) {
+          const labels = ensureWorkflowLabels(slug, { srs: Boolean(manifest.tools?.srs?.enabled) })
+          if (labels.created.length > 0) provisioning.push(chalk.green(`✓ Created ${labels.created.length} workflow label${labels.created.length > 1 ? 's' : ''} on ${slug}`))
+          if (labels.failed.length > 0) provisioning.push(chalk.yellow(`⚠️  ${labels.failed.length} label(s) could not be created on ${slug} — check 'gh auth status' (repo scope)`))
+        } else {
+          provisioning.push(chalk.yellow("⚠️  Could not resolve the GitHub repo — skipped label creation (run 'gh auth login')"))
+        }
+      }
+    }
+
     spinner.succeed(chalk.green('AI harness installed'))
   } catch (error) {
     spinner.fail(chalk.red('Failed to install the AI harness'))
     console.error(error instanceof Error ? error.message : String(error))
     process.exit(1)
+  }
+
+  if (provisioning.length > 0) {
+    console.log()
+    for (const line of provisioning) console.log(`  ${line}`)
   }
 
   console.log()

--- a/src/installers/harness-provisioning.ts
+++ b/src/installers/harness-provisioning.ts
@@ -1,0 +1,196 @@
+import { execSync } from 'node:child_process'
+
+import { getCurrentBranch, getDefaultBranch, isGitRepo } from '../utils/git-info'
+
+/**
+ * Post-install provisioning for the AI harness on an existing repository.
+ *
+ * After `sf new --profile harness` writes the manifest, the GitHub Projects
+ * board exists but the workflow still cannot run: the declared working branch
+ * (`workflow.workingBranch`) is never created, and the guard labels the
+ * workflow relies on (`complexity:*`, `nature:*`, `srs:*`) don't exist on the
+ * repo. Both gaps surfaced on the Notulia harness install (#474). This module
+ * closes them with two best-effort helpers that never fail the install.
+ */
+
+// ───────────────────────────────────────────────────────────────────────────
+// Working branch
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface BranchProvisionResult {
+  action: 'created' | 'exists' | 'skipped'
+  branch?: string
+  /** True when the freshly created branch was pushed to origin. */
+  pushed?: boolean
+  /** Why the step was a no-op (skipped) or, on `created`, why push was skipped. */
+  reason?: string
+}
+
+function git(args: string, cwd: string): string {
+  return execSync(`git ${args}`, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+}
+
+function refExists(cwd: string, ref: string): boolean {
+  try {
+    git(`rev-parse --verify --quiet ${ref}`, cwd)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function hasOrigin(cwd: string): boolean {
+  try {
+    return git('remote', cwd)
+      .split('\n')
+      .map((r) => r.trim())
+      .includes('origin')
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Pick a starting point for the new working branch. Prefer the configured main
+ * branch (local, then its remote-tracking ref), fall back to the repo's default
+ * branch, and finally to HEAD so we always have a valid base.
+ */
+function pickBase(cwd: string, mainBranch?: string): string {
+  const candidates = [mainBranch, mainBranch && `origin/${mainBranch}`, getDefaultBranch(cwd)].filter((c): c is string => Boolean(c))
+  for (const candidate of candidates) {
+    if (refExists(cwd, `refs/heads/${candidate}`) || refExists(cwd, candidate)) return candidate
+  }
+  return 'HEAD'
+}
+
+/**
+ * Ensure the declared working branch exists locally (and on origin when a
+ * remote is configured). Creates it from `mainBranch` **without switching** the
+ * user off their current branch. Idempotent: an existing or already-current
+ * branch is a no-op. Never throws — degrades to a `skipped` result on any
+ * non-git / missing-config edge case.
+ */
+export function ensureWorkingBranch(opts: { cwd?: string; workingBranch?: string; mainBranch?: string }): BranchProvisionResult {
+  const cwd = opts.cwd ?? process.cwd()
+  const workingBranch = opts.workingBranch?.trim()
+
+  if (!workingBranch) return { action: 'skipped', reason: 'no-working-branch' }
+  if (!isGitRepo(cwd)) return { action: 'skipped', reason: 'not-a-git-repo', branch: workingBranch }
+  if (workingBranch === getCurrentBranch(cwd)) return { action: 'skipped', reason: 'already-current', branch: workingBranch }
+  if (refExists(cwd, `refs/heads/${workingBranch}`)) return { action: 'exists', branch: workingBranch }
+
+  try {
+    git(`branch ${workingBranch} ${pickBase(cwd, opts.mainBranch)}`, cwd)
+  } catch {
+    return { action: 'skipped', reason: 'branch-create-failed', branch: workingBranch }
+  }
+
+  if (!hasOrigin(cwd)) return { action: 'created', branch: workingBranch, pushed: false, reason: 'no-remote' }
+
+  try {
+    git(`push -u origin ${workingBranch}`, cwd)
+    return { action: 'created', branch: workingBranch, pushed: true }
+  } catch {
+    // Offline / no auth / protected branch — the branch is created locally; the
+    // caller surfaces an actionable message rather than failing the install.
+    return { action: 'created', branch: workingBranch, pushed: false, reason: 'push-failed' }
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Workflow labels
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface LabelDef {
+  name: string
+  color: string
+  description: string
+}
+
+/**
+ * Canonical workflow label catalogue — the single source of truth for the
+ * labels the workflow guards depend on. The `complexity:*` / `nature:*` tables
+ * in `scaffolds/docs/github-labels.md` and the github-projects SKILL.md mirror
+ * this list (prose copies); this constant is what actually gets created.
+ *
+ * Feedback labels (`module-request` / `cli-bug` / `scaffold-bug`) are
+ * deliberately excluded — they belong to the upstream SaaSFoundry repo, not to
+ * a consumer project.
+ */
+export function buildWorkflowLabels(opts: { srs: boolean }): LabelDef[] {
+  const labels: LabelDef[] = [
+    // Complexity — rigor level (managed by sf-tool-github-projects)
+    { name: 'complexity: bug', color: 'FF5555', description: '🐛 Bug fix' },
+    { name: 'complexity: low', color: '7CFC00', description: '🟢 Low complexity' },
+    { name: 'complexity: medium', color: 'FFD700', description: '🟡 Medium complexity' },
+    { name: 'complexity: complex', color: 'FF1493', description: '🔴 Complex / critical' },
+    // Nature — Human Testing / In Review optionality (managed by sf-workflow)
+    { name: 'nature:user-facing', color: '0E8A16', description: 'Workflow: ticket has user-visible impact, requires Human Testing' },
+    { name: 'nature:internal', color: 'C5DEF5', description: 'Workflow: refactor/scaffolding/non-terminal story, Human Testing optional' },
+    { name: 'nature:bundled-pr', color: 'FBCA04', description: "Workflow: Sub merged via parent Epic's bundled PR, skips In Review" }
+  ]
+
+  if (opts.srs) {
+    labels.push(
+      { name: 'srs:drafting', color: '8B5CF6', description: 'sf-srs: ticket needs spec drafting / refinement' },
+      { name: 'srs:update', color: 'F97316', description: 'sf-srs: existing SRS page must be updated' },
+      { name: 'srs:new', color: '3B82F6', description: 'sf-srs: create a new Epic / FR spec from scratch' }
+    )
+  }
+
+  return labels
+}
+
+export type CommandRunner = (cmd: string) => string
+
+const defaultRun: CommandRunner = (cmd) => execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).toString()
+
+/** Wrap a value in single quotes for safe shell interpolation. */
+function shq(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function errorText(error: unknown): string {
+  const e = error as { stderr?: Buffer | string; stdout?: Buffer | string; message?: string }
+  return [e?.stderr?.toString(), e?.stdout?.toString(), e?.message].filter(Boolean).join('\n')
+}
+
+export interface LabelProvisionResult {
+  created: string[]
+  existing: string[]
+  failed: string[]
+}
+
+/**
+ * Idempotently create the workflow guard labels on `repoSlug` (owner/name).
+ * Labels that already exist are left untouched (no `--force`, so user colour
+ * customizations survive). Best-effort: a failure on one label is recorded and
+ * never aborts the loop — the caller decides what to surface.
+ */
+export function ensureWorkflowLabels(repoSlug: string, opts: { srs: boolean }, run: CommandRunner = defaultRun): LabelProvisionResult {
+  const result: LabelProvisionResult = { created: [], existing: [], failed: [] }
+
+  for (const label of buildWorkflowLabels(opts)) {
+    try {
+      run(`gh label create ${shq(label.name)} --repo ${shq(repoSlug)} --color ${label.color} --description ${shq(label.description)}`)
+      result.created.push(label.name)
+    } catch (error) {
+      // `gh label create` exits non-zero when the label already exists — treat
+      // that as success (idempotent). Anything else is a real failure.
+      if (/already exists/i.test(errorText(error))) result.existing.push(label.name)
+      else result.failed.push(label.name)
+    }
+  }
+
+  return result
+}
+
+/** Resolve the current repo's `owner/name` slug, or null when unavailable. */
+export function resolveRepoSlug(run: CommandRunner = defaultRun): string | null {
+  try {
+    const slug = run('gh repo view --json nameWithOwner --jq .nameWithOwner').trim()
+    return slug || null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Why

Surfaced on the **Notulia** harness install (`sf new --profile harness`). The GitHub Projects board was created, but the workflow was **not runnable**:

1. The declared working branch (`workflow.workingBranch`, e.g. `develop`) was never created — every workflow PR would target a missing branch.
2. The guard labels (`complexity:*`, `nature:*`, `srs:*`) never existed on the repo — the complexity guard (leave Backlog) and nature guard (→ In Review) couldn't function.

These were the 6th and 7th Notulia findings (the first 5 were resolved by #463).

## What

New `src/installers/harness-provisioning.ts`:
- **`ensureWorkingBranch`** — creates the working branch from `mainBranch` **without switching** the user's current branch, pushes best-effort (only if a remote exists), idempotent, never throws.
- **`buildWorkflowLabels` / `ensureWorkflowLabels`** — a canonical label catalogue (single source of truth) created idempotently via `gh label create`. Feedback labels stay upstream-only; `srs:*` only when an SRS backend is configured. Existing labels are left untouched (no `--force`).

`runHarnessInstall` wires both as **best-effort** post-manifest steps that print a summary and never fail the install. `scaffolds/docs/github-labels.md` documents the auto-provisioning.

## Tests

- 14 new unit tests (`harness-provisioning.spec.ts`) — branch ops exercised against real git temp repos (incl. a bare remote for push); label logic via an injected runner (idempotency, real-failure separation).
- Full pre-commit suite green (1605 passed) + pre-push Docker scenarios passed.

## Scope

`full` profile (no pushed remote at build time) is out of scope — this bug was harness-specific.

Closes #474, #475, #476