### PR TITLE
feat(#478): Board-layout view with the right visible fields on auto-created boards

### DIFF
--- a/src/__tests__/unit/prompts/workflow.board-view.spec.ts
+++ b/src/__tests__/unit/prompts/workflow.board-view.spec.ts
@@ -1,0 +1,97 @@
+import { buildCreateViewArgs, configureBoardView, DEFAULT_BOARD_VISIBLE_FIELDS, ownerScope, resolveVisibleFieldIds, type ApiRunner, type ProjectField } from '../../../prompts/workflow.board-view'
+
+const FIELDS: ProjectField[] = [
+  { id: 269932801, name: 'Title' },
+  { id: 269932802, name: 'Assignees' },
+  { id: 269932803, name: 'Status' },
+  { id: 269932804, name: 'Labels' },
+  { id: 269932805, name: 'Linked pull requests' },
+  { id: 269932808, name: 'Type' },
+  { id: 269932810, name: 'Parent issue' },
+  { id: 269932811, name: 'Sub-issues progress' }
+  // note: no "Updated" — GitHub doesn't expose it as a regular field
+]
+
+describe('workflow.board-view', () => {
+  describe('resolveVisibleFieldIds', () => {
+    it('maps names to numeric ids and reports missing ones', () => {
+      const { ids, missing } = resolveVisibleFieldIds(FIELDS, DEFAULT_BOARD_VISIBLE_FIELDS)
+      expect(ids).toEqual([269932801, 269932803, 269932804, 269932805, 269932808, 269932810, 269932811])
+      expect(missing).toEqual(['Updated'])
+    })
+
+    it('preserves the requested order', () => {
+      const { ids } = resolveVisibleFieldIds(FIELDS, ['Status', 'Title'])
+      expect(ids).toEqual([269932803, 269932801])
+    })
+  })
+
+  describe('ownerScope', () => {
+    it('uses orgs/<login> for organizations', () => {
+      expect(ownerScope({ owner: 'DiamondForgeFr', isOrg: true })).toBe('orgs/DiamondForgeFr')
+    })
+
+    it('uses users/<numeric-id> for user-owned projects', () => {
+      expect(ownerScope({ owner: 'agachet', isOrg: false, userId: 12345 })).toBe('users/12345')
+    })
+  })
+
+  describe('buildCreateViewArgs', () => {
+    it('builds a POST with board layout and repeated visible_fields', () => {
+      const args = buildCreateViewArgs('orgs/acme', 7, 'Board', [10, 20])
+      expect(args).toContain('X-GitHub-Api-Version: 2026-03-10')
+      expect(args).toContain('--method POST /orgs/acme/projectsV2/7/views')
+      expect(args).toContain("-f 'name=Board'")
+      expect(args).toContain("-f 'layout=board'")
+      expect(args).toContain("-F 'visible_fields[]=10'")
+      expect(args).toContain("-F 'visible_fields[]=20'")
+    })
+  })
+
+  describe('configureBoardView', () => {
+    it('queries fields then creates the Board view, reporting missing fields', () => {
+      const calls: string[] = []
+      const run: ApiRunner = (args) => {
+        calls.push(args)
+        if (args.includes('/fields')) return JSON.stringify(FIELDS)
+        return '{}'
+      }
+
+      const result = configureBoardView({ owner: 'acme', isOrg: true, projectNumber: 7 }, run)
+
+      expect(result.created).toBe(true)
+      expect(result.viewName).toBe('Board')
+      expect(result.missing).toEqual(['Updated'])
+      expect(result.visible).not.toContain('Updated')
+      expect(result.visible).toContain('Status')
+      // second call is the POST with the resolved ids
+      expect(calls[1]).toContain('--method POST /orgs/acme/projectsV2/7/views')
+      expect(calls[1]).toContain("-F 'visible_fields[]=269932803'")
+    })
+
+    it('targets the user endpoint with the numeric id for user-owned projects', () => {
+      const calls: string[] = []
+      const run: ApiRunner = (args) => {
+        calls.push(args)
+        if (args.includes('/fields')) return JSON.stringify(FIELDS)
+        return '{}'
+      }
+
+      configureBoardView({ owner: 'agachet', isOrg: false, userId: 999, projectNumber: 3 }, run)
+
+      expect(calls[0]).toContain('/users/999/projectsV2/3/fields')
+      expect(calls[1]).toContain('--method POST /users/999/projectsV2/3/views')
+    })
+
+    it('is best-effort: a REST failure returns created=false with the error, never throws', () => {
+      const run: ApiRunner = () => {
+        throw new Error('HTTP 404: views endpoint unavailable')
+      }
+
+      const result = configureBoardView({ owner: 'acme', isOrg: true, projectNumber: 7 }, run)
+
+      expect(result.created).toBe(false)
+      expect(result.error).toMatch(/404/)
+    })
+  })
+})

--- a/src/prompts/workflow.board-view.ts
+++ b/src/prompts/workflow.board-view.ts
@@ -1,0 +1,93 @@
+import { execSync } from 'node:child_process'
+
+/**
+ * Configure a Board-layout view on a freshly auto-created GitHub Project.
+ *
+ * `createProjectV2` (GraphQL) always seeds a single Table view with GitHub's
+ * default columns and there is NO API to change a view's layout or visible
+ * fields after the fact — GraphQL has no view mutations, and `copyProjectV2`
+ * does not preserve view config. The only lever is the REST Projects API
+ * (shipped 2025-09): `POST /{owner-scope}/projectsV2/{n}/views` accepts
+ * `layout` + `visible_fields`. It is **create-only** (no GET/PATCH/DELETE), so
+ * we ADD a configured Board view; the default Table view cannot be removed or
+ * demoted via API (the user can do that in the UI). (#478)
+ */
+
+/** REST API version that introduced the Projects view-creation endpoint. */
+const PROJECTS_API_VERSION = '2026-03-10'
+
+/**
+ * Fields shown by default on the Board view, in order. Single source of truth.
+ * Fields the live project doesn't expose (e.g. Updated/Created/Closed are not
+ * returned as regular project fields) are reported as `missing`, never silently
+ * dropped. `Title` is always present and pinned by GitHub.
+ */
+export const DEFAULT_BOARD_VISIBLE_FIELDS = ['Title', 'Status', 'Labels', 'Linked pull requests', 'Type', 'Parent issue', 'Sub-issues progress', 'Updated']
+
+export interface ProjectField {
+  id: number
+  name: string
+}
+
+/** Map desired field names to the live project's numeric field IDs (per-project). */
+export function resolveVisibleFieldIds(fields: ProjectField[], desiredNames: string[]): { ids: number[]; missing: string[] } {
+  const byName = new Map(fields.map((f) => [f.name, f.id]))
+  const ids: number[] = []
+  const missing: string[] = []
+  for (const name of desiredNames) {
+    const id = byName.get(name)
+    if (typeof id === 'number') ids.push(id)
+    else missing.push(name)
+  }
+  return { ids, missing }
+}
+
+export type ApiRunner = (args: string) => string
+
+const defaultRun: ApiRunner = (args) => execSync(`gh api ${args}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).toString()
+
+/** REST scope segment: `orgs/<login>` or `users/<numeric-id>`. */
+export function ownerScope(opts: { owner: string; isOrg: boolean; userId?: number }): string {
+  return opts.isOrg ? `orgs/${opts.owner}` : `users/${opts.userId}`
+}
+
+/** Build the `gh api` argument string that creates the Board view. */
+export function buildCreateViewArgs(scope: string, projectNumber: number, name: string, visibleFieldIds: number[]): string {
+  const fieldArgs = visibleFieldIds.map((id) => `-F 'visible_fields[]=${id}'`).join(' ')
+  return [`-H 'X-GitHub-Api-Version: ${PROJECTS_API_VERSION}'`, `--method POST /${scope}/projectsV2/${projectNumber}/views`, `-f 'name=${name}'`, `-f 'layout=board'`, fieldArgs]
+    .filter(Boolean)
+    .join(' ')
+}
+
+export interface BoardViewResult {
+  created: boolean
+  viewName: string
+  visible: string[]
+  missing: string[]
+  error?: string
+}
+
+/**
+ * Create a Board-layout view named `viewName` with the default visible fields.
+ * Best-effort: any REST failure is captured in `error` and never thrown — board
+ * creation must not fail because the (newer) view endpoint is unavailable.
+ */
+export function configureBoardView(
+  opts: { owner: string; isOrg: boolean; userId?: number; projectNumber: number; viewName?: string; desiredFields?: string[] },
+  run: ApiRunner = defaultRun
+): BoardViewResult {
+  const viewName = opts.viewName ?? 'Board'
+  const desired = opts.desiredFields ?? DEFAULT_BOARD_VISIBLE_FIELDS
+
+  try {
+    const scope = ownerScope(opts)
+    const fields = JSON.parse(run(`-H 'X-GitHub-Api-Version: ${PROJECTS_API_VERSION}' /${scope}/projectsV2/${opts.projectNumber}/fields`)) as ProjectField[]
+    const { ids, missing } = resolveVisibleFieldIds(fields, desired)
+
+    run(buildCreateViewArgs(scope, opts.projectNumber, viewName, ids))
+
+    return { created: true, viewName, visible: desired.filter((n) => !missing.includes(n)), missing }
+  } catch (error) {
+    return { created: false, viewName, visible: [], missing: [], error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/src/prompts/workflow.prompts.ts
+++ b/src/prompts/workflow.prompts.ts
@@ -6,6 +6,7 @@ import os from 'os'
 import { execSync } from 'child_process'
 import type { WorkflowConfig, AIRules, WorkflowTemplate, WorkflowStatus, GitHubProjectColor } from '../types'
 import { fileExists } from '../utils'
+import { configureBoardView } from './workflow.board-view'
 
 const WORKFLOWS_DIR = path.join(os.homedir(), '.claude', 'workflows')
 const CREDENTIALS_DIR = path.join(os.homedir(), '.claude', 'credentials')
@@ -407,6 +408,25 @@ export async function setupGitHubProjectWithAutoCreation(projectName: string, st
 
     // Display concise confirmation (full descriptions already shown when selecting the workflow)
     console.log(chalk.green(`✅ Status field configured with ${statuses.length} states`))
+
+    // Add a Board-layout view with the team's default visible fields. The REST
+    // view endpoint is create-only, so the default Table view stays — surface
+    // that so the user knows they can drop it in the UI. Best-effort (#478).
+    let userId: number | undefined
+    if (!isOrg) {
+      try {
+        userId = Number(execSync(`gh api users/${repoOwner} --jq .id`, { encoding: 'utf-8' }).trim())
+      } catch {
+        // fall through — configureBoardView reports the failure as best-effort
+      }
+    }
+    const view = configureBoardView({ owner: repoOwner, isOrg, userId, projectNumber: projectData.number })
+    if (view.created) {
+      console.log(chalk.green(`✅ Added a Board view (${view.visible.length} fields)`) + chalk.gray(' — the default Table view remains; remove it from the board if you prefer.'))
+      if (view.missing.length > 0) console.log(chalk.gray(`   Skipped fields not exposed by the API: ${view.missing.join(', ')}`))
+    } else {
+      console.log(chalk.yellow('⚠️  Could not add the Board view — configure the layout + fields manually from the board (Views → New view → Board).'))
+    }
 
     return projectData.url
   } catch (error) {


### PR DESCRIPTION
## Why

Auto-created GitHub Projects boards shipped GitHub's default single **Table** view. The team wants a **Board** layout exposing: Status, Labels, Linked pull requests, Type, Parent issue, Sub-issues progress (+ Updated where the API allows).

## What

View layout + field visibility is settable **only** via the REST Projects API (shipped 2025-09): `POST /{owner-scope}/projectsV2/{n}/views` with `layout` + `visible_fields`. GraphQL has no view mutations and `copyProjectV2` doesn't preserve views.

New `src/prompts/workflow.board-view.ts`:
- `resolveVisibleFieldIds` — maps desired field names → the live project's per-project numeric ids, **reporting** unexposed ones (never silently dropped).
- `buildCreateViewArgs` / `configureBoardView` — create the Board view via `gh api` REST, org vs user endpoint, **best-effort** (never throws).

`setupGitHubProjectWithAutoCreation` calls it after the Status field is configured (resolving the numeric user id for user-owned boards).

## Limitations (surfaced to the user)

- The REST endpoint is **create-only** (no GET/PATCH/DELETE), so the default Table view **remains** — removable in the UI. A one-line note is printed.
- `Updated` isn't exposed as a project field → reported as **skipped**.

## Tests

- 8 new unit tests (`workflow.board-view.spec.ts`).
- **Real end-to-end**: throwaway org project → POST board view (HTTP 201) → GraphQL readback confirmed `BOARD_LAYOUT` + requested fields → project deleted.
- Full pre-commit (1613 passed) + pre-push Docker scenarios passed.

Closes #478